### PR TITLE
[cli-dev] Enrich opencrust stats with trust tier + review quality (#72)

### DIFF
--- a/packages/cli/src/__tests__/agent-commands.test.ts
+++ b/packages/cli/src/__tests__/agent-commands.test.ts
@@ -122,27 +122,75 @@ describe('agent commands', () => {
   });
 
   describe('agent list', () => {
-    it('displays agents in table format', async () => {
-      mockGet.mockResolvedValueOnce({
-        agents: [
-          {
+    it('displays agents in table format with Trust column', async () => {
+      mockGet
+        .mockResolvedValueOnce({
+          agents: [
+            {
+              id: 'agent-1',
+              model: 'gpt-4',
+              tool: 'claude-code',
+              status: 'online',
+              createdAt: '2024-01-01',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          agent: {
             id: 'agent-1',
             model: 'gpt-4',
             tool: 'claude-code',
             status: 'online',
-            createdAt: '2024-01-01',
+            trustTier: {
+              tier: 'trusted',
+              label: 'Trusted',
+              reviewCount: 25,
+              positiveRate: 0.88,
+              nextTier: 'expert',
+              progressToNext: 0.6,
+            },
           },
-        ],
-      });
+          stats: {
+            totalReviews: 25,
+            totalSummaries: 8,
+            totalRatings: 20,
+            thumbsUp: 18,
+            thumbsDown: 2,
+            tokensUsed: 50000,
+          },
+        });
 
       await agentCommand.parseAsync(['list'], { from: 'user' });
 
       // Header row
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('ID'));
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Model'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Trust'));
       // Agent row
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('agent-1'));
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('gpt-4'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Trusted'));
+    });
+
+    it('shows -- for trust when stats fetch fails', async () => {
+      mockGet
+        .mockResolvedValueOnce({
+          agents: [
+            {
+              id: 'agent-1',
+              model: 'gpt-4',
+              tool: 'claude-code',
+              status: 'online',
+              createdAt: '2024-01-01',
+            },
+          ],
+        })
+        .mockRejectedValueOnce(new Error('Stats unavailable'));
+
+      await agentCommand.parseAsync(['list'], { from: 'user' });
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('agent-1'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('--'));
     });
 
     it('shows message when no agents', async () => {

--- a/packages/cli/src/__tests__/stats.test.ts
+++ b/packages/cli/src/__tests__/stats.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ConsumptionStatsResponse, AgentResponse } from '@opencrust/shared';
+import type {
+  ConsumptionStatsResponse,
+  AgentResponse,
+  AgentStatsResponse,
+} from '@opencrust/shared';
 
 const mockGet = vi.hoisted(() => vi.fn());
 const mockFetchConsumptionStats = vi.hoisted(() => vi.fn());
@@ -25,7 +29,13 @@ vi.mock('../consumption.js', async (importOriginal) => {
   };
 });
 
-import { formatAgentStats, statsCommand } from '../commands/stats.js';
+import {
+  formatAgentStats,
+  formatTrustTier,
+  formatReviewQuality,
+  formatConsumption,
+  statsCommand,
+} from '../commands/stats.js';
 
 function makeAgent(overrides?: Partial<AgentResponse>): AgentResponse {
   return {
@@ -38,7 +48,7 @@ function makeAgent(overrides?: Partial<AgentResponse>): AgentResponse {
   };
 }
 
-function makeStats(overrides?: Partial<ConsumptionStatsResponse>): ConsumptionStatsResponse {
+function makeConsumption(overrides?: Partial<ConsumptionStatsResponse>): ConsumptionStatsResponse {
   return {
     agentId: 'agent-1',
     period: {
@@ -48,6 +58,34 @@ function makeStats(overrides?: Partial<ConsumptionStatsResponse>): ConsumptionSt
     },
     totalTokens: 125_430,
     totalReviews: 47,
+    ...overrides,
+  };
+}
+
+function makeAgentStats(overrides?: Partial<AgentStatsResponse>): AgentStatsResponse {
+  return {
+    agent: {
+      id: 'agent-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      status: 'online',
+      trustTier: {
+        tier: 'trusted',
+        label: 'Trusted',
+        reviewCount: 25,
+        positiveRate: 0.88,
+        nextTier: 'expert',
+        progressToNext: 0.6,
+      },
+    },
+    stats: {
+      totalReviews: 25,
+      totalSummaries: 8,
+      totalRatings: 20,
+      thumbsUp: 18,
+      thumbsDown: 2,
+      tokensUsed: 50_000,
+    },
     ...overrides,
   };
 }
@@ -69,34 +107,120 @@ describe('stats command', () => {
     vi.restoreAllMocks();
   });
 
-  describe('formatAgentStats', () => {
-    it('displays agent info and all period stats', () => {
-      const output = formatAgentStats(makeAgent(), makeStats());
-      expect(output).toContain('Agent: agent-1 (claude-sonnet-4-6 / claude-code)');
-      expect(output).toContain('Total: 125,430 tokens across 47 reviews');
-      expect(output).toContain('Last 24h: 12,300 tokens / 5 reviews');
-      expect(output).toContain('Last 7d:  45,200 tokens / 18 reviews');
-      expect(output).toContain('Last 30d: 98,100 tokens / 39 reviews');
+  describe('formatTrustTier', () => {
+    it('shows trust tier with review count and positive rate', () => {
+      const output = formatTrustTier({
+        tier: 'trusted',
+        label: 'Trusted',
+        reviewCount: 25,
+        positiveRate: 0.88,
+        nextTier: 'expert',
+        progressToNext: 0.6,
+      });
+      expect(output).toContain('Trusted');
+      expect(output).toContain('25 reviews');
+      expect(output).toContain('88% positive');
     });
 
-    it('shows daily budget line when tokens_per_day configured', () => {
-      const output = formatAgentStats(makeAgent(), makeStats(), { tokens_per_day: 100_000 });
+    it('shows progress to next tier', () => {
+      const output = formatTrustTier({
+        tier: 'newcomer',
+        label: 'Newcomer',
+        reviewCount: 3,
+        positiveRate: 0.67,
+        nextTier: 'trusted',
+        progressToNext: 0.3,
+      });
+      expect(output).toContain('Progress to Trusted: 30%');
+    });
+
+    it('does not show progress when at max tier', () => {
+      const output = formatTrustTier({
+        tier: 'expert',
+        label: 'Expert',
+        reviewCount: 100,
+        positiveRate: 0.95,
+        nextTier: null,
+        progressToNext: 1,
+      });
+      expect(output).toContain('Expert');
+      expect(output).not.toContain('Progress to');
+    });
+
+    it('capitalizes next tier name', () => {
+      const output = formatTrustTier({
+        tier: 'trusted',
+        label: 'Trusted',
+        reviewCount: 25,
+        positiveRate: 0.88,
+        nextTier: 'expert',
+        progressToNext: 0.5,
+      });
+      expect(output).toContain('Progress to Expert');
+    });
+  });
+
+  describe('formatReviewQuality', () => {
+    it('shows reviews completed and summaries', () => {
+      const output = formatReviewQuality({
+        totalReviews: 25,
+        totalSummaries: 8,
+        totalRatings: 20,
+        thumbsUp: 18,
+        thumbsDown: 2,
+        tokensUsed: 50_000,
+      });
+      expect(output).toContain('25 completed');
+      expect(output).toContain('8 summaries');
+    });
+
+    it('shows quality percentage', () => {
+      const output = formatReviewQuality({
+        totalReviews: 25,
+        totalSummaries: 8,
+        totalRatings: 20,
+        thumbsUp: 18,
+        thumbsDown: 2,
+        tokensUsed: 50_000,
+      });
+      expect(output).toContain('18/20 positive ratings (90%)');
+    });
+
+    it('shows no ratings message when no ratings', () => {
+      const output = formatReviewQuality({
+        totalReviews: 5,
+        totalSummaries: 1,
+        totalRatings: 0,
+        thumbsUp: 0,
+        thumbsDown: 0,
+        tokensUsed: 10_000,
+      });
+      expect(output).toContain('No ratings yet');
+    });
+  });
+
+  describe('formatConsumption', () => {
+    it('shows token totals with today and this week', () => {
+      const output = formatConsumption(makeConsumption());
+      expect(output).toContain('125,430 total');
+      expect(output).toContain('12,300 today');
+      expect(output).toContain('45,200 this week');
+    });
+
+    it('shows daily budget when configured', () => {
+      const output = formatConsumption(makeConsumption(), { tokens_per_day: 100_000 });
       expect(output).toContain('Budget:');
-      expect(output).toContain('12,300');
-      expect(output).toContain('100,000');
       expect(output).toContain('87,700 remaining');
     });
 
-    it('shows monthly budget line when tokens_per_month configured but no daily limit', () => {
-      const output = formatAgentStats(makeAgent(), makeStats(), { tokens_per_month: 200_000 });
+    it('shows monthly budget when no daily limit', () => {
+      const output = formatConsumption(makeConsumption(), { tokens_per_month: 200_000 });
       expect(output).toContain('Budget:');
-      expect(output).toContain('98,100');
-      expect(output).toContain('200,000');
       expect(output).toContain('101,900 remaining');
     });
 
-    it('prefers daily budget over monthly when both configured', () => {
-      const output = formatAgentStats(makeAgent(), makeStats(), {
+    it('prefers daily budget over monthly', () => {
+      const output = formatConsumption(makeConsumption(), {
         tokens_per_day: 100_000,
         tokens_per_month: 200_000,
       });
@@ -104,20 +228,14 @@ describe('stats command', () => {
       expect(output).not.toContain('(30d)');
     });
 
-    it('does not show budget line when no limits configured', () => {
-      const output = formatAgentStats(makeAgent(), makeStats());
-      expect(output).not.toContain('Budget:');
-    });
-
-    it('does not show budget line when limits is null', () => {
-      const output = formatAgentStats(makeAgent(), makeStats(), null);
+    it('does not show budget when no limits', () => {
+      const output = formatConsumption(makeConsumption());
       expect(output).not.toContain('Budget:');
     });
 
     it('shows 0 remaining when budget exceeded', () => {
-      const output = formatAgentStats(
-        makeAgent(),
-        makeStats({
+      const output = formatConsumption(
+        makeConsumption({
           period: {
             last24h: { tokens: 150_000, reviews: 60 },
             last7d: { tokens: 150_000, reviews: 60 },
@@ -130,27 +248,61 @@ describe('stats command', () => {
     });
   });
 
+  describe('formatAgentStats', () => {
+    it('displays agent info and consumption', () => {
+      const output = formatAgentStats(makeAgent(), makeConsumption());
+      expect(output).toContain('Agent: agent-1 (claude-sonnet-4-6 / claude-code)');
+      expect(output).toContain('Tokens:');
+      expect(output).toContain('125,430 total');
+    });
+
+    it('displays trust tier when agent stats provided', () => {
+      const output = formatAgentStats(makeAgent(), makeConsumption(), null, makeAgentStats());
+      expect(output).toContain('Trusted');
+      expect(output).toContain('25 reviews');
+      expect(output).toContain('88% positive');
+    });
+
+    it('displays review quality when agent stats provided', () => {
+      const output = formatAgentStats(makeAgent(), makeConsumption(), null, makeAgentStats());
+      expect(output).toContain('25 completed');
+      expect(output).toContain('18/20 positive ratings');
+    });
+
+    it('omits trust and quality when no agent stats', () => {
+      const output = formatAgentStats(makeAgent(), makeConsumption());
+      expect(output).not.toContain('Trust:');
+      expect(output).not.toContain('Quality:');
+    });
+
+    it('shows budget when limits configured', () => {
+      const output = formatAgentStats(makeAgent(), makeConsumption(), { tokens_per_day: 100_000 });
+      expect(output).toContain('Budget:');
+      expect(output).toContain('87,700 remaining');
+    });
+  });
+
   describe('statsCommand action', () => {
-    it('displays stats for a specific agent', async () => {
-      const stats = makeStats();
-      mockFetchConsumptionStats.mockResolvedValueOnce(stats);
-      mockGet.mockResolvedValueOnce({
-        agents: [makeAgent()],
-      });
+    it('displays stats for a specific agent with trust tier', async () => {
+      const consumption = makeConsumption();
+      mockFetchConsumptionStats.mockResolvedValueOnce(consumption);
+      mockGet
+        .mockResolvedValueOnce({ agents: [makeAgent()] }) // /api/agents
+        .mockResolvedValueOnce(makeAgentStats()); // /api/stats/:agentId
 
       await statsCommand.parseAsync(['--agent', 'agent-1'], { from: 'user' });
 
       expect(mockFetchConsumptionStats).toHaveBeenCalled();
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Agent: agent-1'));
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining('claude-sonnet-4-6 / claude-code'),
-      );
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Trusted'));
     });
 
     it('shows unknown model/tool when agent list fetch fails for specific agent', async () => {
-      const stats = makeStats();
-      mockFetchConsumptionStats.mockResolvedValueOnce(stats);
-      mockGet.mockRejectedValueOnce(new Error('Network error'));
+      const consumption = makeConsumption();
+      mockFetchConsumptionStats.mockResolvedValueOnce(consumption);
+      mockGet
+        .mockRejectedValueOnce(new Error('Network error')) // /api/agents fails
+        .mockResolvedValueOnce(makeAgentStats()); // /api/stats/:agentId
 
       await statsCommand.parseAsync(['--agent', 'agent-1'], { from: 'user' });
 
@@ -158,15 +310,31 @@ describe('stats command', () => {
     });
 
     it('shows unknown model/tool when agent not found in list', async () => {
-      const stats = makeStats();
-      mockFetchConsumptionStats.mockResolvedValueOnce(stats);
-      mockGet.mockResolvedValueOnce({
-        agents: [makeAgent({ id: 'other-agent' })],
-      });
+      const consumption = makeConsumption();
+      mockFetchConsumptionStats.mockResolvedValueOnce(consumption);
+      mockGet
+        .mockResolvedValueOnce({ agents: [makeAgent({ id: 'other-agent' })] })
+        .mockResolvedValueOnce(makeAgentStats());
 
       await statsCommand.parseAsync(['--agent', 'agent-1'], { from: 'user' });
 
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('unknown / unknown'));
+    });
+
+    it('displays stats without trust tier when agent stats fail', async () => {
+      const consumption = makeConsumption();
+      mockFetchConsumptionStats.mockResolvedValueOnce(consumption);
+      mockGet
+        .mockResolvedValueOnce({ agents: [makeAgent()] })
+        .mockRejectedValueOnce(new Error('Stats unavailable'));
+
+      await statsCommand.parseAsync(['--agent', 'agent-1'], { from: 'user' });
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Agent: agent-1'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Tokens:'));
+      // Should not contain trust info since stats fetch failed
+      const output = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).not.toContain('Trust:');
     });
 
     it('exits when consumption stats fetch fails for specific agent', async () => {
@@ -190,12 +358,17 @@ describe('stats command', () => {
     });
 
     it('displays stats for all agents', async () => {
-      mockGet.mockResolvedValueOnce({
-        agents: [makeAgent(), makeAgent({ id: 'agent-2', model: 'gpt-4', tool: 'copilot' })],
-      });
+      mockGet
+        .mockResolvedValueOnce({
+          agents: [makeAgent(), makeAgent({ id: 'agent-2', model: 'gpt-4', tool: 'copilot' })],
+        })
+        .mockResolvedValueOnce(makeAgentStats()) // stats for agent-1
+        .mockResolvedValueOnce(
+          makeAgentStats({ agent: { ...makeAgentStats().agent, id: 'agent-2' } }),
+        ); // stats for agent-2
       mockFetchConsumptionStats
-        .mockResolvedValueOnce(makeStats())
-        .mockResolvedValueOnce(makeStats({ agentId: 'agent-2' }));
+        .mockResolvedValueOnce(makeConsumption())
+        .mockResolvedValueOnce(makeConsumption({ agentId: 'agent-2' }));
 
       await statsCommand.parseAsync([], { from: 'user' });
 
@@ -228,11 +401,13 @@ describe('stats command', () => {
     });
 
     it('handles individual agent stats fetch failure in all-agents mode', async () => {
-      mockGet.mockResolvedValueOnce({
-        agents: [makeAgent(), makeAgent({ id: 'agent-2', model: 'gpt-4', tool: 'copilot' })],
-      });
+      mockGet
+        .mockResolvedValueOnce({
+          agents: [makeAgent(), makeAgent({ id: 'agent-2', model: 'gpt-4', tool: 'copilot' })],
+        })
+        .mockResolvedValueOnce(makeAgentStats()); // stats for agent-1 (agent-2 consumption fails)
       mockFetchConsumptionStats
-        .mockResolvedValueOnce(makeStats())
+        .mockResolvedValueOnce(makeConsumption())
         .mockRejectedValueOnce(new Error('Agent offline'));
 
       await statsCommand.parseAsync([], { from: 'user' });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -6,6 +6,7 @@ import type {
   CreateAgentResponse,
   ListAgentsResponse,
   AgentResponse,
+  AgentStatsResponse,
   PlatformMessage,
   ReviewRequestMessage,
   SummaryRequestMessage,
@@ -35,17 +36,26 @@ export interface ConsumptionDeps {
 /** Minimum time (ms) a connection must be alive before we reset the attempt counter */
 const CONNECTION_STABILITY_THRESHOLD_MS = 30_000;
 
-function formatTable(agents: AgentResponse[]): void {
+function formatTable(agents: AgentResponse[], trustLabels?: Map<string, string>): void {
   if (agents.length === 0) {
     console.log('No agents registered. Run `opencrust agent create` to register one.');
     return;
   }
 
-  const header = ['ID'.padEnd(38), 'Model'.padEnd(22), 'Tool'.padEnd(16), 'Status'].join('');
+  const header = [
+    'ID'.padEnd(38),
+    'Model'.padEnd(22),
+    'Tool'.padEnd(16),
+    'Status'.padEnd(10),
+    'Trust',
+  ].join('');
   console.log(header);
 
   for (const a of agents) {
-    console.log([a.id.padEnd(38), a.model.padEnd(22), a.tool.padEnd(16), a.status].join(''));
+    const trust = trustLabels?.get(a.id) ?? '--';
+    console.log(
+      [a.id.padEnd(38), a.model.padEnd(22), a.tool.padEnd(16), a.status.padEnd(10), trust].join(''),
+    );
   }
 }
 
@@ -483,7 +493,18 @@ agentCommand
       process.exit(1);
     }
 
-    formatTable(res.agents);
+    // Fetch trust tier labels for each agent
+    const trustLabels = new Map<string, string>();
+    for (const agent of res.agents) {
+      try {
+        const stats = await client.get<AgentStatsResponse>(`/api/stats/${agent.id}`);
+        trustLabels.set(agent.id, stats.agent.trustTier.label);
+      } catch {
+        // Leave as '--' if stats unavailable
+      }
+    }
+
+    formatTable(res.agents, trustLabels);
   });
 
 agentCommand

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -3,50 +3,96 @@ import type {
   ConsumptionStatsResponse,
   ListAgentsResponse,
   AgentResponse,
+  AgentStatsResponse,
+  TrustTierInfo,
 } from '@opencrust/shared';
 import { loadConfig, requireApiKey, type ConsumptionLimits } from '../config.js';
 import { ApiClient } from '../http.js';
 import { fetchConsumptionStats } from '../consumption.js';
 
-function formatAgentStats(
-  agent: AgentResponse,
-  stats: ConsumptionStatsResponse,
+function formatTrustTier(tier: TrustTierInfo): string {
+  const lines: string[] = [];
+  const pctPositive = Math.round(tier.positiveRate * 100);
+  lines.push(`  Trust:    ${tier.label} (${tier.reviewCount} reviews, ${pctPositive}% positive)`);
+  if (tier.nextTier) {
+    const pctProgress = Math.round(tier.progressToNext * 100);
+    const nextLabel = tier.nextTier.charAt(0).toUpperCase() + tier.nextTier.slice(1);
+    lines.push(`            Progress to ${nextLabel}: ${pctProgress}%`);
+  }
+  return lines.join('\n');
+}
+
+function formatReviewQuality(stats: AgentStatsResponse['stats']): string {
+  const lines: string[] = [];
+  lines.push(`  Reviews:  ${stats.totalReviews} completed, ${stats.totalSummaries} summaries`);
+  const totalRatings = stats.thumbsUp + stats.thumbsDown;
+  if (totalRatings > 0) {
+    const pctPositive = Math.round((stats.thumbsUp / totalRatings) * 100);
+    lines.push(`  Quality:  ${stats.thumbsUp}/${totalRatings} positive ratings (${pctPositive}%)`);
+  } else {
+    lines.push(`  Quality:  No ratings yet`);
+  }
+  return lines.join('\n');
+}
+
+function formatConsumption(
+  consumption: ConsumptionStatsResponse,
   limits?: ConsumptionLimits | null,
 ): string {
   const lines: string[] = [];
-  lines.push(`Agent: ${agent.id} (${agent.model} / ${agent.tool})`);
   lines.push(
-    `  Total: ${stats.totalTokens.toLocaleString()} tokens across ${stats.totalReviews} reviews`,
-  );
-  lines.push(
-    `  Last 24h: ${stats.period.last24h.tokens.toLocaleString()} tokens / ${stats.period.last24h.reviews} reviews`,
-  );
-  lines.push(
-    `  Last 7d:  ${stats.period.last7d.tokens.toLocaleString()} tokens / ${stats.period.last7d.reviews} reviews`,
-  );
-  lines.push(
-    `  Last 30d: ${stats.period.last30d.tokens.toLocaleString()} tokens / ${stats.period.last30d.reviews} reviews`,
+    `  Tokens:   ${consumption.totalTokens.toLocaleString()} total (${consumption.period.last24h.tokens.toLocaleString()} today, ${consumption.period.last7d.tokens.toLocaleString()} this week)`,
   );
 
   if (limits?.tokens_per_day) {
-    const remaining = Math.max(0, limits.tokens_per_day - stats.period.last24h.tokens);
+    const remaining = Math.max(0, limits.tokens_per_day - consumption.period.last24h.tokens);
     lines.push(
-      `  Budget:   ${stats.period.last24h.tokens.toLocaleString()} / ${limits.tokens_per_day.toLocaleString()} tokens (24h) — ${remaining.toLocaleString()} remaining`,
+      `  Budget:   ${consumption.period.last24h.tokens.toLocaleString()} / ${limits.tokens_per_day.toLocaleString()} tokens (24h) — ${remaining.toLocaleString()} remaining`,
     );
   } else if (limits?.tokens_per_month) {
-    const remaining = Math.max(0, limits.tokens_per_month - stats.period.last30d.tokens);
+    const remaining = Math.max(0, limits.tokens_per_month - consumption.period.last30d.tokens);
     lines.push(
-      `  Budget:   ${stats.period.last30d.tokens.toLocaleString()} / ${limits.tokens_per_month.toLocaleString()} tokens (30d) — ${remaining.toLocaleString()} remaining`,
+      `  Budget:   ${consumption.period.last30d.tokens.toLocaleString()} / ${limits.tokens_per_month.toLocaleString()} tokens (30d) — ${remaining.toLocaleString()} remaining`,
     );
   }
 
   return lines.join('\n');
 }
 
-export { formatAgentStats };
+function formatAgentStats(
+  agent: AgentResponse,
+  consumption: ConsumptionStatsResponse,
+  limits?: ConsumptionLimits | null,
+  agentStats?: AgentStatsResponse | null,
+): string {
+  const lines: string[] = [];
+  lines.push(`Agent: ${agent.id} (${agent.model} / ${agent.tool})`);
+
+  if (agentStats) {
+    lines.push(formatTrustTier(agentStats.agent.trustTier));
+    lines.push(formatReviewQuality(agentStats.stats));
+  }
+
+  lines.push(formatConsumption(consumption, limits));
+
+  return lines.join('\n');
+}
+
+export { formatAgentStats, formatTrustTier, formatReviewQuality, formatConsumption };
+
+async function fetchAgentStats(
+  client: ApiClient,
+  agentId: string,
+): Promise<AgentStatsResponse | null> {
+  try {
+    return await client.get<AgentStatsResponse>(`/api/stats/${agentId}`);
+  } catch {
+    return null;
+  }
+}
 
 export const statsCommand = new Command('stats')
-  .description('Display consumption statistics for agents')
+  .description('Display agent dashboard: trust tier, review quality, and consumption stats')
   .option('--agent <agentId>', 'Show stats for a specific agent')
   .action(async (opts: { agent?: string }) => {
     const config = loadConfig();
@@ -54,9 +100,9 @@ export const statsCommand = new Command('stats')
     const client = new ApiClient(config.platformUrl, apiKey);
 
     if (opts.agent) {
-      let stats: ConsumptionStatsResponse;
+      let consumption: ConsumptionStatsResponse;
       try {
-        stats = await fetchConsumptionStats(client, opts.agent);
+        consumption = await fetchConsumptionStats(client, opts.agent);
       } catch (err) {
         console.error(
           'Failed to fetch consumption stats:',
@@ -86,7 +132,8 @@ export const statsCommand = new Command('stats')
         // Proceed with unknown model/tool
       }
 
-      console.log(formatAgentStats(agent, stats, config.limits));
+      const agentStats = await fetchAgentStats(client, opts.agent);
+      console.log(formatAgentStats(agent, consumption, config.limits, agentStats));
       return;
     }
 
@@ -107,8 +154,9 @@ export const statsCommand = new Command('stats')
     const outputs: string[] = [];
     for (const agent of agentsRes.agents) {
       try {
-        const stats = await fetchConsumptionStats(client, agent.id);
-        outputs.push(formatAgentStats(agent, stats, config.limits));
+        const consumption = await fetchConsumptionStats(client, agent.id);
+        const agentStats = await fetchAgentStats(client, agent.id);
+        outputs.push(formatAgentStats(agent, consumption, config.limits, agentStats));
       } catch (err) {
         outputs.push(
           `Agent: ${agent.id} (${agent.model} / ${agent.tool})\n  Error: ${err instanceof Error ? err.message : 'Failed to fetch stats'}`,


### PR DESCRIPTION
Closes #72

## Summary
- Enriched `opencrust stats` to show trust tier (with progress to next tier), review quality (positive ratings %), review counts, and consumption in a unified dashboard view
- Added Trust column to `opencrust agent list` table, fetching trust tier labels from `/api/stats/:agentId`
- Extracted `formatTrustTier`, `formatReviewQuality`, `formatConsumption` helpers for clean separation
- Graceful degradation: stats display works without trust tier data (shows consumption only)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm vitest run` — 645/645 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run typecheck` — clean
- [ ] Verify `opencrust stats` shows trust tier + quality when API available
- [ ] Verify `opencrust agent list` shows Trust column