### PR TITLE
Add preferred_models support to .review.yml

### DIFF
--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -13,6 +13,9 @@ prompt: |
   This project uses TypeScript + React, following ESLint standards.
 agents:
   review_count: 2
+  preferred_models:
+    - claude-opus-4-6
+    - glm-5
   preferred_tools:
     - claude-code
     - codex
@@ -48,6 +51,7 @@ describe('parseReviewConfig', () => {
     expect(config.version).toBe(1);
     expect(config.prompt).toContain('Focus on code quality');
     expect(config.agents.reviewCount).toBe(2);
+    expect(config.agents.preferredModels).toEqual(['claude-opus-4-6', 'glm-5']);
     expect(config.agents.preferredTools).toEqual(['claude-code', 'codex']);
     expect(config.agents.minReputation).toBe(0.6);
     expect(config.reviewer.whitelist).toEqual([{ user: 'alice' }, { agent: 'abc-123' }]);

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -12,6 +12,7 @@ export interface ReviewConfig {
   trigger: TriggerConfig;
   agents: {
     reviewCount: number;
+    preferredModels: string[];
     preferredTools: string[];
     minReputation: number;
   };
@@ -84,6 +85,7 @@ export const DEFAULT_REVIEW_CONFIG: ReviewConfig = {
   trigger: DEFAULT_TRIGGER,
   agents: {
     reviewCount: 1,
+    preferredModels: [],
     preferredTools: [],
     minReputation: 0,
   },
@@ -153,6 +155,9 @@ export function parseReviewConfig(yaml: string): ParseResult {
         1,
         10,
       ),
+      preferredModels: Array.isArray(agentsRaw.preferred_models)
+        ? agentsRaw.preferred_models.filter((t: unknown) => typeof t === 'string')
+        : [],
       preferredTools: Array.isArray(agentsRaw.preferred_tools)
         ? agentsRaw.preferred_tools.filter((t: unknown) => typeof t === 'string')
         : [],

--- a/packages/worker/src/__tests__/task-distribution.test.ts
+++ b/packages/worker/src/__tests__/task-distribution.test.ts
@@ -98,12 +98,12 @@ describe('selectAgents', () => {
   ];
 
   it('returns exactly reviewCount agents', () => {
-    const result = selectAgents(agents, 2, []);
+    const result = selectAgents(agents, 2, [], []);
     expect(result).toHaveLength(2);
   });
 
   it('selects preferred tools first, then by reputation', () => {
-    const result = selectAgents(agents, 2, ['cursor']);
+    const result = selectAgents(agents, 2, [], ['cursor']);
     expect(result).toHaveLength(2);
     // Both cursor agents selected (preferred)
     expect(result.map((a) => a.id)).toEqual(['a1', 'a3']);
@@ -115,29 +115,49 @@ describe('selectAgents', () => {
       makeAgent({ id: 'a2', tool: 'vscode', reputationScore: 0.9 }),
       makeAgent({ id: 'a3', tool: 'cursor', reputationScore: 0.7 }),
     ];
-    const result = selectAgents(ranked, 2, []);
+    const result = selectAgents(ranked, 2, [], []);
     expect(result.map((a) => a.id)).toEqual(['a2', 'a3']); // highest reputation first
   });
 
   it('returns available agents when fewer than reviewCount', () => {
-    const result = selectAgents([agents[0]], 3, []);
+    const result = selectAgents([agents[0]], 3, [], []);
     expect(result).toHaveLength(1); // dispatches to what's available
   });
 
   it('returns empty array for empty agents', () => {
-    expect(selectAgents([], 2, ['cursor'])).toEqual([]);
+    expect(selectAgents([], 2, [], ['cursor'])).toEqual([]);
   });
 
   it('caps at reviewCount even with many agents', () => {
     const manyAgents = Array.from({ length: 15 }, (_, i) =>
       makeAgent({ id: `a${i}`, tool: 'cursor' }),
     );
-    const result = selectAgents(manyAgents, 3, []);
+    const result = selectAgents(manyAgents, 3, [], []);
     expect(result).toHaveLength(3);
   });
 
   it('returns all agents when exactly reviewCount are available', () => {
-    const result = selectAgents(agents, 4, []);
+    const result = selectAgents(agents, 4, [], []);
     expect(result).toHaveLength(4);
+  });
+
+  it('prioritizes preferred models over preferred tools', () => {
+    const mixed = [
+      makeAgent({ id: 'a1', model: 'gpt-4', tool: 'cursor', reputationScore: 0.5 }),
+      makeAgent({ id: 'a2', model: 'claude-opus-4-6', tool: 'vscode', reputationScore: 0.9 }),
+      makeAgent({ id: 'a3', model: 'glm-5', tool: 'cursor', reputationScore: 0.7 }),
+    ];
+    const result = selectAgents(mixed, 2, ['claude-opus-4-6'], ['cursor']);
+    expect(result.map((a) => a.id)).toEqual(['a2', 'a3']); // model match first, then tool match by reputation
+  });
+
+  it('selects by preferred models only', () => {
+    const mixed = [
+      makeAgent({ id: 'a1', model: 'gpt-4', reputationScore: 0.9 }),
+      makeAgent({ id: 'a2', model: 'claude-opus-4-6', reputationScore: 0.5 }),
+      makeAgent({ id: 'a3', model: 'glm-5', reputationScore: 0.7 }),
+    ];
+    const result = selectAgents(mixed, 2, ['claude-opus-4-6', 'glm-5'], []);
+    expect(result.map((a) => a.id)).toEqual(['a3', 'a2']); // model matches by reputation
   });
 });

--- a/packages/worker/src/task-distribution.ts
+++ b/packages/worker/src/task-distribution.ts
@@ -94,31 +94,43 @@ export const MAX_AGENTS_PER_TASK = 10;
 
 /**
  * Select up to `reviewCount` agents for a review.
- * Preferred tools first, then sorted by reputation (descending).
+ * Priority: preferred models > preferred tools > others, sorted by reputation within each group.
  * Returns empty only if no agents are available at all.
- * Returns fewer than reviewCount if not enough agents are online.
  */
 export function selectAgents(
   agents: EligibleAgent[],
   reviewCount: number,
+  preferredModels: string[],
   preferredTools: string[],
 ): EligibleAgent[] {
   if (agents.length === 0) return [];
 
   const count = Math.min(reviewCount, agents.length);
-
-  // Sort by reputation descending within each group
   const byReputation = (a: EligibleAgent, b: EligibleAgent) =>
     b.reputationScore - a.reputationScore;
 
-  if (preferredTools.length === 0) {
+  const hasModelPref = preferredModels.length > 0;
+  const hasToolPref = preferredTools.length > 0;
+
+  if (!hasModelPref && !hasToolPref) {
     return [...agents].sort(byReputation).slice(0, count);
   }
 
-  const preferred = agents.filter((a) => preferredTools.includes(a.tool)).sort(byReputation);
-  const others = agents.filter((a) => !preferredTools.includes(a.tool)).sort(byReputation);
+  const modelMatch = hasModelPref
+    ? agents.filter((a) => preferredModels.includes(a.model)).sort(byReputation)
+    : [];
+  const modelMatchIds = new Set(modelMatch.map((a) => a.id));
 
-  return [...preferred, ...others].slice(0, count);
+  const toolMatch = hasToolPref
+    ? agents
+        .filter((a) => preferredTools.includes(a.tool) && !modelMatchIds.has(a.id))
+        .sort(byReputation)
+    : [];
+  const matchedIds = new Set([...modelMatchIds, ...toolMatch.map((a) => a.id)]);
+
+  const others = agents.filter((a) => !matchedIds.has(a.id)).sort(byReputation);
+
+  return [...modelMatch, ...toolMatch, ...others].slice(0, count);
 }
 
 /**
@@ -243,7 +255,12 @@ export async function distributeTask(
     config.reviewer.whitelist,
     config.reviewer.blacklist,
   );
-  const selected = selectAgents(filtered, config.agents.reviewCount, config.agents.preferredTools);
+  const selected = selectAgents(
+    filtered,
+    config.agents.reviewCount,
+    config.agents.preferredModels,
+    config.agents.preferredTools,
+  );
 
   if (selected.length === 0) {
     console.log(`No eligible agents found for task ${taskId} — stays pending for pickup`);


### PR DESCRIPTION
## Summary
Add `preferred_models` field to `.review.yml` config so repo owners can prioritize which AI models review their code.

Closes #84

## Changes
- `ReviewConfig.agents.preferredModels` — parsed from `preferred_models` in YAML
- `selectAgents()` priority: preferred models > preferred tools > others (sorted by reputation within each group)

## Config example
```yaml
agents:
  review_count: 3
  preferred_models: [claude-opus-4-6, glm-5]
  preferred_tools: [claude-code]
```

## Test plan
- [x] 642 tests pass (+2 new: model priority, model-only selection)
- [x] Build, lint, format, typecheck pass