### PR TITLE
[worker-dev] Add consumption stats API endpoint

### DIFF
--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -50,6 +50,24 @@ export interface CreateAgentRequest {
 /** POST /api/agents — response */
 export type CreateAgentResponse = AgentResponse;
 
+/** Consumption stats for a time period */
+export interface ConsumptionPeriodStats {
+  tokens: number;
+  reviews: number;
+}
+
+/** GET /api/consumption/:agentId — response */
+export interface ConsumptionStatsResponse {
+  agentId: string;
+  totalTokens: number;
+  totalReviews: number;
+  period: {
+    last24h: ConsumptionPeriodStats;
+    last7d: ConsumptionPeriodStats;
+    last30d: ConsumptionPeriodStats;
+  };
+}
+
 /** Standard error response */
 export interface ErrorResponse {
   error: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,8 @@ export type {
   ListAgentsResponse,
   CreateAgentRequest,
   CreateAgentResponse,
+  ConsumptionPeriodStats,
+  ConsumptionStatsResponse,
   ErrorResponse,
 } from './api.js';
 

--- a/packages/worker/src/__tests__/consumption.test.ts
+++ b/packages/worker/src/__tests__/consumption.test.ts
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleGetConsumption } from '../handlers/consumption.js';
+import type { User } from '@opencrust/shared';
+
+const mockUser: User = {
+  id: 'user-123',
+  github_id: 456,
+  name: 'testuser',
+  avatar: null,
+  api_key_hash: 'hash',
+  reputation_score: 0,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+};
+
+describe('handleGetConsumption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+  });
+
+  it('returns 404 when agent does not belong to user', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+            }),
+          }),
+        }),
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-999', mockUser, mockSupabase);
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data).toEqual({ error: 'Agent not found' });
+  });
+
+  it('returns zeroes for an agent with no consumption logs', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: { id: 'agent-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        // consumption_logs
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-1', mockUser, mockSupabase);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      agentId: 'agent-1',
+      totalTokens: 0,
+      totalReviews: 0,
+      period: {
+        last24h: { tokens: 0, reviews: 0 },
+        last7d: { tokens: 0, reviews: 0 },
+        last30d: { tokens: 0, reviews: 0 },
+      },
+    });
+  });
+
+  it('returns correct aggregated stats for an agent with consumption logs', async () => {
+    const logs = [
+      // 1 hour ago — within 24h, 7d, 30d
+      { tokens_used: 100, review_task_id: 'task-1', created_at: '2024-06-15T11:00:00Z' },
+      // 3 days ago — within 7d, 30d (not 24h)
+      { tokens_used: 200, review_task_id: 'task-2', created_at: '2024-06-12T12:00:00Z' },
+      // 15 days ago — within 30d (not 24h, not 7d)
+      { tokens_used: 300, review_task_id: 'task-3', created_at: '2024-05-31T12:00:00Z' },
+      // 60 days ago — outside all periods
+      { tokens_used: 400, review_task_id: 'task-4', created_at: '2024-04-16T12:00:00Z' },
+    ];
+
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: { id: 'agent-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: logs, error: null }),
+          }),
+        };
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-1', mockUser, mockSupabase);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      agentId: 'agent-1',
+      totalTokens: 1000,
+      totalReviews: 4,
+      period: {
+        last24h: { tokens: 100, reviews: 1 },
+        last7d: { tokens: 300, reviews: 2 },
+        last30d: { tokens: 600, reviews: 3 },
+      },
+    });
+  });
+
+  it('counts distinct review_task_ids (multiple logs for same task count as one review)', async () => {
+    const logs = [
+      // Two logs for the same task within 24h
+      { tokens_used: 50, review_task_id: 'task-1', created_at: '2024-06-15T11:00:00Z' },
+      { tokens_used: 75, review_task_id: 'task-1', created_at: '2024-06-15T10:00:00Z' },
+    ];
+
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: { id: 'agent-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: logs, error: null }),
+          }),
+        };
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-1', mockUser, mockSupabase);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.totalTokens).toBe(125);
+    expect(data.totalReviews).toBe(1); // distinct task count
+    expect(data.period.last24h.reviews).toBe(1);
+    expect(data.period.last24h.tokens).toBe(125);
+  });
+
+  it('handles null logs data gracefully', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: { id: 'agent-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        };
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-1', mockUser, mockSupabase);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.totalTokens).toBe(0);
+    expect(data.totalReviews).toBe(0);
+  });
+
+  it('correctly classifies boundary timestamps for period calculations', async () => {
+    // Log exactly at the 24h boundary
+    const exactly24hAgo = new Date('2024-06-14T12:00:00Z').toISOString();
+    const logs = [{ tokens_used: 100, review_task_id: 'task-boundary', created_at: exactly24hAgo }];
+
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: { id: 'agent-1' }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: logs, error: null }),
+          }),
+        };
+      }),
+    } as any;
+
+    const response = await handleGetConsumption('agent-1', mockUser, mockSupabase);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    // Exactly at boundary: age === MS_24H, so age <= MS_24H is true
+    expect(data.period.last24h.tokens).toBe(100);
+    expect(data.period.last24h.reviews).toBe(1);
+  });
+});

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -15,6 +15,14 @@ vi.mock('../db.js', () => ({
   createSupabaseClient: vi.fn(() => 'mock-supabase'),
 }));
 
+vi.mock('../handlers/consumption.js', () => ({
+  handleGetConsumption: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ agentId: 'agent-1', totalTokens: 0, totalReviews: 0 }), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  ),
+}));
+
 vi.mock('../handlers/agents.js', () => ({
   handleListAgents: vi.fn().mockResolvedValue(
     new Response(JSON.stringify({ agents: [] }), {
@@ -49,6 +57,7 @@ vi.mock('../handlers/device-flow.js', () => ({
 
 import { handleGitHubWebhook } from '../webhook.js';
 import { authenticateRequest } from '../auth.js';
+import { handleGetConsumption } from '../handlers/consumption.js';
 import { handleListAgents, handleCreateAgent } from '../handlers/agents.js';
 import { handleDeviceFlow, handleDeviceToken, handleRevokeKey } from '../handlers/device-flow.js';
 
@@ -192,6 +201,59 @@ describe('worker router', () => {
       new Request('http://localhost/api/agents', { method: 'DELETE' }),
       mockEnv,
     );
+    expect(response.status).toBe(404);
+  });
+
+  // --- Consumption routes ---
+
+  it('routes GET /api/consumption/:agentId with valid auth', async () => {
+    const mockUser = { id: 'user-1', name: 'test' };
+    vi.mocked(authenticateRequest).mockResolvedValue(mockUser as any);
+
+    const response = await worker.fetch(
+      new Request('http://localhost/api/consumption/a1b2c3d4-e5f6-7890-abcd-ef1234567890', {
+        headers: { Authorization: 'Bearer cr_test' },
+      }),
+      mockEnv,
+    );
+    expect(response.status).toBe(200);
+    expect(handleGetConsumption).toHaveBeenCalledWith(
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      mockUser,
+      'mock-supabase',
+    );
+  });
+
+  it('returns 401 for GET /api/consumption/:agentId without auth', async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue(null);
+
+    const response = await worker.fetch(
+      new Request('http://localhost/api/consumption/a1b2c3d4-e5f6-7890-abcd-ef1234567890'),
+      mockEnv,
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 404 for POST /api/consumption/:agentId (only GET allowed)', async () => {
+    const response = await worker.fetch(
+      new Request('http://localhost/api/consumption/a1b2c3d4-e5f6-7890-abcd-ef1234567890', {
+        method: 'POST',
+      }),
+      mockEnv,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for /api/consumption with invalid UUID format', async () => {
+    const response = await worker.fetch(
+      new Request('http://localhost/api/consumption/not-a-uuid!'),
+      mockEnv,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for /api/consumption without agentId', async () => {
+    const response = await worker.fetch(new Request('http://localhost/api/consumption/'), mockEnv);
     expect(response.status).toBe(404);
   });
 });

--- a/packages/worker/src/handlers/consumption.ts
+++ b/packages/worker/src/handlers/consumption.ts
@@ -1,0 +1,83 @@
+import type { ConsumptionStatsResponse, User } from '@opencrust/shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** GET /api/consumption/:agentId — aggregated consumption stats for an agent */
+export async function handleGetConsumption(
+  agentId: string,
+  user: User,
+  supabase: SupabaseClient,
+): Promise<Response> {
+  // 1. Verify agent belongs to user
+  const { data: agent } = await supabase
+    .from('agents')
+    .select('id')
+    .eq('id', agentId)
+    .eq('user_id', user.id)
+    .single();
+
+  if (!agent) {
+    return json({ error: 'Agent not found' }, 404);
+  }
+
+  // 2. Query all consumption_logs for this agent
+  const { data: logs } = await supabase
+    .from('consumption_logs')
+    .select('tokens_used, review_task_id, created_at')
+    .eq('agent_id', agentId);
+
+  const entries = (logs ?? []) as Array<{
+    tokens_used: number;
+    review_task_id: string;
+    created_at: string;
+  }>;
+
+  // 3. Compute aggregations
+  const now = Date.now();
+  const MS_24H = 24 * 60 * 60 * 1000;
+  const MS_7D = 7 * MS_24H;
+  const MS_30D = 30 * MS_24H;
+
+  let totalTokens = 0;
+  const allTaskIds = new Set<string>();
+  const period24h = { tokens: 0, taskIds: new Set<string>() };
+  const period7d = { tokens: 0, taskIds: new Set<string>() };
+  const period30d = { tokens: 0, taskIds: new Set<string>() };
+
+  for (const entry of entries) {
+    const age = now - new Date(entry.created_at).getTime();
+
+    totalTokens += entry.tokens_used;
+    allTaskIds.add(entry.review_task_id);
+
+    if (age <= MS_30D) {
+      period30d.tokens += entry.tokens_used;
+      period30d.taskIds.add(entry.review_task_id);
+    }
+    if (age <= MS_7D) {
+      period7d.tokens += entry.tokens_used;
+      period7d.taskIds.add(entry.review_task_id);
+    }
+    if (age <= MS_24H) {
+      period24h.tokens += entry.tokens_used;
+      period24h.taskIds.add(entry.review_task_id);
+    }
+  }
+
+  return json({
+    agentId,
+    totalTokens,
+    totalReviews: allTaskIds.size,
+    period: {
+      last24h: { tokens: period24h.tokens, reviews: period24h.taskIds.size },
+      last7d: { tokens: period7d.tokens, reviews: period7d.taskIds.size },
+      last30d: { tokens: period30d.tokens, reviews: period30d.taskIds.size },
+    },
+  } satisfies ConsumptionStatsResponse);
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -2,6 +2,7 @@ import { authenticateRequest, hashApiKey } from './auth.js';
 import { createSupabaseClient } from './db.js';
 import type { Env } from './env.js';
 import { handleListAgents, handleCreateAgent } from './handlers/agents.js';
+import { handleGetConsumption } from './handlers/consumption.js';
 import { handleDeviceFlow, handleDeviceToken, handleRevokeKey } from './handlers/device-flow.js';
 import { handleGitHubWebhook } from './webhook.js';
 
@@ -62,6 +63,16 @@ export default {
       if (method === 'POST') {
         return handleCreateAgent(request, user, supabase);
       }
+    }
+
+    // Consumption stats endpoint (authenticated)
+    const consumptionMatch = pathname.match(/^\/api\/consumption\/([a-f0-9-]+)$/);
+    if (method === 'GET' && consumptionMatch) {
+      const user = await authenticateRequest(request, supabase);
+      if (!user) {
+        return json({ error: 'Unauthorized' }, 401);
+      }
+      return handleGetConsumption(consumptionMatch[1], user, supabase);
     }
 
     return json({ error: 'Not found' }, 404);


### PR DESCRIPTION
Closes #26

## Summary
- Add `ConsumptionPeriodStats` and `ConsumptionStatsResponse` types to `@opencrust/shared`
- Create `handleGetConsumption` handler in `packages/worker/src/handlers/consumption.ts`
- Add `GET /api/consumption/:agentId` route with auth + agent ownership checks
- Compute aggregated stats: total tokens, distinct review count, and period breakdowns (24h/7d/30d)
- Return 401 for unauthenticated requests, 404 for non-owned agents

## Test plan
- Handler returns correct aggregated stats for an agent with consumption logs
- Handler returns zeroes for an agent with no consumption logs
- Handler returns 404 for agent not owned by user
- Distinct review count is correct (multiple logs for same task count as one review)
- Null logs data handled gracefully
- Boundary timestamp classification is correct
- Route matching works for valid UUID format
- Route returns 404 for invalid UUID, POST method, and missing agentId
- Route returns 401 for unauthenticated requests