### PR TITLE
[worker-dev] Replace leaderboard with project stats + trust tier API

### DIFF
--- a/packages/cli/src/__tests__/agent-commands.test.ts
+++ b/packages/cli/src/__tests__/agent-commands.test.ts
@@ -129,7 +129,6 @@ describe('agent commands', () => {
             model: 'gpt-4',
             tool: 'claude-code',
             status: 'online',
-            reputationScore: 4.5,
             createdAt: '2024-01-01',
           },
         ],

--- a/packages/cli/src/__tests__/stats.test.ts
+++ b/packages/cli/src/__tests__/stats.test.ts
@@ -32,7 +32,6 @@ function makeAgent(overrides?: Partial<AgentResponse>): AgentResponse {
     id: 'agent-1',
     model: 'claude-sonnet-4-6',
     tool: 'claude-code',
-    reputationScore: 1.0,
     status: 'online',
     createdAt: '2024-01-01T00:00:00Z',
     ...overrides,

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -41,25 +41,11 @@ function formatTable(agents: AgentResponse[]): void {
     return;
   }
 
-  const header = [
-    'ID'.padEnd(38),
-    'Model'.padEnd(22),
-    'Tool'.padEnd(16),
-    'Status'.padEnd(10),
-    'Reputation',
-  ].join('');
+  const header = ['ID'.padEnd(38), 'Model'.padEnd(22), 'Tool'.padEnd(16), 'Status'].join('');
   console.log(header);
 
   for (const a of agents) {
-    console.log(
-      [
-        a.id.padEnd(38),
-        a.model.padEnd(22),
-        a.tool.padEnd(16),
-        a.status.padEnd(10),
-        a.reputationScore.toFixed(2),
-      ].join(''),
-    );
+    console.log([a.id.padEnd(38), a.model.padEnd(22), a.tool.padEnd(16), a.status].join(''));
   }
 }
 

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -70,7 +70,6 @@ export const statsCommand = new Command('stats')
         id: opts.agent,
         model: 'unknown',
         tool: 'unknown',
-        reputationScore: 0,
         status: 'offline',
         createdAt: '',
       };

--- a/packages/web/app/__tests__/dashboard.test.ts
+++ b/packages/web/app/__tests__/dashboard.test.ts
@@ -31,7 +31,6 @@ const AGENT_1 = {
   id: 'agent-1',
   model: 'claude-sonnet-4',
   tool: 'claude-code',
-  reputationScore: 0.85,
   status: 'online' as const,
   createdAt: '2025-01-01T00:00:00Z',
 };
@@ -40,7 +39,6 @@ const AGENT_2 = {
   id: 'agent-2',
   model: 'gpt-4o',
   tool: 'copilot',
-  reputationScore: 0.72,
   status: 'offline' as const,
   createdAt: '2025-01-02T00:00:00Z',
 };
@@ -50,7 +48,6 @@ const STATS_1 = {
     id: 'agent-1',
     model: 'claude-sonnet-4',
     tool: 'claude-code',
-    reputationScore: 0.85,
     status: 'online' as const,
   },
   stats: {
@@ -79,7 +76,6 @@ const STATS_2 = {
     id: 'agent-2',
     model: 'gpt-4o',
     tool: 'copilot',
-    reputationScore: 0.72,
     status: 'offline' as const,
   },
   stats: {
@@ -156,10 +152,8 @@ describe('DashboardPage', () => {
     await waitFor(() => {
       expect(screen.getByText('claude-sonnet-4 / claude-code')).toBeDefined();
     });
-    // Check reputation display
-    expect(screen.getByText('0.85')).toBeDefined();
-    // Check status badge
-    expect(screen.getByText('online')).toBeDefined();
+    // Check status is shown (badge + status card)
+    expect(screen.getAllByText('online').length).toBeGreaterThanOrEqual(1);
     // Check review stats
     expect(screen.getByText('42')).toBeDefined();
     // Check consumption
@@ -183,8 +177,8 @@ describe('DashboardPage', () => {
       expect(screen.getByText('claude-sonnet-4 / claude-code')).toBeDefined();
     });
     expect(screen.getByText('gpt-4o / copilot')).toBeDefined();
-    expect(screen.getByText('online')).toBeDefined();
-    expect(screen.getByText('offline')).toBeDefined();
+    expect(screen.getAllByText('online').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('offline').length).toBeGreaterThanOrEqual(1);
   });
 
   it('shows error when agents API fails', async () => {
@@ -413,7 +407,7 @@ describe('DashboardPage', () => {
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders reputation bar with correct width', async () => {
+  it('renders status section in agent card', async () => {
     mockAuth('test-token');
     mockApiFetch(async (path: string) => {
       if (path === '/api/agents') return { agents: [AGENT_1] };
@@ -424,32 +418,9 @@ describe('DashboardPage', () => {
 
     await renderDashboard();
     await waitFor(() => {
-      expect(screen.getByText('0.85')).toBeDefined();
+      expect(screen.getByText('claude-sonnet-4 / claude-code')).toBeDefined();
     });
-    // The reputation bar div should have a width style
-    const bars = document.querySelectorAll('.bg-crust-500');
-    expect(bars.length).toBeGreaterThanOrEqual(1);
-    const bar = bars[0] as HTMLElement;
-    expect(bar.style.width).toBe('85%');
-  });
-
-  it('caps reputation bar width at 100%', async () => {
-    const highRepAgent = { ...AGENT_1, reputationScore: 1.5 };
-    mockAuth('test-token');
-    mockApiFetch(async (path: string) => {
-      if (path === '/api/agents') return { agents: [highRepAgent] };
-      if (path.startsWith('/api/stats/')) return STATS_1;
-      if (path.startsWith('/api/consumption/')) return CONSUMPTION_1;
-      return {};
-    });
-
-    await renderDashboard();
-    await waitFor(() => {
-      expect(screen.getByText('1.50')).toBeDefined();
-    });
-    const bars = document.querySelectorAll('.bg-crust-500');
-    const bar = bars[0] as HTMLElement;
-    expect(bar.style.width).toBe('100%');
+    expect(screen.getByText('Status')).toBeDefined();
   });
 
   it('displays 0 total tokens when totalTokens is null', async () => {

--- a/packages/web/app/__tests__/leaderboard.test.ts
+++ b/packages/web/app/__tests__/leaderboard.test.ts
@@ -1,174 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createElement } from 'react';
 import { renderToString } from 'react-dom/server';
-import type { LeaderboardResponse } from '@opencrust/shared';
-
-const mockLeaderboardData: LeaderboardResponse = {
-  agents: [
-    {
-      id: 'agent-1',
-      model: 'claude-sonnet-4',
-      tool: 'claude-code',
-      userName: 'alice',
-      reputationScore: 0.85,
-      totalReviews: 42,
-      thumbsUp: 38,
-      thumbsDown: 4,
-    },
-    {
-      id: 'agent-2',
-      model: 'gpt-4o',
-      tool: 'copilot',
-      userName: 'bob',
-      reputationScore: 0.72,
-      totalReviews: 15,
-      thumbsUp: 11,
-      thumbsDown: 4,
-    },
-  ],
-};
-
-beforeEach(() => {
-  vi.restoreAllMocks();
-});
 
 async function renderLeaderboard() {
   const mod = await import('../leaderboard/page.js');
   const Component = mod.default;
-  const element = await Component();
-  return renderToString(createElement(() => element));
+  return renderToString(createElement(Component));
 }
 
 describe('Leaderboard page', () => {
   it('renders leaderboard heading', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockLeaderboardData),
-      }),
-    );
     const html = await renderLeaderboard();
     expect(html).toContain('Leaderboard');
   });
 
-  it('renders table with agent data', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockLeaderboardData),
-      }),
-    );
+  it('shows replacement message', async () => {
     const html = await renderLeaderboard();
-    expect(html).toContain('claude-sonnet-4');
-    expect(html).toContain('claude-code');
-    expect(html).toContain('alice');
-    expect(html).toContain('0.85');
-    expect(html).toContain('42');
-    expect(html).toContain('gpt-4o');
-    expect(html).toContain('bob');
+    expect(html).toContain('replaced with project stats and trust tiers');
   });
 
-  it('renders correct column headers', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockLeaderboardData),
-      }),
-    );
+  it('does not render a table', async () => {
     const html = await renderLeaderboard();
-    expect(html).toContain('Agent');
-    expect(html).toContain('Contributor');
-    expect(html).toContain('Score');
-    expect(html).toContain('Reviews');
-    expect(html).toContain('Ratings');
-  });
-
-  it('renders rank numbers', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockLeaderboardData),
-      }),
-    );
-    const html = await renderLeaderboard();
-    // Check rank column header exists
-    expect(html).toContain('#');
-  });
-
-  it('renders thumbs up and thumbs down counts', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockLeaderboardData),
-      }),
-    );
-    const html = await renderLeaderboard();
-    expect(html).toContain('38');
-    expect(html).toContain('4');
-    expect(html).toContain('11');
-  });
-
-  it('renders empty state when no agents', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ agents: [] }),
-      }),
-    );
-    const html = await renderLeaderboard();
-    expect(html).toContain('No agents ranked yet');
     expect(html).not.toContain('<table');
-  });
-
-  it('renders error state on API failure', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      }),
-    );
-    const html = await renderLeaderboard();
-    expect(html).toContain('Unable to load leaderboard');
-    expect(html).not.toContain('<table');
-  });
-
-  it('renders error state on network failure', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
-    const html = await renderLeaderboard();
-    expect(html).toContain('Unable to load leaderboard');
-  });
-
-  it('formats reputation score to 2 decimal places', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            agents: [
-              {
-                id: 'a1',
-                model: 'test',
-                tool: 'tool',
-                userName: 'user',
-                reputationScore: 0.8,
-                totalReviews: 1,
-                thumbsUp: 1,
-                thumbsDown: 0,
-              },
-            ],
-          }),
-      }),
-    );
-    const html = await renderLeaderboard();
-    expect(html).toContain('0.80');
   });
 });

--- a/packages/web/app/dashboard/page.tsx
+++ b/packages/web/app/dashboard/page.tsx
@@ -69,16 +69,10 @@ function AgentCard({ data }: { data: AgentCardData }) {
       )}
 
       <div className="grid gap-4 sm:grid-cols-3">
-        {/* Reputation */}
+        {/* Status */}
         <div className="rounded-md bg-surface-900 p-4">
-          <p className="mb-1 text-xs text-surface-100/60">Reputation</p>
-          <p className="text-2xl font-bold text-crust-400">{agent.reputationScore.toFixed(2)}</p>
-          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-surface-800">
-            <div
-              className="h-full rounded-full bg-crust-500"
-              style={{ width: `${Math.min(agent.reputationScore * 100, 100)}%` }}
-            />
-          </div>
+          <p className="mb-1 text-xs text-surface-100/60">Status</p>
+          <p className="text-2xl font-bold text-crust-400">{agent.status}</p>
         </div>
 
         {/* Review Stats */}

--- a/packages/web/app/leaderboard/page.tsx
+++ b/packages/web/app/leaderboard/page.tsx
@@ -1,75 +1,17 @@
-import type { LeaderboardResponse } from '@opencrust/shared';
-import { apiFetch } from '../../lib/api';
-
 export const dynamic = 'force-dynamic';
 
-async function getLeaderboard(): Promise<{ data?: LeaderboardResponse; error?: string }> {
-  try {
-    const data = await apiFetch<LeaderboardResponse>('/api/leaderboard');
-    return { data };
-  } catch (e) {
-    return { error: e instanceof Error ? e.message : 'Failed to load leaderboard' };
-  }
-}
-
-export default async function LeaderboardPage() {
-  const { data, error } = await getLeaderboard();
-
+export default function LeaderboardPage() {
   return (
     <div className="mx-auto max-w-5xl px-4 py-12">
       <h1 className="mb-8 text-3xl font-bold text-surface-50">Leaderboard</h1>
-
-      {error && (
-        <div className="rounded-lg border border-red-800 bg-red-950/50 p-6 text-center">
-          <p className="text-red-400">Unable to load leaderboard. Please try again later.</p>
-        </div>
-      )}
-
-      {data && data.agents.length === 0 && (
-        <div className="rounded-lg border border-surface-800 p-12 text-center">
-          <p className="text-surface-100/60">No agents ranked yet. Be the first contributor!</p>
-        </div>
-      )}
-
-      {data && data.agents.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="w-full text-left">
-            <thead>
-              <tr className="border-b border-surface-800 text-sm text-surface-100/60">
-                <th className="px-4 py-3">#</th>
-                <th className="px-4 py-3">Agent</th>
-                <th className="px-4 py-3">Contributor</th>
-                <th className="px-4 py-3 text-right">Score</th>
-                <th className="px-4 py-3 text-right">Reviews</th>
-                <th className="px-4 py-3 text-right">Ratings</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.agents.map((agent, i) => (
-                <tr
-                  key={agent.id}
-                  className="border-b border-surface-800/50 hover:bg-surface-800/30"
-                >
-                  <td className="px-4 py-3 text-surface-100/60">{i + 1}</td>
-                  <td className="px-4 py-3 font-medium text-surface-50">
-                    {agent.model} / {agent.tool}
-                  </td>
-                  <td className="px-4 py-3 text-surface-100/80">{agent.userName}</td>
-                  <td className="px-4 py-3 text-right font-mono text-crust-400">
-                    {agent.reputationScore.toFixed(2)}
-                  </td>
-                  <td className="px-4 py-3 text-right text-surface-100/80">{agent.totalReviews}</td>
-                  <td className="px-4 py-3 text-right text-surface-100/80">
-                    <span className="text-green-400">{agent.thumbsUp}</span>
-                    {' / '}
-                    <span className="text-red-400">{agent.thumbsDown}</span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <div className="rounded-lg border border-surface-800 p-12 text-center">
+        <p className="text-surface-100/60">
+          The leaderboard has been replaced with project stats and trust tiers.
+        </p>
+        <p className="mt-2 text-sm text-surface-100/40">
+          Check the dashboard for your agent trust tiers.
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/worker/src/__tests__/agents.test.ts
+++ b/packages/worker/src/__tests__/agents.test.ts
@@ -65,7 +65,6 @@ describe('handleListAgents', () => {
       id: 'agent-1',
       model: 'gpt-4',
       tool: 'cline',
-      reputationScore: 4.5,
       status: 'online',
       createdAt: '2024-01-01',
     });
@@ -138,7 +137,7 @@ describe('handleCreateAgent', () => {
     expect(data.id).toBe('agent-new');
     expect(data.model).toBe('claude-3');
     expect(data.tool).toBe('cursor');
-    expect(data.reputationScore).toBe(0);
+    expect(data).not.toHaveProperty('reputationScore');
     expect(data.status).toBe('offline');
   });
 

--- a/packages/worker/src/__tests__/index.test.ts
+++ b/packages/worker/src/__tests__/index.test.ts
@@ -70,10 +70,19 @@ vi.mock('../handlers/stats.js', () => ({
       headers: { 'Content-Type': 'application/json' },
     }),
   ),
-  handleGetLeaderboard: vi.fn().mockResolvedValue(
-    new Response(JSON.stringify({ agents: [] }), {
-      headers: { 'Content-Type': 'application/json' },
-    }),
+  handleGetProjectStats: vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        totalReviews: 0,
+        totalContributors: 0,
+        activeContributorsThisWeek: 0,
+        averagePositiveRate: 0,
+        recentActivity: [],
+      }),
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ),
   ),
 }));
 
@@ -107,7 +116,7 @@ import { handleGetConsumption } from '../handlers/consumption.js';
 import { handleListAgents, handleCreateAgent } from '../handlers/agents.js';
 import { handleCollectRatings } from '../handlers/collect-ratings.js';
 import { handleDeviceFlow, handleDeviceToken, handleRevokeKey } from '../handlers/device-flow.js';
-import { handleGetStats, handleGetLeaderboard } from '../handlers/stats.js';
+import { handleGetStats, handleGetProjectStats } from '../handlers/stats.js';
 import { handleWebLogin, handleWebCallback, handleWebLogout } from '../handlers/web-auth.js';
 import {
   addCorsHeaders,
@@ -309,12 +318,20 @@ describe('worker router', () => {
     expect(response.status).toBe(401);
   });
 
-  // --- Leaderboard routes ---
+  // --- Project stats routes ---
 
-  it('routes GET /api/leaderboard (public)', async () => {
-    const response = await worker.fetch(new Request('http://localhost/api/leaderboard'), mockEnv);
+  it('routes GET /api/projects/stats (public)', async () => {
+    const response = await worker.fetch(
+      new Request('http://localhost/api/projects/stats'),
+      mockEnv,
+    );
     expect(response.status).toBe(200);
-    expect(handleGetLeaderboard).toHaveBeenCalledWith('mock-supabase');
+    expect(handleGetProjectStats).toHaveBeenCalledWith('mock-supabase');
+  });
+
+  it('returns 404 for GET /api/leaderboard (removed)', async () => {
+    const response = await worker.fetch(new Request('http://localhost/api/leaderboard'), mockEnv);
+    expect(response.status).toBe(404);
   });
 
   // --- Collect ratings routes ---

--- a/packages/worker/src/__tests__/stats.test.ts
+++ b/packages/worker/src/__tests__/stats.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
-import { handleGetStats, handleGetLeaderboard } from '../handlers/stats.js';
+import { handleGetStats, handleGetProjectStats, calculateTrustTier } from '../handlers/stats.js';
 import type { User } from '@opencrust/shared';
 
 const mockUser: User = {
@@ -13,6 +13,95 @@ const mockUser: User = {
   created_at: '2024-01-01',
   updated_at: '2024-01-01',
 };
+
+describe('calculateTrustTier', () => {
+  it('returns newcomer for zero reviews', () => {
+    const tier = calculateTrustTier(0, 0, 0);
+    expect(tier.tier).toBe('newcomer');
+    expect(tier.label).toBe('Newcomer');
+    expect(tier.reviewCount).toBe(0);
+    expect(tier.positiveRate).toBe(0);
+    expect(tier.nextTier).toBe('trusted');
+    expect(tier.progressToNext).toBe(0);
+  });
+
+  it('returns newcomer when reviews < 5', () => {
+    const tier = calculateTrustTier(3, 3, 0);
+    expect(tier.tier).toBe('newcomer');
+    expect(tier.nextTier).toBe('trusted');
+    expect(tier.positiveRate).toBe(1);
+  });
+
+  it('returns newcomer when reviews >= 5 but positive rate < 0.6', () => {
+    const tier = calculateTrustTier(10, 2, 8);
+    expect(tier.tier).toBe('newcomer');
+    expect(tier.positiveRate).toBe(0.2);
+  });
+
+  it('returns trusted at exact threshold (5 reviews, 60% positive)', () => {
+    const tier = calculateTrustTier(5, 3, 2);
+    expect(tier.tier).toBe('trusted');
+    expect(tier.label).toBe('Trusted');
+    expect(tier.nextTier).toBe('expert');
+  });
+
+  it('returns trusted when reviews >= 5 and positive rate >= 0.6 but below expert', () => {
+    const tier = calculateTrustTier(10, 7, 3);
+    expect(tier.tier).toBe('trusted');
+    expect(tier.positiveRate).toBe(0.7);
+    expect(tier.nextTier).toBe('expert');
+  });
+
+  it('returns expert at exact threshold (20 reviews, 80% positive)', () => {
+    const tier = calculateTrustTier(20, 8, 2);
+    expect(tier.tier).toBe('expert');
+    expect(tier.label).toBe('Expert');
+    expect(tier.nextTier).toBeNull();
+    expect(tier.progressToNext).toBe(1);
+  });
+
+  it('returns expert when reviews >= 20 and positive rate >= 0.8', () => {
+    const tier = calculateTrustTier(50, 45, 5);
+    expect(tier.tier).toBe('expert');
+    expect(tier.positiveRate).toBe(0.9);
+    expect(tier.nextTier).toBeNull();
+    expect(tier.progressToNext).toBe(1);
+  });
+
+  it('returns newcomer when reviews >= 20 but positive rate < 0.6 (below trusted)', () => {
+    const tier = calculateTrustTier(25, 5, 20);
+    expect(tier.tier).toBe('newcomer');
+    expect(tier.positiveRate).toBe(0.2);
+  });
+
+  it('returns trusted when reviews >= 20 but positive rate < 0.8 (above 0.6)', () => {
+    const tier = calculateTrustTier(25, 15, 10);
+    expect(tier.tier).toBe('trusted');
+    expect(tier.positiveRate).toBe(0.6);
+  });
+
+  it('calculates progress to next tier for newcomer', () => {
+    // reviewProgress = 2/5 = 0.4, rateProgress = min(1.0/0.6, 1) = 1.0
+    // progress = (0.4 + 1.0) / 2 = 0.7
+    const tier = calculateTrustTier(2, 2, 0);
+    expect(tier.progressToNext).toBeCloseTo(0.7, 5);
+  });
+
+  it('calculates progress to next tier for trusted', () => {
+    // 10 out of 20 reviews = 0.5, rate 0.7/0.8 = 0.875 => avg 0.6875
+    const tier = calculateTrustTier(10, 7, 3);
+    expect(tier.progressToNext).toBeCloseTo(0.6875);
+  });
+
+  it('handles zero ratings with reviews for newcomer progress', () => {
+    // totalRatings=0, positiveRate=0 => rateProgress=0
+    // reviewProgress = 3/5 = 0.6 => progress = (0.6 + 0) / 2 = 0.3
+    const tier = calculateTrustTier(3, 0, 0);
+    expect(tier.tier).toBe('newcomer');
+    expect(tier.positiveRate).toBe(0);
+    expect(tier.progressToNext).toBeCloseTo(0.3);
+  });
+});
 
 describe('handleGetStats', () => {
   it('returns 404 when agent not found', async () => {
@@ -40,7 +129,6 @@ describe('handleGetStats', () => {
                 id: 'agent-1',
                 model: 'gpt-4',
                 tool: 'cline',
-                reputation_score: 0.5,
                 status: 'online',
                 user_id: 'other-user',
               },
@@ -55,7 +143,7 @@ describe('handleGetStats', () => {
     expect(response.status).toBe(404);
   });
 
-  it('returns agent stats with correct structure', async () => {
+  it('returns agent stats with trustTier instead of reputationScore', async () => {
     const mockSupabase = {
       from: vi.fn().mockImplementation((table: string) => {
         if (table === 'agents') {
@@ -67,7 +155,6 @@ describe('handleGetStats', () => {
                     id: 'agent-1',
                     model: 'gpt-4',
                     tool: 'cline',
-                    reputation_score: 0.75,
                     status: 'online',
                     user_id: 'user-123',
                   },
@@ -84,7 +171,7 @@ describe('handleGetStats', () => {
                 // Count query for completed reviews
                 return {
                   eq: vi.fn().mockReturnValue({
-                    eq: vi.fn().mockResolvedValue({ count: 5 }),
+                    eq: vi.fn().mockResolvedValue({ count: 10 }),
                   }),
                 };
               }
@@ -107,9 +194,11 @@ describe('handleGetStats', () => {
         if (table === 'ratings') {
           return {
             select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                in: vi.fn().mockResolvedValue({ count: 3 }),
-              }),
+              eq: vi.fn().mockImplementation((_field: string, value: string) => ({
+                in: vi.fn().mockResolvedValue({
+                  count: value === 'thumbs_up' ? 7 : 3,
+                }),
+              })),
               in: vi.fn().mockResolvedValue({ count: 10 }),
             }),
           };
@@ -133,7 +222,11 @@ describe('handleGetStats', () => {
     const data = await response.json();
     expect(data.agent.id).toBe('agent-1');
     expect(data.agent.model).toBe('gpt-4');
-    expect(data.agent.reputationScore).toBe(0.75);
+    expect(data.agent).not.toHaveProperty('reputationScore');
+    expect(data.agent.trustTier).toBeDefined();
+    expect(data.agent.trustTier.tier).toBe('trusted');
+    expect(data.agent.trustTier.label).toBe('Trusted');
+    expect(data.agent.trustTier.reviewCount).toBe(10);
     expect(data.stats.tokensUsed).toBe(3000);
   });
 
@@ -149,7 +242,6 @@ describe('handleGetStats', () => {
                     id: 'agent-1',
                     model: 'gpt-4',
                     tool: 'cline',
-                    reputation_score: 0,
                     status: 'offline',
                     user_id: 'user-123',
                   },
@@ -197,6 +289,8 @@ describe('handleGetStats', () => {
     expect(response.status).toBe(200);
 
     const data = await response.json();
+    expect(data.agent.trustTier.tier).toBe('newcomer');
+    expect(data.agent.trustTier.positiveRate).toBe(0);
     expect(data.stats.totalReviews).toBe(0);
     expect(data.stats.totalSummaries).toBe(0);
     expect(data.stats.totalRatings).toBe(0);
@@ -206,96 +300,73 @@ describe('handleGetStats', () => {
   });
 });
 
-describe('handleGetLeaderboard', () => {
-  it('returns empty leaderboard when no agents exist', async () => {
-    const mockSupabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue({ data: [], error: null }),
-          }),
-        }),
-      }),
-    } as any;
-
-    const response = await handleGetLeaderboard(mockSupabase);
-    expect(response.status).toBe(200);
-
-    const data = await response.json();
-    expect(data.agents).toEqual([]);
-  });
-
-  it('returns 500 when database query fails', async () => {
-    const mockSupabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } }),
-          }),
-        }),
-      }),
-    } as any;
-
-    const response = await handleGetLeaderboard(mockSupabase);
-    expect(response.status).toBe(500);
-  });
-
-  it('returns agents sorted by reputation with stats', async () => {
+describe('handleGetProjectStats', () => {
+  it('returns aggregate stats with all fields', async () => {
+    let selectCallCount = 0;
     const mockSupabase = {
       from: vi.fn().mockImplementation((table: string) => {
-        if (table === 'agents') {
-          return {
-            select: vi.fn().mockReturnValue({
-              order: vi.fn().mockReturnValue({
-                limit: vi.fn().mockResolvedValue({
-                  data: [
-                    {
-                      id: 'agent-1',
-                      model: 'gpt-4',
-                      tool: 'cline',
-                      reputation_score: 0.9,
-                      user_id: 'u1',
-                      users: { name: 'alice' },
-                    },
-                    {
-                      id: 'agent-2',
-                      model: 'claude-3',
-                      tool: 'cursor',
-                      reputation_score: 0.7,
-                      user_id: 'u2',
-                      users: { name: 'bob' },
-                    },
-                  ],
-                  error: null,
-                }),
-              }),
-            }),
-          };
-        }
         if (table === 'review_results') {
           return {
             select: vi.fn().mockImplementation((_fields: string, opts?: any) => {
+              selectCallCount++;
               if (opts?.count === 'exact') {
+                // Total completed reviews count (call 1)
+                return {
+                  eq: vi.fn().mockResolvedValue({ count: 42 }),
+                };
+              }
+              if (selectCallCount === 2) {
+                // Active contributors query: select('agent_id, agents!inner(user_id)')
                 return {
                   eq: vi.fn().mockReturnValue({
-                    eq: vi.fn().mockResolvedValue({ count: 10 }),
+                    gte: vi.fn().mockResolvedValue({
+                      data: [
+                        { agent_id: 'a1', agents: { user_id: 'u1' } },
+                        { agent_id: 'a2', agents: { user_id: 'u1' } },
+                        { agent_id: 'a3', agents: { user_id: 'u2' } },
+                      ],
+                    }),
                   }),
                 };
               }
+              // Recent activity query: select('completed_at, agents!inner(model), review_tasks!inner(...)')
               return {
-                eq: vi.fn().mockResolvedValue({
-                  data: [{ id: 'r1' }],
+                eq: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({
+                      data: [
+                        {
+                          completed_at: '2024-01-15T10:00:00Z',
+                          agents: { model: 'gpt-4' },
+                          review_tasks: {
+                            pr_number: 42,
+                            projects: { repo_full_name: 'octocat/hello-world' },
+                          },
+                        },
+                      ],
+                    }),
+                  }),
                 }),
               };
             }),
           };
         }
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockResolvedValue({
+              data: [{ user_id: 'u1' }, { user_id: 'u2' }, { user_id: 'u2' }, { user_id: 'u3' }],
+            }),
+          };
+        }
         if (table === 'ratings') {
           return {
-            select: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                in: vi.fn().mockResolvedValue({ count: 5 }),
-              }),
+            select: vi.fn().mockResolvedValue({
+              data: [
+                { emoji: 'thumbs_up' },
+                { emoji: 'thumbs_up' },
+                { emoji: 'thumbs_up' },
+                { emoji: 'thumbs_down' },
+              ],
             }),
           };
         }
@@ -303,33 +374,113 @@ describe('handleGetLeaderboard', () => {
       }),
     } as any;
 
-    const response = await handleGetLeaderboard(mockSupabase);
+    const response = await handleGetProjectStats(mockSupabase);
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.agents).toHaveLength(2);
-    expect(data.agents[0].id).toBe('agent-1');
-    expect(data.agents[0].userName).toBe('alice');
-    expect(data.agents[0].reputationScore).toBe(0.9);
-    expect(data.agents[1].id).toBe('agent-2');
-    expect(data.agents[1].userName).toBe('bob');
+    expect(data.totalReviews).toBe(42);
+    expect(data.totalContributors).toBe(3); // u1, u2, u3
+    expect(data.activeContributorsThisWeek).toBe(2); // u1, u2
+    expect(data.averagePositiveRate).toBe(0.75); // 3 up / 4 total
+    expect(data.recentActivity).toHaveLength(1);
+    expect(data.recentActivity[0].type).toBe('review_completed');
+    expect(data.recentActivity[0].repo).toBe('octocat/hello-world');
+    expect(data.recentActivity[0].prNumber).toBe(42);
+    expect(data.recentActivity[0].agentModel).toBe('gpt-4');
+  });
+
+  it('returns zero stats when no data exists', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'review_results') {
+          return {
+            select: vi.fn().mockImplementation((_fields: string, opts?: any) => {
+              if (opts?.count === 'exact') {
+                return {
+                  eq: vi.fn().mockResolvedValue({ count: 0 }),
+                };
+              }
+              // For both active contributors and recent activity queries
+              return {
+                eq: vi.fn().mockReturnValue({
+                  gte: vi.fn().mockResolvedValue({ data: [] }),
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: [] }),
+                  }),
+                }),
+              };
+            }),
+          };
+        }
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockResolvedValue({ data: [] }),
+          };
+        }
+        if (table === 'ratings') {
+          return {
+            select: vi.fn().mockResolvedValue({ data: [] }),
+          };
+        }
+        return {};
+      }),
+    } as any;
+
+    const response = await handleGetProjectStats(mockSupabase);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.totalReviews).toBe(0);
+    expect(data.totalContributors).toBe(0);
+    expect(data.activeContributorsThisWeek).toBe(0);
+    expect(data.averagePositiveRate).toBe(0);
+    expect(data.recentActivity).toEqual([]);
   });
 
   it('handles null data from database gracefully', async () => {
     const mockSupabase = {
-      from: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue({ data: null, error: null }),
-          }),
-        }),
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'review_results') {
+          return {
+            select: vi.fn().mockImplementation((_fields: string, opts?: any) => {
+              if (opts?.count === 'exact') {
+                return {
+                  eq: vi.fn().mockResolvedValue({ count: null }),
+                };
+              }
+              return {
+                eq: vi.fn().mockReturnValue({
+                  gte: vi.fn().mockResolvedValue({ data: null }),
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: null }),
+                  }),
+                }),
+              };
+            }),
+          };
+        }
+        if (table === 'agents') {
+          return {
+            select: vi.fn().mockResolvedValue({ data: null }),
+          };
+        }
+        if (table === 'ratings') {
+          return {
+            select: vi.fn().mockResolvedValue({ data: null }),
+          };
+        }
+        return {};
       }),
     } as any;
 
-    const response = await handleGetLeaderboard(mockSupabase);
+    const response = await handleGetProjectStats(mockSupabase);
     expect(response.status).toBe(200);
 
     const data = await response.json();
-    expect(data.agents).toEqual([]);
+    expect(data.totalReviews).toBe(0);
+    expect(data.totalContributors).toBe(0);
+    expect(data.activeContributorsThisWeek).toBe(0);
+    expect(data.averagePositiveRate).toBe(0);
+    expect(data.recentActivity).toEqual([]);
   });
 });

--- a/packages/worker/src/handlers/agents.ts
+++ b/packages/worker/src/handlers/agents.ts
@@ -30,7 +30,6 @@ export async function handleListAgents(user: User, supabase: SupabaseClient): Pr
     id: agent.id as string,
     model: agent.model as string,
     tool: agent.tool as string,
-    reputationScore: agent.reputation_score as number,
     status: agent.status as 'online' | 'offline',
     createdAt: agent.created_at as string,
   }));
@@ -74,7 +73,6 @@ export async function handleCreateAgent(
       id: data.id,
       model: data.model,
       tool: data.tool,
-      reputationScore: data.reputation_score,
       status: data.status,
       createdAt: data.created_at,
     } satisfies CreateAgentResponse,

--- a/packages/worker/src/handlers/stats.ts
+++ b/packages/worker/src/handlers/stats.ts
@@ -1,4 +1,11 @@
-import type { AgentStatsResponse, LeaderboardResponse, User } from '@opencrust/shared';
+import type {
+  AgentStatsResponse,
+  ProjectStatsResponse,
+  ProjectActivityEntry,
+  TrustTier,
+  TrustTierInfo,
+  User,
+} from '@opencrust/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 function json(data: unknown, status = 200): Response {
@@ -6,6 +13,68 @@ function json(data: unknown, status = 200): Response {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+const TIER_THRESHOLDS = {
+  trusted: { reviews: 5, positiveRate: 0.6 },
+  expert: { reviews: 20, positiveRate: 0.8 },
+};
+
+/** Calculate the trust tier for an agent based on review count and positive rate */
+export function calculateTrustTier(
+  totalReviews: number,
+  thumbsUp: number,
+  thumbsDown: number,
+): TrustTierInfo {
+  const totalRatings = thumbsUp + thumbsDown;
+  const positiveRate = totalRatings > 0 ? thumbsUp / totalRatings : 0;
+
+  let tier: TrustTier = 'newcomer';
+  if (
+    totalReviews >= TIER_THRESHOLDS.expert.reviews &&
+    positiveRate >= TIER_THRESHOLDS.expert.positiveRate
+  ) {
+    tier = 'expert';
+  } else if (
+    totalReviews >= TIER_THRESHOLDS.trusted.reviews &&
+    positiveRate >= TIER_THRESHOLDS.trusted.positiveRate
+  ) {
+    tier = 'trusted';
+  }
+
+  const labels: Record<TrustTier, string> = {
+    newcomer: 'Newcomer',
+    trusted: 'Trusted',
+    expert: 'Expert',
+  };
+
+  let nextTier: TrustTier | null;
+  let progressToNext: number;
+
+  if (tier === 'expert') {
+    nextTier = null;
+    progressToNext = 1;
+  } else if (tier === 'trusted') {
+    nextTier = 'expert';
+    const reviewProgress = Math.min(totalReviews / TIER_THRESHOLDS.expert.reviews, 1);
+    const rateProgress = Math.min(positiveRate / TIER_THRESHOLDS.expert.positiveRate, 1);
+    progressToNext = (reviewProgress + rateProgress) / 2;
+  } else {
+    nextTier = 'trusted';
+    const reviewProgress = Math.min(totalReviews / TIER_THRESHOLDS.trusted.reviews, 1);
+    const rateProgress =
+      totalRatings > 0 ? Math.min(positiveRate / TIER_THRESHOLDS.trusted.positiveRate, 1) : 0;
+    progressToNext = (reviewProgress + rateProgress) / 2;
+  }
+
+  return {
+    tier,
+    label: labels[tier],
+    reviewCount: totalReviews,
+    positiveRate,
+    nextTier,
+    progressToNext,
+  };
 }
 
 /** GET /api/stats/:agentId — returns agent statistics (authenticated) */
@@ -17,7 +86,7 @@ export async function handleGetStats(
   // Fetch agent and verify ownership
   const { data: agent, error: agentError } = await supabase
     .from('agents')
-    .select('id, model, tool, reputation_score, status, user_id')
+    .select('id, model, tool, status, user_id')
     .eq('id', agentId)
     .single();
 
@@ -87,13 +156,15 @@ export async function handleGetStats(
     0,
   );
 
+  const trustTier = calculateTrustTier(totalReviews ?? 0, thumbsUp, thumbsDown);
+
   const response: AgentStatsResponse = {
     agent: {
       id: agent.id as string,
       model: agent.model as string,
       tool: agent.tool as string,
-      reputationScore: agent.reputation_score as number,
       status: agent.status as 'online' | 'offline',
+      trustTier,
     },
     stats: {
       totalReviews: totalReviews ?? 0,
@@ -108,69 +179,76 @@ export async function handleGetStats(
   return json(response);
 }
 
-/** GET /api/leaderboard — returns top agents by reputation (public) */
-export async function handleGetLeaderboard(supabase: SupabaseClient): Promise<Response> {
-  // Fetch top 50 agents sorted by reputation
-  const { data: agents, error } = await supabase
-    .from('agents')
-    .select('id, model, tool, reputation_score, user_id, users!inner(name)')
-    .order('reputation_score', { ascending: false })
-    .limit(50);
+/** GET /api/projects/stats — returns aggregate project statistics (public) */
+export async function handleGetProjectStats(supabase: SupabaseClient): Promise<Response> {
+  // Total completed reviews
+  const { count: totalReviews } = await supabase
+    .from('review_results')
+    .select('id', { count: 'exact', head: true })
+    .eq('status', 'completed');
 
-  if (error) {
-    return json({ error: 'Failed to fetch leaderboard' }, 500);
+  // Count distinct contributor users (users who have at least one agent)
+  const { data: contributorData } = await supabase.from('agents').select('user_id');
+
+  const uniqueUserIds = new Set((contributorData ?? []).map((a: { user_id: string }) => a.user_id));
+  const totalContributors = uniqueUserIds.size;
+
+  // Active contributors this week (users whose agents completed reviews in last 7 days)
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: recentResults } = await supabase
+    .from('review_results')
+    .select('agent_id, agents!inner(user_id)')
+    .eq('status', 'completed')
+    .gte('completed_at', oneWeekAgo);
+
+  const activeUserIds = new Set(
+    (recentResults ?? []).map(
+      (r: Record<string, unknown>) => (r.agents as Record<string, unknown>).user_id as string,
+    ),
+  );
+  const activeContributorsThisWeek = activeUserIds.size;
+
+  // Average positive rate across all agents
+  const { data: allRatings } = await supabase.from('ratings').select('emoji');
+
+  let averagePositiveRate = 0;
+  if (allRatings && allRatings.length > 0) {
+    const totalUp = allRatings.filter((r: { emoji: string }) => r.emoji === 'thumbs_up').length;
+    averagePositiveRate = totalUp / allRatings.length;
   }
 
-  // TODO: Optimize with a single aggregated SQL query or Supabase RPC to avoid N+1 queries.
-  // Current approach makes ~4 queries per agent (up to 200 total for 50 agents).
-  // For each agent, count reviews and ratings
-  const entries = [];
-  for (const agent of (agents ?? []) as Record<string, unknown>[]) {
-    const agentId = agent.id as string;
+  // Last 10 completed reviews with repo + PR info
+  const { data: recentReviews } = await supabase
+    .from('review_results')
+    .select(
+      'completed_at, agents!inner(model), review_tasks!inner(pr_number, projects!inner(repo_full_name))',
+    )
+    .eq('status', 'completed')
+    .order('completed_at', { ascending: false })
+    .limit(10);
 
-    const { count: totalReviews } = await supabase
-      .from('review_results')
-      .select('id', { count: 'exact', head: true })
-      .eq('agent_id', agentId)
-      .eq('status', 'completed');
+  const recentActivity: ProjectActivityEntry[] = (recentReviews ?? []).map(
+    (r: Record<string, unknown>) => {
+      const agents = r.agents as Record<string, unknown>;
+      const tasks = r.review_tasks as Record<string, unknown>;
+      const projects = tasks.projects as Record<string, unknown>;
+      return {
+        type: 'review_completed' as const,
+        repo: projects.repo_full_name as string,
+        prNumber: tasks.pr_number as number,
+        agentModel: agents.model as string,
+        completedAt: r.completed_at as string,
+      };
+    },
+  );
 
-    const { data: resultIds } = await supabase
-      .from('review_results')
-      .select('id')
-      .eq('agent_id', agentId);
+  const response: ProjectStatsResponse = {
+    totalReviews: totalReviews ?? 0,
+    totalContributors,
+    activeContributorsThisWeek,
+    averagePositiveRate,
+    recentActivity,
+  };
 
-    const ids = (resultIds ?? []).map((r: { id: string }) => r.id);
-
-    let thumbsUp = 0;
-    let thumbsDown = 0;
-
-    if (ids.length > 0) {
-      const { count: upCount } = await supabase
-        .from('ratings')
-        .select('id', { count: 'exact', head: true })
-        .eq('emoji', 'thumbs_up')
-        .in('review_result_id', ids);
-      thumbsUp = upCount ?? 0;
-
-      const { count: downCount } = await supabase
-        .from('ratings')
-        .select('id', { count: 'exact', head: true })
-        .eq('emoji', 'thumbs_down')
-        .in('review_result_id', ids);
-      thumbsDown = downCount ?? 0;
-    }
-
-    entries.push({
-      id: agentId,
-      model: agent.model as string,
-      tool: agent.tool as string,
-      userName: (agent.users as Record<string, unknown>).name as string,
-      reputationScore: agent.reputation_score as number,
-      totalReviews: totalReviews ?? 0,
-      thumbsUp,
-      thumbsDown,
-    });
-  }
-
-  return json({ agents: entries } satisfies LeaderboardResponse);
+  return json(response);
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -6,7 +6,7 @@ import { handleCollectRatings } from './handlers/collect-ratings.js';
 import { handleGetConsumption } from './handlers/consumption.js';
 import { addCorsHeaders, addSecurityHeaders, handleCorsPreflightRequest } from './handlers/cors.js';
 import { handleDeviceFlow, handleDeviceToken, handleRevokeKey } from './handlers/device-flow.js';
-import { handleGetStats, handleGetLeaderboard } from './handlers/stats.js';
+import { handleGetStats, handleGetProjectStats } from './handlers/stats.js';
 import { handleWebLogin, handleWebCallback, handleWebLogout } from './handlers/web-auth.js';
 import { handleGitHubWebhook } from './webhook.js';
 
@@ -113,9 +113,9 @@ async function handleApiRoutes(
     return handleGetStats(statsMatch[1], user, supabase);
   }
 
-  // Leaderboard endpoint (public)
-  if (method === 'GET' && pathname === '/api/leaderboard') {
-    return handleGetLeaderboard(supabase);
+  // Project stats endpoint (public)
+  if (method === 'GET' && pathname === '/api/projects/stats') {
+    return handleGetProjectStats(supabase);
   }
 
   // Collect ratings endpoint (authenticated)


### PR DESCRIPTION
Closes #70
Also closes #35

## Summary
- Removed `/api/leaderboard` endpoint and `handleGetLeaderboard` function
- Added `calculateTrustTier()` utility with newcomer/trusted/expert tiers based on review count and positive rate
- Added public `GET /api/projects/stats` endpoint returning aggregate stats (total reviews, contributors, active this week, positive rate, recent activity feed)
- Updated `GET /api/stats/:agentId` to return `trustTier` field instead of `reputationScore`
- Removed `reputationScore` from `AgentResponse` in agent list/create handlers
- Updated CLI to remove reputation column from agent list display
- Fixed all tests across worker, CLI, and web packages (648 tests passing)
- Stubbed leaderboard page in web (will be redesigned in #71)

## Test plan
- [x] `calculateTrustTier` boundary tests: newcomer (0 reviews, <5 reviews, low rate), trusted (exact threshold, above threshold), expert (exact threshold, above threshold)
- [x] Progress-to-next-tier calculation verified for all tiers
- [x] `handleGetStats` returns `trustTier` field, no `reputationScore`
- [x] `handleGetProjectStats` returns aggregate stats with correct counts
- [x] `handleGetProjectStats` handles empty/null data gracefully
- [x] `/api/leaderboard` returns 404 (removed)
- [x] `/api/projects/stats` routes to handler (public, no auth)
- [x] Agent list/create responses omit `reputationScore`
- [x] Full build + 648 tests + lint + format + typecheck all passing