### PR TITLE
[web-dev] M8 Dashboard — Personal Stats + Consumption

### DIFF
--- a/packages/web/app/__tests__/dashboard-layout.test.ts
+++ b/packages/web/app/__tests__/dashboard-layout.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+function mockAuth(authenticated: boolean) {
+  vi.doMock('../../lib/auth.js', () => ({
+    isAuthenticated: () => authenticated,
+    getLoginUrl: () => '/auth/login',
+    getLogoutUrl: () => '/auth/logout',
+    getSessionToken: () => (authenticated ? 'token' : null),
+  }));
+}
+
+async function renderLayout(children: React.ReactNode) {
+  const mod = await import('../dashboard/layout.js');
+  const Layout = mod.default;
+  return renderToString(createElement(Layout, { children }));
+}
+
+describe('DashboardLayout', () => {
+  it('shows login prompt when not authenticated', async () => {
+    mockAuth(false);
+    const child = createElement('p', null, 'secret content');
+    const html = await renderLayout(child);
+    expect(html).toContain('Sign in to view your dashboard');
+    expect(html).toContain('Login with GitHub');
+    expect(html).toContain('/auth/login');
+    expect(html).not.toContain('secret content');
+  });
+
+  it('renders children when authenticated', async () => {
+    mockAuth(true);
+    const child = createElement('p', null, 'dashboard content');
+    const html = await renderLayout(child);
+    expect(html).toContain('dashboard content');
+    expect(html).not.toContain('Sign in to view your dashboard');
+  });
+
+  it('exports a function component', async () => {
+    mockAuth(false);
+    const mod = await import('../dashboard/layout.js');
+    expect(typeof mod.default).toBe('function');
+  });
+});

--- a/packages/web/app/__tests__/dashboard.test.ts
+++ b/packages/web/app/__tests__/dashboard.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+// Helper: mock auth module so dashboard page sees desired auth state
+function mockAuth(token: string | null) {
+  vi.doMock('../../lib/auth.js', () => ({
+    getSessionToken: () => token,
+    isAuthenticated: () => token !== null,
+    getLoginUrl: () => '/auth/login',
+    getLogoutUrl: () => '/auth/logout',
+  }));
+}
+
+// Helper: mock apiFetch
+function mockApiFetch(impl: (path: string, init?: RequestInit) => Promise<unknown>) {
+  vi.doMock('../../lib/api.js', () => ({
+    apiFetch: impl,
+  }));
+}
+
+async function renderDashboard() {
+  const mod = await import('../dashboard/page.js');
+  const Component = mod.default;
+  return renderToString(createElement(Component));
+}
+
+describe('DashboardPage', () => {
+  it('renders the dashboard heading', async () => {
+    mockAuth('test-token');
+    mockApiFetch(async () => ({ agents: [] }));
+
+    const html = await renderDashboard();
+    expect(html).toContain('My Dashboard');
+  });
+
+  it('renders loading skeletons initially', async () => {
+    mockAuth('test-token');
+    mockApiFetch(async () => ({ agents: [] }));
+
+    const html = await renderDashboard();
+    // SSR renders with loading=true initially
+    expect(html).toContain('animate-pulse');
+  });
+
+  it('exports a function component', async () => {
+    mockAuth(null);
+    mockApiFetch(async () => ({ agents: [] }));
+
+    const mod = await import('../dashboard/page.js');
+    expect(typeof mod.default).toBe('function');
+  });
+});

--- a/packages/web/app/__tests__/layout.test.ts
+++ b/packages/web/app/__tests__/layout.test.ts
@@ -1,66 +1,86 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createElement } from 'react';
 import { renderToString } from 'react-dom/server';
-import RootLayout, { metadata } from '../layout.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  // Mock auth module for NavBar (client component)
+  vi.doMock('../../lib/auth.js', () => ({
+    isAuthenticated: () => false,
+    getLoginUrl: () => '/auth/login',
+    getLogoutUrl: () => '/auth/logout',
+    getSessionToken: () => null,
+  }));
+});
+
+async function renderLayout(children: React.ReactNode) {
+  const mod = await import('../layout.js');
+  return renderToString(createElement(mod.default, { children }));
+}
+
+async function getMetadata() {
+  const mod = await import('../layout.js');
+  return mod.metadata;
+}
 
 describe('RootLayout', () => {
-  it('renders children inside html and body tags', () => {
+  it('renders children inside html and body tags', async () => {
     const child = createElement('p', null, 'Hello World');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('<html');
     expect(html).toContain('<body');
     expect(html).toContain('Hello World');
   });
 
-  it('sets lang attribute to en', () => {
+  it('sets lang attribute to en', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('lang="en"');
   });
 
-  it('exports a function component', () => {
-    expect(typeof RootLayout).toBe('function');
+  it('exports a function component', async () => {
+    const mod = await import('../layout.js');
+    expect(typeof mod.default).toBe('function');
   });
 
-  it('renders nav bar with OpenCrust brand link', () => {
+  it('renders nav bar with OpenCrust brand link', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('OpenCrust');
     expect(html).toContain('href="/"');
   });
 
-  it('renders nav links for Leaderboard and Dashboard', () => {
+  it('renders nav link for Leaderboard', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('href="/leaderboard"');
     expect(html).toContain('Leaderboard');
-    expect(html).toContain('href="/dashboard"');
-    expect(html).toContain('Dashboard');
   });
 
-  it('renders Login button', () => {
+  it('renders Login link', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('Login');
   });
 
-  it('renders footer with GitHub link', () => {
+  it('renders footer with GitHub link', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('GitHub');
     expect(html).toContain('https://github.com/yugoo-ai/OpenCrust');
   });
 
-  it('renders footer with current year', () => {
+  it('renders footer with current year', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     const year = new Date().getFullYear().toString();
     expect(html).toContain(year);
   });
 
-  it('renders semantic HTML elements', () => {
+  it('renders semantic HTML elements', async () => {
     const child = createElement('span', null, 'test');
-    const html = renderToString(createElement(RootLayout, { children: child }));
+    const html = await renderLayout(child);
     expect(html).toContain('<header');
     expect(html).toContain('<nav');
     expect(html).toContain('<main');
@@ -69,11 +89,13 @@ describe('RootLayout', () => {
 });
 
 describe('metadata', () => {
-  it('has correct title', () => {
+  it('has correct title', async () => {
+    const metadata = await getMetadata();
     expect(metadata.title).toBe('OpenCrust');
   });
 
-  it('has correct description', () => {
+  it('has correct description', async () => {
+    const metadata = await getMetadata();
     expect(metadata.description).toBe('Distributed AI code review');
   });
 });

--- a/packages/web/app/__tests__/navbar.test.ts
+++ b/packages/web/app/__tests__/navbar.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+function mockAuth(authenticated: boolean) {
+  vi.doMock('../../lib/auth.js', () => ({
+    isAuthenticated: () => authenticated,
+    getLoginUrl: () => '/auth/login',
+    getLogoutUrl: () => '/auth/logout',
+    getSessionToken: () => (authenticated ? 'token' : null),
+  }));
+}
+
+async function renderNavBar() {
+  const mod = await import('../components/NavBar.js');
+  const NavBar = mod.default;
+  return renderToString(createElement(NavBar));
+}
+
+describe('NavBar', () => {
+  it('renders OpenCrust brand link', async () => {
+    mockAuth(false);
+    const html = await renderNavBar();
+    expect(html).toContain('OpenCrust');
+    expect(html).toContain('href="/"');
+  });
+
+  it('renders leaderboard link', async () => {
+    mockAuth(false);
+    const html = await renderNavBar();
+    expect(html).toContain('Leaderboard');
+    expect(html).toContain('href="/leaderboard"');
+  });
+
+  it('renders Login link when not mounted (SSR initial)', async () => {
+    mockAuth(false);
+    const html = await renderNavBar();
+    // Before useEffect runs (SSR), shows Login
+    expect(html).toContain('Login');
+  });
+
+  it('renders semantic header and nav elements', async () => {
+    mockAuth(false);
+    const html = await renderNavBar();
+    expect(html).toContain('<header');
+    expect(html).toContain('<nav');
+  });
+
+  it('exports a function component', async () => {
+    mockAuth(false);
+    const mod = await import('../components/NavBar.js');
+    expect(typeof mod.default).toBe('function');
+  });
+});

--- a/packages/web/app/components/NavBar.tsx
+++ b/packages/web/app/components/NavBar.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { isAuthenticated, getLoginUrl, getLogoutUrl } from '../../lib/auth';
+
+export default function NavBar() {
+  const [authed, setAuthed] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setAuthed(isAuthenticated());
+    setMounted(true);
+  }, []);
+
+  return (
+    <header className="border-b border-surface-800">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+        <a href="/" className="text-xl font-bold text-crust-500">
+          OpenCrust
+        </a>
+        <div className="flex items-center gap-6">
+          <a href="/leaderboard" className="text-surface-100 hover:text-crust-400">
+            Leaderboard
+          </a>
+          {mounted && authed && (
+            <a href="/dashboard" className="text-surface-100 hover:text-crust-400">
+              Dashboard
+            </a>
+          )}
+          {mounted && authed ? (
+            <a
+              href={getLogoutUrl()}
+              className="rounded-md border border-surface-800 px-4 py-2 text-sm font-medium text-surface-100 hover:border-crust-600 hover:text-crust-400"
+            >
+              Logout
+            </a>
+          ) : (
+            <a
+              href={mounted ? getLoginUrl() : '#'}
+              className="rounded-md bg-crust-600 px-4 py-2 text-sm font-medium text-white hover:bg-crust-500"
+            >
+              Login
+            </a>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/packages/web/app/dashboard/layout.tsx
+++ b/packages/web/app/dashboard/layout.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { isAuthenticated, getLoginUrl } from '../../lib/auth';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  if (!isAuthenticated()) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-24 text-center">
+        <h1 className="mb-4 text-3xl font-bold text-surface-50">Sign in to view your dashboard</h1>
+        <p className="mb-8 text-surface-100/70">
+          Log in with GitHub to see your agents, stats, and consumption data.
+        </p>
+        <a
+          href={getLoginUrl()}
+          className="rounded-md bg-crust-600 px-6 py-3 font-medium text-white hover:bg-crust-500"
+        >
+          Login with GitHub
+        </a>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/packages/web/app/dashboard/page.tsx
+++ b/packages/web/app/dashboard/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type {
+  ListAgentsResponse,
+  AgentResponse,
+  AgentStatsResponse,
+  ConsumptionStatsResponse,
+} from '@opencrust/shared';
+import { apiFetch } from '../../lib/api';
+import { getSessionToken } from '../../lib/auth';
+
+interface AgentCardData {
+  agent: AgentResponse;
+  stats: AgentStatsResponse['stats'] | null;
+  consumption: ConsumptionStatsResponse['period'] | null;
+  totalTokens: number | null;
+  error: string | null;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function AgentCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-lg border border-surface-800 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="h-6 w-40 rounded bg-surface-800" />
+        <div className="h-5 w-16 rounded-full bg-surface-800" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="h-20 rounded bg-surface-800" />
+        <div className="h-20 rounded bg-surface-800" />
+        <div className="h-20 rounded bg-surface-800" />
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({ data }: { data: AgentCardData }) {
+  const { agent, stats, consumption, totalTokens, error } = data;
+
+  return (
+    <div className="rounded-lg border border-surface-800 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-surface-50">
+          {agent.model} / {agent.tool}
+        </h3>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-medium ${
+            agent.status === 'online'
+              ? 'bg-green-900/50 text-green-400'
+              : 'bg-surface-800 text-surface-100/60'
+          }`}
+        >
+          {agent.status}
+        </span>
+      </div>
+
+      {error && <p className="mb-4 text-sm text-red-400">Failed to load details for this agent.</p>}
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {/* Reputation */}
+        <div className="rounded-md bg-surface-900 p-4">
+          <p className="mb-1 text-xs text-surface-100/60">Reputation</p>
+          <p className="text-2xl font-bold text-crust-400">{agent.reputationScore.toFixed(2)}</p>
+          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-surface-800">
+            <div
+              className="h-full rounded-full bg-crust-500"
+              style={{ width: `${Math.min(agent.reputationScore * 100, 100)}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Review Stats */}
+        <div className="rounded-md bg-surface-900 p-4">
+          <p className="mb-1 text-xs text-surface-100/60">Reviews</p>
+          {stats ? (
+            <>
+              <p className="text-2xl font-bold text-surface-50">
+                {formatNumber(stats.totalReviews)}
+              </p>
+              <div className="mt-1 text-xs text-surface-100/60">
+                <span>{formatNumber(stats.totalSummaries)} summaries</span>
+                <span className="mx-1">&middot;</span>
+                <span>{formatNumber(stats.totalRatings)} ratings</span>
+              </div>
+              <div className="mt-1 text-xs">
+                <span className="text-green-400">{formatNumber(stats.thumbsUp)}</span>
+                <span className="text-surface-100/40"> / </span>
+                <span className="text-red-400">{formatNumber(stats.thumbsDown)}</span>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-surface-100/40">--</p>
+          )}
+        </div>
+
+        {/* Consumption */}
+        <div className="rounded-md bg-surface-900 p-4">
+          <p className="mb-1 text-xs text-surface-100/60">Consumption</p>
+          {consumption ? (
+            <>
+              <p className="text-2xl font-bold text-surface-50">{formatNumber(totalTokens ?? 0)}</p>
+              <p className="mb-1 text-xs text-surface-100/40">total tokens</p>
+              <div className="space-y-0.5 text-xs text-surface-100/60">
+                <p>24h: {formatNumber(consumption.last24h.tokens)}</p>
+                <p>7d: {formatNumber(consumption.last7d.tokens)}</p>
+                <p>30d: {formatNumber(consumption.last30d.tokens)}</p>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-surface-100/40">--</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  const [agents, setAgents] = useState<AgentCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadDashboard() {
+      const token = getSessionToken();
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      try {
+        const { agents: agentList } = await apiFetch<ListAgentsResponse>('/api/agents', {
+          headers,
+        });
+
+        const cards = await Promise.all(
+          agentList.map(async (agent) => {
+            let stats: AgentStatsResponse['stats'] | null = null;
+            let consumption: ConsumptionStatsResponse['period'] | null = null;
+            let totalTokens: number | null = null;
+            let cardError: string | null = null;
+
+            try {
+              const statsRes = await apiFetch<AgentStatsResponse>(`/api/stats/${agent.id}`, {
+                headers,
+              });
+              stats = statsRes.stats;
+            } catch {
+              cardError = 'Failed to load stats';
+            }
+
+            try {
+              const consumptionRes = await apiFetch<ConsumptionStatsResponse>(
+                `/api/consumption/${agent.id}`,
+                { headers },
+              );
+              consumption = consumptionRes.period;
+              totalTokens = consumptionRes.totalTokens;
+            } catch {
+              cardError = cardError ? 'Failed to load details' : 'Failed to load consumption';
+            }
+
+            return { agent, stats, consumption, totalTokens, error: cardError };
+          }),
+        );
+
+        setAgents(cards);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load agents');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadDashboard();
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-12">
+      <h1 className="mb-8 text-3xl font-bold text-surface-50">My Dashboard</h1>
+
+      {error && (
+        <div className="rounded-lg border border-red-800 bg-red-950/50 p-6 text-center">
+          <p className="text-red-400">{error}</p>
+        </div>
+      )}
+
+      {loading && (
+        <div className="space-y-6">
+          <AgentCardSkeleton />
+          <AgentCardSkeleton />
+        </div>
+      )}
+
+      {!loading && !error && agents.length === 0 && (
+        <div className="rounded-lg border border-surface-800 p-12 text-center">
+          <p className="text-lg text-surface-100/60">No agents registered.</p>
+          <p className="mt-2 text-sm text-surface-100/40">
+            Run <code className="rounded bg-surface-800 px-2 py-0.5">opencrust agent create</code>{' '}
+            to get started.
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && agents.length > 0 && (
+        <div className="space-y-6">
+          {agents.map((card) => (
+            <AgentCard key={card.agent.id} data={card} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -1,32 +1,10 @@
 import './globals.css';
+import NavBar from './components/NavBar';
 
 export const metadata = {
   title: 'OpenCrust',
   description: 'Distributed AI code review',
 };
-
-function NavBar() {
-  return (
-    <header className="border-b border-surface-800">
-      <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
-        <a href="/" className="text-xl font-bold text-crust-500">
-          OpenCrust
-        </a>
-        <div className="flex items-center gap-6">
-          <a href="/leaderboard" className="text-surface-100 hover:text-crust-400">
-            Leaderboard
-          </a>
-          <a href="/dashboard" className="text-surface-100 hover:text-crust-400">
-            Dashboard
-          </a>
-          <button className="rounded-md bg-crust-600 px-4 py-2 text-sm font-medium text-white hover:bg-crust-500">
-            Login
-          </button>
-        </div>
-      </nav>
-    </header>
-  );
-}
 
 function Footer() {
   return (

--- a/packages/web/lib/__tests__/auth.test.ts
+++ b/packages/web/lib/__tests__/auth.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getSessionToken', () => {
+  it('returns null when document is undefined (SSR)', async () => {
+    const origDoc = globalThis.document;
+    // @ts-expect-error - testing SSR
+    delete globalThis.document;
+    const { getSessionToken } = await import('../auth.js');
+    expect(getSessionToken()).toBeNull();
+    globalThis.document = origDoc;
+  });
+
+  it('returns null when cookie is not set', async () => {
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: '' },
+      writable: true,
+      configurable: true,
+    });
+    const { getSessionToken } = await import('../auth.js');
+    expect(getSessionToken()).toBeNull();
+  });
+
+  it('returns the session token from cookie', async () => {
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: 'opencrust_session=test-token-123; other=value' },
+      writable: true,
+      configurable: true,
+    });
+    const { getSessionToken } = await import('../auth.js');
+    expect(getSessionToken()).toBe('test-token-123');
+  });
+
+  it('decodes URI-encoded cookie values', async () => {
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: 'opencrust_session=token%20with%20spaces' },
+      writable: true,
+      configurable: true,
+    });
+    const { getSessionToken } = await import('../auth.js');
+    expect(getSessionToken()).toBe('token with spaces');
+  });
+});
+
+describe('isAuthenticated', () => {
+  it('returns false when no session token', async () => {
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: '' },
+      writable: true,
+      configurable: true,
+    });
+    const { isAuthenticated } = await import('../auth.js');
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it('returns true when session token exists', async () => {
+    Object.defineProperty(globalThis, 'document', {
+      value: { cookie: 'opencrust_session=abc' },
+      writable: true,
+      configurable: true,
+    });
+    const { isAuthenticated } = await import('../auth.js');
+    expect(isAuthenticated()).toBe(true);
+  });
+});
+
+describe('getLoginUrl', () => {
+  it('returns /auth/login when no API URL configured', async () => {
+    const { getLoginUrl } = await import('../auth.js');
+    expect(getLoginUrl()).toBe('/auth/login');
+  });
+
+  it('prepends API URL when configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.example.com');
+    vi.resetModules();
+    const { getLoginUrl } = await import('../auth.js');
+    expect(getLoginUrl()).toBe('https://api.example.com/auth/login');
+  });
+});
+
+describe('getLogoutUrl', () => {
+  it('returns /auth/logout when no API URL configured', async () => {
+    const { getLogoutUrl } = await import('../auth.js');
+    expect(getLogoutUrl()).toBe('/auth/logout');
+  });
+
+  it('prepends API URL when configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://api.example.com');
+    vi.resetModules();
+    const { getLogoutUrl } = await import('../auth.js');
+    expect(getLogoutUrl()).toBe('https://api.example.com/auth/logout');
+  });
+});

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -1,0 +1,24 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const COOKIE_NAME = 'opencrust_session';
+
+/** Read the session token from the opencrust_session cookie (client-side) */
+export function getSessionToken(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/** Check whether a session token exists */
+export function isAuthenticated(): boolean {
+  return getSessionToken() !== null;
+}
+
+/** Return the Worker's /auth/login URL */
+export function getLoginUrl(): string {
+  return `${API_URL}/auth/login`;
+}
+
+/** Return the Worker's /auth/logout URL */
+export function getLogoutUrl(): string {
+  return `${API_URL}/auth/logout`;
+}


### PR DESCRIPTION
Closes #34

## Summary
- Auth helpers (`lib/auth.ts`): `getSessionToken`, `isAuthenticated`, `getLoginUrl`, `getLogoutUrl` — reads `opencrust_session` cookie and constructs Worker auth URLs
- Dashboard layout (`app/dashboard/layout.tsx`): auth-protected wrapper that shows "Login with GitHub" prompt for unauthenticated users
- Dashboard page (`app/dashboard/page.tsx`): client component that fetches user's agents via `/api/agents`, then loads stats (`/api/stats/:id`) and consumption (`/api/consumption/:id`) per agent
- Agent cards display: model/tool, online/offline status badge, reputation score with progress bar, review stats (reviews, summaries, ratings, thumbs up/down), consumption breakdown (24h, 7d, 30d, total tokens)
- Empty state ("No agents registered"), loading skeletons, per-agent error handling
- NavBar extracted as client component (`app/components/NavBar.tsx`) with auth-aware behavior: shows Login when unauthenticated, Dashboard + Logout when authenticated
- Updated root layout to use the new NavBar component

## Test plan
- [x] Auth helpers: 10 tests (cookie parsing, SSR safety, URL construction)
- [x] Dashboard page: 3 tests (heading, loading skeletons, component export)
- [x] Dashboard layout: 3 tests (login prompt when unauthed, children when authed, component export)
- [x] NavBar: 5 tests (brand link, leaderboard, login, semantic HTML, component export)
- [x] Updated layout: 11 tests (all existing tests updated for new NavBar import)
- [x] All 532 tests pass across all packages
- [x] `npm run build` passes (dashboard renders at /dashboard)
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck` all pass