### PR TITLE
[cli-dev] Configurable stability threshold for agent start (#73)

### DIFF
--- a/packages/cli/src/__tests__/agent-commands.test.ts
+++ b/packages/cli/src/__tests__/agent-commands.test.ts
@@ -400,6 +400,51 @@ describe('agent commands', () => {
       vi.useRealTimers();
     });
 
+    it('accepts valid --stability-threshold option', async () => {
+      await agentCommand.parseAsync(['start', 'a1', '--stability-threshold', '60000'], {
+        from: 'user',
+      });
+
+      expect(logSpy).toHaveBeenCalledWith('Starting agent a1...');
+      expect(mockWsInstances).toHaveLength(1);
+    });
+
+    it('rejects --stability-threshold below minimum', async () => {
+      await expect(
+        agentCommand.parseAsync(['start', 'a1', '--stability-threshold', '1000'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid --stability-threshold'),
+      );
+    });
+
+    it('rejects --stability-threshold above maximum', async () => {
+      await expect(
+        agentCommand.parseAsync(['start', 'a1', '--stability-threshold', '500000'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid --stability-threshold'),
+      );
+    });
+
+    it('rejects non-integer --stability-threshold', async () => {
+      await expect(
+        agentCommand.parseAsync(['start', 'a1', '--stability-threshold', 'abc'], {
+          from: 'user',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid --stability-threshold'),
+      );
+    });
+
     it('shuts down gracefully on SIGINT', async () => {
       const onceSpy = vi.mocked(process.once);
 

--- a/packages/cli/src/__tests__/reconnect-guard.test.ts
+++ b/packages/cli/src/__tests__/reconnect-guard.test.ts
@@ -178,4 +178,42 @@ describe('startAgent reconnect guards', () => {
     );
     expect(verboseCalls).toHaveLength(0);
   });
+
+  it('uses custom stability threshold when provided', async () => {
+    startAgent('agent-1', 'http://localhost:8787', 'test-key', undefined, undefined, {
+      verbose: true,
+      stabilityThresholdMs: 60_000,
+    });
+
+    const ws = mockWsInstances[0];
+    ws.emit('open');
+
+    // At 31s (past default 30s but before custom 60s), should NOT have reset
+    vi.advanceTimersByTime(31_000);
+    const stableCalls = (console.log as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('Connection stable'),
+    );
+    expect(stableCalls).toHaveLength(0);
+
+    // At 61s (past custom 60s), should have reset
+    vi.advanceTimersByTime(30_000);
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('[verbose] Connection stable for 60s'),
+    );
+  });
+
+  it('uses default threshold when stabilityThresholdMs is not provided', async () => {
+    startAgent('agent-1', 'http://localhost:8787', 'test-key', undefined, undefined, {
+      verbose: true,
+    });
+
+    const ws = mockWsInstances[0];
+    ws.emit('open');
+
+    // Advance past default 30s threshold
+    vi.advanceTimersByTime(31_000);
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('[verbose] Connection stable for 30s'),
+    );
+  });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -70,8 +70,12 @@ export { buildWsUrl };
 
 const HEARTBEAT_TIMEOUT_MS = 90_000;
 
+export const STABILITY_THRESHOLD_MIN_MS = 5_000;
+export const STABILITY_THRESHOLD_MAX_MS = 300_000;
+
 export interface StartAgentOptions {
   verbose?: boolean;
+  stabilityThresholdMs?: number;
 }
 
 export function startAgent(
@@ -83,6 +87,7 @@ export function startAgent(
   options?: StartAgentOptions,
 ): void {
   const verbose = options?.verbose ?? false;
+  const stabilityThreshold = options?.stabilityThresholdMs ?? CONNECTION_STABILITY_THRESHOLD_MS;
   let attempt = 0;
   let intentionalClose = false;
   let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
@@ -138,16 +143,16 @@ export function startAgent(
         console.log(`[verbose] Connection opened at ${new Date(connectionOpenedAt).toISOString()}`);
       }
 
-      // Deferred attempt reset: only reset after connection is stable for 30s
+      // Deferred attempt reset: only reset after connection is stable
       clearStabilityTimer();
       stabilityTimer = setTimeout(() => {
         if (verbose) {
           console.log(
-            `[verbose] Connection stable for ${CONNECTION_STABILITY_THRESHOLD_MS / 1000}s — resetting reconnect counter`,
+            `[verbose] Connection stable for ${stabilityThreshold / 1000}s — resetting reconnect counter`,
           );
         }
         attempt = 0;
-      }, CONNECTION_STABILITY_THRESHOLD_MS);
+      }, stabilityThreshold);
     });
 
     ws.on('message', (data: WebSocket.Data) => {
@@ -511,76 +516,101 @@ agentCommand
   .command('start [agentId]')
   .description('Connect agent to platform via WebSocket')
   .option('--verbose', 'Enable detailed WebSocket diagnostic logging')
-  .action(async (agentId: string | undefined, opts: { verbose?: boolean }) => {
-    const config = loadConfig();
-    const apiKey = requireApiKey(config);
-
-    const client = new ApiClient(config.platformUrl, apiKey);
-    let agentTool: string | undefined;
-
-    if (!agentId) {
-      let res: ListAgentsResponse;
-      try {
-        res = await client.get<ListAgentsResponse>('/api/agents');
-      } catch (err) {
-        console.error('Failed to list agents:', err instanceof Error ? err.message : err);
-        process.exit(1);
+  .option(
+    '--stability-threshold <ms>',
+    `Connection stability threshold in ms (${STABILITY_THRESHOLD_MIN_MS}–${STABILITY_THRESHOLD_MAX_MS}, default: ${CONNECTION_STABILITY_THRESHOLD_MS})`,
+  )
+  .action(
+    async (
+      agentId: string | undefined,
+      opts: { verbose?: boolean; stabilityThreshold?: string },
+    ) => {
+      let stabilityThresholdMs: number | undefined;
+      if (opts.stabilityThreshold !== undefined) {
+        const val = Number(opts.stabilityThreshold);
+        if (
+          !Number.isInteger(val) ||
+          val < STABILITY_THRESHOLD_MIN_MS ||
+          val > STABILITY_THRESHOLD_MAX_MS
+        ) {
+          console.error(
+            `Invalid --stability-threshold: must be an integer between ${STABILITY_THRESHOLD_MIN_MS} and ${STABILITY_THRESHOLD_MAX_MS}`,
+          );
+          process.exit(1);
+        }
+        stabilityThresholdMs = val;
       }
+      const config = loadConfig();
+      const apiKey = requireApiKey(config);
 
-      if (res.agents.length === 0) {
-        console.error('No agents registered. Run `opencrust agent create` first.');
-        process.exit(1);
-      }
+      const client = new ApiClient(config.platformUrl, apiKey);
+      let agentTool: string | undefined;
 
-      if (res.agents.length === 1) {
-        agentId = res.agents[0].id;
-        agentTool = res.agents[0].tool;
-        console.log(`Using agent ${agentId}`);
+      if (!agentId) {
+        let res: ListAgentsResponse;
+        try {
+          res = await client.get<ListAgentsResponse>('/api/agents');
+        } catch (err) {
+          console.error('Failed to list agents:', err instanceof Error ? err.message : err);
+          process.exit(1);
+        }
+
+        if (res.agents.length === 0) {
+          console.error('No agents registered. Run `opencrust agent create` first.');
+          process.exit(1);
+        }
+
+        if (res.agents.length === 1) {
+          agentId = res.agents[0].id;
+          agentTool = res.agents[0].tool;
+          console.log(`Using agent ${agentId}`);
+        } else {
+          console.error('Multiple agents found. Please specify an agent ID:');
+          for (const a of res.agents) {
+            console.error(`  ${a.id}  ${a.model} / ${a.tool}`);
+          }
+          process.exit(1);
+        }
       } else {
-        console.error('Multiple agents found. Please specify an agent ID:');
-        for (const a of res.agents) {
-          console.error(`  ${a.id}  ${a.model} / ${a.tool}`);
+        // Fetch agent info to get the tool field
+        try {
+          const res = await client.get<ListAgentsResponse>('/api/agents');
+          const agent = res.agents.find((a) => a.id === agentId);
+          if (agent) {
+            agentTool = agent.tool;
+          }
+        } catch (err) {
+          console.warn(
+            `Warning: Failed to fetch agent info: ${err instanceof Error ? err.message : 'unknown error'}`,
+          );
         }
-        process.exit(1);
       }
-    } else {
-      // Fetch agent info to get the tool field
+
+      let reviewDeps: ReviewExecutorDeps | undefined;
       try {
-        const res = await client.get<ListAgentsResponse>('/api/agents');
-        const agent = res.agents.find((a) => a.id === agentId);
-        if (agent) {
-          agentTool = agent.tool;
-        }
+        const commandTemplate = resolveCommandTemplate(config.agentCommand, agentTool);
+        reviewDeps = {
+          commandTemplate,
+          maxDiffSizeKb: config.maxDiffSizeKb,
+        };
       } catch (err) {
         console.warn(
-          `Warning: Failed to fetch agent info: ${err instanceof Error ? err.message : 'unknown error'}`,
+          `Warning: ${err instanceof Error ? err.message : 'Could not determine agent command.'}` +
+            ' Reviews will be rejected.',
         );
       }
-    }
 
-    let reviewDeps: ReviewExecutorDeps | undefined;
-    try {
-      const commandTemplate = resolveCommandTemplate(config.agentCommand, agentTool);
-      reviewDeps = {
-        commandTemplate,
-        maxDiffSizeKb: config.maxDiffSizeKb,
+      const consumptionDeps: ConsumptionDeps = {
+        client,
+        agentId,
+        limits: config.limits,
+        session: createSessionTracker(),
       };
-    } catch (err) {
-      console.warn(
-        `Warning: ${err instanceof Error ? err.message : 'Could not determine agent command.'}` +
-          ' Reviews will be rejected.',
-      );
-    }
 
-    const consumptionDeps: ConsumptionDeps = {
-      client,
-      agentId,
-      limits: config.limits,
-      session: createSessionTracker(),
-    };
-
-    console.log(`Starting agent ${agentId}...`);
-    startAgent(agentId, config.platformUrl, apiKey, reviewDeps, consumptionDeps, {
-      verbose: opts.verbose,
-    });
-  });
+      console.log(`Starting agent ${agentId}...`);
+      startAgent(agentId, config.platformUrl, apiKey, reviewDeps, consumptionDeps, {
+        verbose: opts.verbose,
+        stabilityThresholdMs,
+      });
+    },
+  );


### PR DESCRIPTION
Closes #73

## Summary
- Added `--stability-threshold <ms>` option to `opencrust agent start` for configuring how long a WebSocket connection must be alive before the reconnect counter resets
- Input validation: must be an integer between 5000ms (5s) and 300000ms (5min)
- Defaults to existing 30000ms (30s) when not specified
- Exported `STABILITY_THRESHOLD_MIN_MS` and `STABILITY_THRESHOLD_MAX_MS` constants

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm vitest run` — 651/651 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run typecheck` — clean
- [ ] Verify custom threshold timing works (60s threshold doesn't reset at 31s)
- [ ] Verify default threshold still works (30s)
- [ ] Verify validation rejects invalid values