### PR TITLE
Show contributor GitHub profile in reviews

### DIFF
--- a/packages/worker/src/agent-connection.ts
+++ b/packages/worker/src/agent-connection.ts
@@ -17,6 +17,7 @@ import {
   formatSummaryComment,
   postIndividualReviewsFallback,
   fetchCompletedReviews,
+  fetchReviewContributors,
 } from './summarization.js';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -36,13 +37,18 @@ export function formatReviewComment(
   model: string,
   tool: string,
   review: string,
+  contributorName?: string,
 ): string {
   const verdictLabel = VERDICT_LABELS[verdict];
+  const contributorLine = contributorName
+    ? `**Contributor**: [@${contributorName}](https://github.com/${contributorName})`
+    : '';
   return [
     '## \uD83D\uDD0D OpenCara Review',
     '',
     `**Verdict**: ${verdictLabel}`,
     `**Agent**: \`${model}\` / \`${tool}\``,
+    ...(contributorLine ? [contributorLine] : []),
     '',
     '---',
     '',
@@ -539,12 +545,15 @@ export class AgentConnection implements DurableObject {
     // Look up agent model/tool for comment formatting
     const { data: agentData } = await supabase
       .from('agents')
-      .select('model, tool')
+      .select('model, tool, users!inner(name)')
       .eq('id', agentId)
       .single();
 
     const model = agentData?.model ?? 'unknown';
     const tool = agentData?.tool ?? 'unknown';
+    const contributorName = agentData
+      ? (((agentData.users as unknown as Record<string, unknown>)?.name as string) ?? undefined)
+      : undefined;
 
     // Parse structured review for inline comments
     const parsed = parseStructuredReview(msg.review);
@@ -555,7 +564,13 @@ export class AgentConnection implements DurableObject {
     // Use parsed summary if available, otherwise use raw review text
     const reviewBody = parsed.summary !== msg.review ? parsed.summary : msg.review;
     const effectiveVerdict = parsed.verdict ?? msg.verdict;
-    const formattedReview = formatReviewComment(effectiveVerdict, model, tool, reviewBody);
+    const formattedReview = formatReviewComment(
+      effectiveVerdict,
+      model,
+      tool,
+      reviewBody,
+      contributorName,
+    );
 
     try {
       console.log(
@@ -836,7 +851,12 @@ export class AgentConnection implements DurableObject {
       const inlineComments = filterValidComments(parsed.comments, diffFiles);
 
       const summaryText = parsed.summary !== msg.summary ? parsed.summary : msg.summary;
-      const summaryBody = formatSummaryComment(summaryText, reviewCountResult ?? 0);
+      const contributorNames = await fetchReviewContributors(supabase, msg.taskId);
+      const summaryBody = formatSummaryComment(
+        summaryText,
+        reviewCountResult ?? 0,
+        contributorNames,
+      );
       const event = parsed.verdict ? verdictToReviewEvent(parsed.verdict) : 'COMMENT';
       const summaryUrl = await postPrReview(
         project.owner,

--- a/packages/worker/src/summarization.ts
+++ b/packages/worker/src/summarization.ts
@@ -21,11 +21,20 @@ const VERDICT_EMOJI: Record<ReviewVerdict, string> = {
 /**
  * Format the summary as the main PR comment.
  */
-export function formatSummaryComment(summary: string, reviewCount: number): string {
+export function formatSummaryComment(
+  summary: string,
+  reviewCount: number,
+  contributorNames?: string[],
+): string {
+  const contributorsLine =
+    contributorNames && contributorNames.length > 0
+      ? `**Contributors**: ${contributorNames.map((n) => `[@${n}](https://github.com/${n})`).join(', ')}`
+      : '';
   return [
     '## \uD83D\uDD0D OpenCara Review Summary',
     '',
     `**Reviews**: ${reviewCount} agent${reviewCount !== 1 ? 's' : ''} reviewed this PR`,
+    ...(contributorsLine ? [contributorsLine] : []),
     '',
     '---',
     '',
@@ -52,6 +61,31 @@ export function formatIndividualReviewComment(
     '',
     review,
   ].join('\n');
+}
+
+/**
+ * Fetch distinct contributor names for a task's reviews.
+ */
+export async function fetchReviewContributors(
+  supabase: SupabaseClient,
+  taskId: string,
+): Promise<string[]> {
+  const { data } = await supabase
+    .from('review_results')
+    .select('agents!inner(users!inner(name))')
+    .eq('review_task_id', taskId)
+    .eq('status', 'completed');
+
+  if (!data) return [];
+
+  const names = new Set<string>();
+  for (const row of data as Record<string, unknown>[]) {
+    const agent = row.agents as Record<string, unknown>;
+    const user = agent?.users as Record<string, unknown>;
+    const name = user?.name as string | undefined;
+    if (name) names.add(name);
+  }
+  return [...names];
 }
 
 /**


### PR DESCRIPTION
## Summary
Show the contributor's GitHub profile link in review comments so PR authors know who reviewed their code.

Closes #101

## Changes
- `formatReviewComment()` accepts optional `contributorName` — displays `**Contributor**: [@name](https://github.com/name)`
- `formatSummaryComment()` accepts optional `contributorNames[]` — displays all contributing reviewers
- `postReviewDirectly()` fetches contributor name via `agents→users` join
- New `fetchReviewContributors()` for multi-agent summaries

## Test plan
- [x] 642 tests pass
- [x] Build, lint, format, typecheck pass