### PR TITLE
[worker-dev] Fix WebSocket reconnect loop — stale close guard + code 4002

### DIFF
--- a/packages/cli/src/__tests__/reconnect-guard.test.ts
+++ b/packages/cli/src/__tests__/reconnect-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import EventEmitter from 'node:events';
+
+// Track all created mock WebSocket instances
+const mockWsInstances: EventEmitter[] = [];
+
+function createMockWs() {
+  const emitter = new EventEmitter();
+  (emitter as Record<string, unknown>).send = vi.fn();
+  (emitter as Record<string, unknown>).close = vi.fn();
+  (emitter as Record<string, unknown>).terminate = vi.fn();
+  mockWsInstances.push(emitter);
+  return emitter;
+}
+
+vi.mock('ws', () => ({
+  default: vi.fn(() => createMockWs()),
+}));
+
+vi.mock('../reconnect.js', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { startAgent } from '../commands/agent.js';
+
+describe('startAgent reconnect guards', () => {
+  beforeEach(() => {
+    mockWsInstances.length = 0;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  it('does not reconnect when a stale WebSocket closes (ws !== currentWs)', async () => {
+    startAgent('agent-1', 'http://localhost:8787', 'test-key');
+
+    // First connection created (WS-A)
+    expect(mockWsInstances).toHaveLength(1);
+    const wsA = mockWsInstances[0];
+    wsA.emit('open');
+
+    // WS-A closes normally — triggers reconnect, creates WS-B
+    wsA.emit('close', 1006, Buffer.from('abnormal'));
+
+    await vi.waitFor(() => {
+      expect(mockWsInstances).toHaveLength(2);
+    });
+
+    const wsB = mockWsInstances[1];
+    wsB.emit('open');
+
+    // Stale WS-A fires another close event — should NOT trigger reconnect
+    wsA.emit('close', 4002, Buffer.from('replaced'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Should still only have 2 instances — no third reconnect
+    expect(mockWsInstances).toHaveLength(2);
+  });
+
+  it('does not reconnect when close code is 4002 (replaced)', async () => {
+    startAgent('agent-1', 'http://localhost:8787', 'test-key');
+
+    expect(mockWsInstances).toHaveLength(1);
+    const ws = mockWsInstances[0];
+    ws.emit('open');
+
+    // Close with 4002 "replaced" — should NOT reconnect
+    ws.emit('close', 4002, Buffer.from('replaced'));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(console.log).toHaveBeenCalledWith('Connection replaced by server — not reconnecting.');
+    expect(mockWsInstances).toHaveLength(1);
+  });
+
+  it('reconnects normally on non-4002 close codes', async () => {
+    startAgent('agent-1', 'http://localhost:8787', 'test-key');
+
+    expect(mockWsInstances).toHaveLength(1);
+    const ws = mockWsInstances[0];
+    ws.emit('open');
+
+    // Normal close — should reconnect
+    ws.emit('close', 1006, Buffer.from('abnormal'));
+
+    await vi.waitFor(() => {
+      expect(mockWsInstances).toHaveLength(2);
+    });
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Reconnecting'));
+  });
+});

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -71,7 +71,7 @@ export { buildWsUrl };
 
 const HEARTBEAT_TIMEOUT_MS = 90_000;
 
-function startAgent(
+export function startAgent(
   agentId: string,
   platformUrl: string,
   apiKey: string,
@@ -134,6 +134,11 @@ function startAgent(
     ws.on('close', (code, reason) => {
       clearHeartbeatTimer();
       if (intentionalClose) return;
+      if (ws !== currentWs) return; // Stale WS — don't reconnect
+      if (code === 4002) {
+        console.log('Connection replaced by server — not reconnecting.');
+        return;
+      }
       console.log(`Disconnected (code=${code}, reason=${reason.toString()}).`);
       reconnect();
     });

--- a/packages/worker/src/__tests__/agent-connection.test.ts
+++ b/packages/worker/src/__tests__/agent-connection.test.ts
@@ -1503,6 +1503,47 @@ describe('AgentConnection', () => {
     });
   });
 
+  describe('handleWebSocket preserves inFlightTaskIds on reconnect', () => {
+    it('clears inFlightTaskIds on fresh connection (no existing WebSocket)', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // No existing WebSockets — fresh connection
+      storage.store.set('inFlightTaskIds', ['task-old']);
+
+      const request = new Request('https://internal/websocket?agentId=agent-1', {
+        headers: { Upgrade: 'websocket' },
+      });
+
+      // Reaches Response(101) — RangeError in Node, success in Workers
+      await expect(connection.fetch(request)).rejects.toThrow('init["status"]');
+
+      // Fresh connection: inFlightTaskIds should be cleared
+      expect(storage.store.get('inFlightTaskIds')).toEqual([]);
+    });
+
+    it('preserves inFlightTaskIds on reconnect (existing WebSocket replaced)', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Simulate existing WebSocket
+      const existingWs = createMockWebSocket();
+      mockCtx._websockets.push(existingWs);
+      storage.store.set('inFlightTaskIds', ['task-in-progress']);
+
+      const request = new Request('https://internal/websocket?agentId=agent-1', {
+        headers: { Upgrade: 'websocket' },
+      });
+
+      // Reaches Response(101) — RangeError in Node, success in Workers
+      await expect(connection.fetch(request)).rejects.toThrow('init["status"]');
+
+      // Reconnect: inFlightTaskIds should be preserved
+      expect(storage.store.get('inFlightTaskIds')).toEqual(['task-in-progress']);
+
+      // Existing WebSocket should have been closed with 4002
+      expect(existingWs.close).toHaveBeenCalledWith(4002, 'replaced');
+    });
+  });
+
   describe('handleWebSocket resilience', () => {
     // Note: In Node.js test environment, `new Response(null, { status: 101 })` throws
     // RangeError because Node's Response only accepts 200-599 status codes.

--- a/packages/worker/src/agent-connection.ts
+++ b/packages/worker/src/agent-connection.ts
@@ -83,8 +83,12 @@ export class AgentConnection implements DurableObject {
       return new Response('Expected WebSocket', { status: 426 });
     }
 
+    // Check if this is a reconnect (existing WebSocket being replaced)
+    const existingWebSockets = this.state.getWebSockets();
+    const isReconnect = existingWebSockets.length > 0;
+
     // Close existing connection if any
-    for (const ws of this.state.getWebSockets()) {
+    for (const ws of existingWebSockets) {
       ws.close(4002, 'replaced');
     }
 
@@ -101,7 +105,11 @@ export class AgentConnection implements DurableObject {
     await this.state.storage.put('status', 'online');
     await this.state.storage.put('connectedAt', now);
     await this.state.storage.put('lastHeartbeatAt', now);
-    await this.state.storage.put('inFlightTaskIds', [] as string[]);
+
+    // Only clear in-flight tasks on fresh connections, not reconnects
+    if (!isReconnect) {
+      await this.state.storage.put('inFlightTaskIds', [] as string[]);
+    }
 
     server.send(
       JSON.stringify({


### PR DESCRIPTION
Closes #53

## Summary
- **CLI**: Guard `onclose` handler against stale WebSocket instances (`ws !== currentWs`) — a close event from a previous WebSocket no longer triggers reconnection
- **CLI**: Skip reconnect on close code 4002 ("replaced") — this code means the server replaced the connection with a newer one, so reconnecting would just create another replacement loop
- **Worker**: Preserve `inFlightTaskIds` on WebSocket reconnect — only clear on fresh connections (no existing WebSocket), preventing in-flight task tracking from being lost during reconnection

## Test plan
- [x] New CLI test: stale WebSocket close (ws !== currentWs) does NOT trigger reconnect
- [x] New CLI test: close code 4002 does NOT trigger reconnect
- [x] New CLI test: non-4002 close codes DO trigger reconnect (normal behavior preserved)
- [x] New Worker test: fresh connection clears inFlightTaskIds
- [x] New Worker test: reconnect preserves inFlightTaskIds
- [x] All 602 existing tests pass
- [x] Build, lint, typecheck, format all pass