### PR TITLE
[worker-dev] Fix E2E review loop — default config, reconnect pickup, diagnostics

### DIFF
--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parseReviewConfig, validateReviewConfig, type ReviewConfig } from '../review-config.js';
+import {
+  parseReviewConfig,
+  validateReviewConfig,
+  DEFAULT_REVIEW_CONFIG,
+  type ReviewConfig,
+} from '../review-config.js';
 
 const VALID_FULL_CONFIG = `
 version: 1
@@ -155,6 +160,21 @@ describe('parseReviewConfig', () => {
       'version: 1\nprompt: test\nagents:\n  preferred_tools:\n    - claude-code\n    - 123\n    - codex',
     ) as ReviewConfig;
     expect(result.agents.preferredTools).toEqual(['claude-code', 'codex']);
+  });
+});
+
+describe('DEFAULT_REVIEW_CONFIG', () => {
+  it('is a valid ReviewConfig', () => {
+    expect(validateReviewConfig(DEFAULT_REVIEW_CONFIG)).toBe(true);
+  });
+
+  it('has sensible defaults', () => {
+    expect(DEFAULT_REVIEW_CONFIG.version).toBe(1);
+    expect(DEFAULT_REVIEW_CONFIG.prompt).toBeTruthy();
+    expect(DEFAULT_REVIEW_CONFIG.agents.minCount).toBe(1);
+    expect(DEFAULT_REVIEW_CONFIG.agents.minReputation).toBe(0);
+    expect(DEFAULT_REVIEW_CONFIG.timeout).toBe('10m');
+    expect(DEFAULT_REVIEW_CONFIG.autoApprove.enabled).toBe(false);
   });
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,4 +59,9 @@ export type {
 export { getVersion } from './protocol.js';
 
 /** Review configuration types and parser */
-export { parseReviewConfig, validateReviewConfig, type ReviewConfig } from './review-config.js';
+export {
+  parseReviewConfig,
+  validateReviewConfig,
+  DEFAULT_REVIEW_CONFIG,
+  type ReviewConfig,
+} from './review-config.js';

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -62,6 +62,32 @@ export function validateReviewConfig(config: unknown): config is ReviewConfig {
   return true;
 }
 
+/**
+ * Default review configuration used when .review.yml is not present in the repo.
+ */
+export const DEFAULT_REVIEW_CONFIG: ReviewConfig = {
+  version: 1,
+  prompt: 'Review this pull request for bugs, security issues, and code quality.',
+  agents: {
+    minCount: 1,
+    preferredTools: [],
+    minReputation: 0,
+  },
+  reviewer: {
+    whitelist: [],
+    blacklist: [],
+  },
+  summarizer: {
+    whitelist: [],
+    blacklist: [],
+  },
+  timeout: '10m',
+  autoApprove: {
+    enabled: false,
+    conditions: [],
+  },
+};
+
 export function parseReviewConfig(yaml: string): ParseResult {
   let raw: unknown;
   try {

--- a/packages/worker/src/__tests__/agent-connection.test.ts
+++ b/packages/worker/src/__tests__/agent-connection.test.ts
@@ -1634,14 +1634,17 @@ describe('AgentConnection', () => {
     });
   });
 
-  describe('handleWebSocket skips pickUpPendingTasks on reconnect', () => {
-    it('skips pickUpPendingTasks when reconnecting (existing WebSocket)', async () => {
+  describe('handleWebSocket pickUpPendingTasks on reconnect', () => {
+    it('skips pickUpPendingTasks when reconnecting with in-flight tasks', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'log').mockImplementation(() => {});
 
       // Simulate existing WebSocket with connectedAt old enough to pass debounce
       const existingWs = createMockWebSocket();
       mockCtx._websockets.push(existingWs);
       storage.store.set('connectedAt', new Date(Date.now() - 10_000).toISOString());
+      // Set in-flight tasks so pickup is skipped
+      storage.store.set('inFlightTaskIds', ['task-in-flight-1']);
 
       // Set up mock with pending tasks to verify they are NOT picked up
       const pendingTaskMock = createSupabaseMock({
@@ -1676,6 +1679,37 @@ describe('AgentConnection', () => {
       // review_tasks should NOT have been queried (pickUpPendingTasks was skipped)
       const reviewTasksFromCalls = pendingTaskMock._calls.from.filter((t) => t === 'review_tasks');
       expect(reviewTasksFromCalls).toHaveLength(0);
+    });
+
+    it('picks up pending tasks on reconnect when no in-flight tasks', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // Simulate existing WebSocket with connectedAt old enough to pass debounce
+      const existingWs = createMockWebSocket();
+      mockCtx._websockets.push(existingWs);
+      storage.store.set('connectedAt', new Date(Date.now() - 10_000).toISOString());
+      // No in-flight tasks — reconnect should pick up pending tasks
+      storage.store.set('inFlightTaskIds', []);
+
+      const reconnectMock = createSupabaseMock({
+        selectResults: {
+          review_tasks: { data: [] },
+        },
+      });
+      mockedCreateSupabase.mockReturnValue(
+        reconnectMock as unknown as ReturnType<typeof createSupabaseClient>,
+      );
+
+      const request = new Request('https://internal/websocket?agentId=agent-1', {
+        headers: { Upgrade: 'websocket' },
+      });
+
+      await expect(connection.fetch(request)).rejects.toThrow('init["status"]');
+
+      // review_tasks SHOULD have been queried (pickUpPendingTasks ran)
+      const reviewTasksFromCalls = reconnectMock._calls.from.filter((t) => t === 'review_tasks');
+      expect(reviewTasksFromCalls.length).toBeGreaterThan(0);
     });
 
     it('calls pickUpPendingTasks on fresh connection (no existing WebSocket)', async () => {

--- a/packages/worker/src/__tests__/webhook.test.ts
+++ b/packages/worker/src/__tests__/webhook.test.ts
@@ -185,8 +185,8 @@ describe('handleGitHubWebhook', () => {
     expect(res.status).toBe(200);
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Processing PR #42'));
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Valid .review.yml parsed'),
-      expect.objectContaining({ version: 1 }),
+      expect.stringContaining('Review config for'),
+      expect.objectContaining({ version: 1, hasCustomConfig: true }),
     );
     expect(mockedFetchReviewConfig).toHaveBeenCalledWith(
       'test-org',
@@ -196,10 +196,11 @@ describe('handleGitHubWebhook', () => {
     );
   });
 
-  it('skips review when .review.yml is not found', async () => {
+  it('uses default config when .review.yml is not found', async () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockedGetInstallationToken.mockResolvedValue('test-token');
     mockedFetchReviewConfig.mockResolvedValue(null);
+    mockedFetchPrDiff.mockResolvedValue('diff --git a/file.ts b/file.ts\n');
 
     const req = await makeSignedRequest('pull_request', {
       action: 'synchronize',
@@ -215,7 +216,11 @@ describe('handleGitHubWebhook', () => {
     });
     const res = await handleGitHubWebhook(req, TEST_ENV);
     expect(res.status).toBe(200);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No .review.yml found'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('using default review config'));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Review config for'),
+      expect.objectContaining({ hasCustomConfig: false }),
+    );
   });
 
   it('posts error comment when .review.yml is malformed', async () => {

--- a/packages/worker/src/agent-connection.ts
+++ b/packages/worker/src/agent-connection.ts
@@ -115,10 +115,21 @@ export class AgentConnection implements DurableObject {
     await this.state.storage.put('connectedAt', now);
     await this.state.storage.put('lastHeartbeatAt', now);
 
-    // Only clear in-flight tasks on fresh connections, not reconnects
-    if (!isReconnect) {
+    // On fresh connections, clear in-flight tasks. On reconnects, check if
+    // there are actually in-flight tasks — if not, treat it as fresh.
+    const existingInFlight = isReconnect
+      ? ((await this.state.storage.get<string[]>('inFlightTaskIds')) ?? [])
+      : [];
+    const hasInFlightTasks = existingInFlight.length > 0;
+
+    if (!hasInFlightTasks) {
       await this.state.storage.put('inFlightTaskIds', [] as string[]);
     }
+
+    console.log(
+      `WebSocket ${isReconnect ? 'reconnect' : 'connect'} for agent ${agentId}` +
+        (isReconnect ? ` (${existingInFlight.length} in-flight tasks)` : ''),
+    );
 
     server.send(
       JSON.stringify({
@@ -143,9 +154,9 @@ export class AgentConnection implements DurableObject {
 
     await this.state.storage.setAlarm(Date.now() + HEARTBEAT_INTERVAL_MS);
 
-    // Only pick up pending tasks on fresh connections, not reconnects.
-    // On reconnect the agent already has in-flight tasks from the previous connection.
-    if (supabase && !isReconnect) {
+    // Pick up pending tasks on fresh connections OR when reconnecting with
+    // no in-flight tasks (the previous connection's tasks were lost).
+    if (supabase && !hasInFlightTasks) {
       try {
         await this.pickUpPendingTasks(agentId, supabase);
       } catch (err) {
@@ -192,14 +203,17 @@ export class AgentConnection implements DurableObject {
   async webSocketClose(
     _ws: WebSocket,
     code: number,
-    _reason: string,
+    reason: string,
     _wasClean: boolean,
   ): Promise<void> {
+    const agentId = await this.state.storage.get<string>('agentId');
+    console.log(
+      `WebSocket closed for agent ${agentId ?? 'unknown'}: code=${code}, reason=${reason}`,
+    );
+
     // Skip cleanup for replaced connections (code 4002) — the new connection
     // already set the correct state (connectedAt, status, alarm).
     if (code === 4002) return;
-
-    const agentId = await this.state.storage.get<string>('agentId');
 
     await this.state.storage.put('status', 'offline');
     await this.state.storage.delete('connectedAt');
@@ -355,8 +369,10 @@ export class AgentConnection implements DurableObject {
   }
 
   private async handlePushTask(request: Request): Promise<Response> {
+    const agentId = (await this.state.storage.get<string>('agentId')) ?? 'unknown';
     const websockets = this.state.getWebSockets();
     if (websockets.length === 0) {
+      console.log(`push-task: agent ${agentId} not connected — returning 503`);
       return new Response('Agent not connected', { status: 503 });
     }
 
@@ -369,6 +385,11 @@ export class AgentConnection implements DurableObject {
       minCount?: number;
       installationId?: number;
     };
+
+    console.log(
+      `push-task: sending review_request for task ${payload.taskId} to agent ${agentId}` +
+        ` (${payload.project.owner}/${payload.project.repo}#${payload.pr.number})`,
+    );
 
     const message: ReviewRequestMessage = {
       id: crypto.randomUUID(),
@@ -442,6 +463,10 @@ export class AgentConnection implements DurableObject {
   private async handleReviewComplete(msg: ReviewCompleteMessage): Promise<void> {
     const agentId = (await this.state.storage.get<string>('agentId')) ?? '';
     const supabase = createSupabaseClient(this.env);
+
+    console.log(
+      `review_complete received: task ${msg.taskId}, agent ${agentId}, verdict ${msg.verdict}, tokens ${msg.tokensUsed}`,
+    );
 
     // Look up task meta to determine single-agent vs multi-agent mode
     const taskMeta = await this.state.storage.get<InFlightTaskMeta>(`taskMeta:${msg.taskId}`);
@@ -521,6 +546,11 @@ export class AgentConnection implements DurableObject {
     const formattedReview = formatReviewComment(msg.verdict, model, tool, msg.review);
 
     try {
+      console.log(
+        `Posting review for task ${msg.taskId} to ${project.owner}/${project.repo}#${taskData.pr_number}` +
+          ` (installation ${project.github_installation_id})`,
+      );
+
       const installationToken = await getInstallationToken(
         project.github_installation_id,
         this.env,
@@ -532,6 +562,8 @@ export class AgentConnection implements DurableObject {
         formattedReview,
         installationToken,
       );
+
+      console.log(`Review posted for task ${msg.taskId}: ${commentUrl}`);
 
       // Update review_results with comment_url
       await supabase

--- a/packages/worker/src/webhook.ts
+++ b/packages/worker/src/webhook.ts
@@ -1,4 +1,4 @@
-import { parseReviewConfig } from '@opencrust/shared';
+import { parseReviewConfig, DEFAULT_REVIEW_CONFIG, type ReviewConfig } from '@opencrust/shared';
 import { createSupabaseClient } from './db.js';
 import type { Env } from './env.js';
 import { fetchPrDiff, fetchReviewConfig, getInstallationToken, postPrComment } from './github.js';
@@ -104,33 +104,37 @@ async function handlePullRequest(payload: PullRequestPayload, env: Env): Promise
     return new Response('OK', { status: 200 });
   }
 
+  let config: ReviewConfig;
+
   if (configYaml === null) {
-    console.log(`No .review.yml found in ${owner}/${repo} — skipping review`);
-    return new Response('OK', { status: 200 });
-  }
+    console.log(`No .review.yml found in ${owner}/${repo} — using default review config`);
+    config = DEFAULT_REVIEW_CONFIG;
+  } else {
+    const parsed = parseReviewConfig(configYaml);
 
-  const result = parseReviewConfig(configYaml);
-
-  if ('error' in result) {
-    console.log(`.review.yml parse error: ${result.error}`);
-    try {
-      await postPrComment(
-        owner,
-        repo,
-        prNumber,
-        `**OpenCrust**: Failed to parse \`.review.yml\`: ${result.error}`,
-        token,
-      );
-    } catch (err) {
-      console.error('Failed to post error comment:', err);
+    if ('error' in parsed) {
+      console.log(`.review.yml parse error: ${parsed.error}`);
+      try {
+        await postPrComment(
+          owner,
+          repo,
+          prNumber,
+          `**OpenCrust**: Failed to parse \`.review.yml\`: ${parsed.error}`,
+          token,
+        );
+      } catch (err) {
+        console.error('Failed to post error comment:', err);
+      }
+      return new Response('OK', { status: 200 });
     }
-    return new Response('OK', { status: 200 });
+    config = parsed;
   }
 
-  console.log(`Valid .review.yml parsed for ${owner}/${repo}:`, {
-    version: result.version,
-    agentMinCount: result.agents.minCount,
-    timeout: result.timeout,
+  console.log(`Review config for ${owner}/${repo}:`, {
+    version: config.version,
+    agentMinCount: config.agents.minCount,
+    timeout: config.timeout,
+    hasCustomConfig: configYaml !== null,
     prUrl: pull_request.html_url,
     diffUrl: pull_request.diff_url,
     baseRef: pull_request.base.ref,
@@ -149,7 +153,7 @@ async function handlePullRequest(payload: PullRequestPayload, env: Env): Promise
   // Create review task and distribute to eligible agents
   const supabase = createSupabaseClient(env);
   try {
-    await distributeTask(env, supabase, {
+    const taskId = await distributeTask(env, supabase, {
       installationId: installation.id,
       owner,
       repo,
@@ -158,9 +162,10 @@ async function handlePullRequest(payload: PullRequestPayload, env: Env): Promise
       diffUrl: pull_request.diff_url,
       baseRef: pull_request.base.ref,
       headRef,
-      config: result,
+      config,
       diffContent,
     });
+    console.log(`Task distributed: ${taskId ?? 'failed'} for PR #${prNumber}`);
   } catch (err) {
     console.error('Failed to distribute task:', err);
   }


### PR DESCRIPTION
Closes #57

## Summary
- **Default review config**: When `.review.yml` is missing from a repo, use `DEFAULT_REVIEW_CONFIG` instead of silently skipping the review. This was the primary E2E blocker — test repos without `.review.yml` never triggered reviews.
- **Reconnect pending task pickup**: On WebSocket reconnect with no in-flight tasks, pick up pending tasks. Previously always skipped on reconnect, causing lost tasks when DO was evicted or WS died.
- **Diagnostic logging**: Added structured logging at key pipeline points — WebSocket connect/close events, push-task delivery, review_complete receipt, and GitHub comment posting — to make future E2E debugging easier.
- **Shared export**: `DEFAULT_REVIEW_CONFIG` exported from `@opencrust/shared` for reuse.

## Test plan
- 612 tests pass (3 new tests added)
- Verified: `npm run build && npm run test && npm run lint && npm run typecheck && npm run format:check` all pass
- New test: `DEFAULT_REVIEW_CONFIG` is valid and has sensible defaults
- Updated test: webhook uses default config when `.review.yml` missing (was previously "skip")
- Updated test: reconnect with in-flight tasks skips pickup; reconnect without picks up
- New test: reconnect with no in-flight tasks picks up pending tasks