### PR TITLE
Add --all flag to start all agents concurrently

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -902,7 +902,13 @@ agentCommand
           process.exit(1);
         }
 
+        // Increase listener limit when starting multiple agents
+        if (agentsToStart.length > 1) {
+          process.setMaxListeners(process.getMaxListeners() + agentsToStart.length * 2);
+        }
+
         // Start each agent
+        let startedCount = 0;
         for (const selected of agentsToStart) {
           let agentId: string;
           try {
@@ -910,6 +916,13 @@ agentCommand
             agentId = sync.agentId;
             if (sync.created) {
               console.log(`Registered new agent ${agentId} on platform`);
+              // Update snapshot to prevent duplicate registrations
+              serverAgents.push({
+                id: agentId,
+                model: selected.local.model,
+                tool: selected.local.tool,
+                status: 'offline',
+              } as AgentResponse);
             }
           } catch (err) {
             console.error(
@@ -936,6 +949,12 @@ agentCommand
             verbose: opts.verbose,
             stabilityThresholdMs,
           });
+          startedCount++;
+        }
+
+        if (startedCount === 0) {
+          console.error('No agents could be started.');
+          process.exit(1);
         }
         return;
       }


### PR DESCRIPTION
## Summary
`opencrust agent start --all` starts all valid agents from local config in a single process.

Closes #85

## Changes
- Add `--all` option to `agent start` command
- When `--all`: loop through all valid agents, sync each to server, start each with its own WebSocket + consumption deps
- Failed agent syncs are skipped with warning (doesn't block other agents)
- Error message updated to suggest `--all` when multiple agents exist

## Usage
```bash
opencrust agent start --all           # start all agents
opencrust agent start claude-opus-4-6  # start specific agent
```

## Test plan
- [x] 642 tests pass
- [x] Build, lint, format, typecheck pass