### PR TITLE
[architect] Add repo config types + protocol extension for agent preferences

### DIFF
--- a/packages/cli/src/__tests__/stats.test.ts
+++ b/packages/cli/src/__tests__/stats.test.ts
@@ -40,6 +40,7 @@ function makeAgent(overrides?: Partial<AgentResponse>): AgentResponse {
     model: 'claude-sonnet-4-6',
     tool: 'claude-code',
     status: 'online',
+    repoConfig: null,
     createdAt: '2024-01-01T00:00:00Z',
     ...overrides,
   };

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -922,7 +922,9 @@ agentCommand
                 model: selected.local.model,
                 tool: selected.local.tool,
                 status: 'offline',
-              } as AgentResponse);
+                repoConfig: null,
+                createdAt: new Date().toISOString(),
+              });
             }
           } catch (err) {
             console.error(

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -117,6 +117,7 @@ export const statsCommand = new Command('stats')
         model: 'unknown',
         tool: 'unknown',
         status: 'offline',
+        repoConfig: null,
         createdAt: '',
       };
 

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -1,3 +1,5 @@
+import type { RepoConfig } from './types.js';
+
 /** API key prefix for OpenCara API keys */
 export const API_KEY_PREFIX = 'cr_';
 
@@ -33,6 +35,7 @@ export interface AgentResponse {
   tool: string;
   // reputationScore removed — trust tier shown via stats instead
   status: 'online' | 'offline';
+  repoConfig: RepoConfig | null;
   createdAt: string;
 }
 
@@ -45,6 +48,7 @@ export interface ListAgentsResponse {
 export interface CreateAgentRequest {
   model: string;
   tool: string;
+  repoConfig?: RepoConfig;
 }
 
 /** POST /api/agents — response */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,8 @@
 export type {
   User,
   AgentStatus,
+  RepoFilterMode,
+  RepoConfig,
   Agent,
   Project,
   ReviewTaskStatus,
@@ -47,6 +49,7 @@ export type {
   MessageBase,
   PlatformMessage,
   AgentMessage,
+  AgentPreferencesMessage,
   ConnectedMessage,
   ReviewRequestMessage,
   ReviewRequestPR,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,3 +1,5 @@
+import type { RepoConfig } from './types.js';
+
 /** Base fields present on all WebSocket messages (the "envelope") */
 export interface MessageBase {
   id: string;
@@ -83,11 +85,17 @@ export interface PlatformErrorMessage extends MessageBase {
 // --- Agent → Platform messages ---
 
 export type AgentMessage =
+  | AgentPreferencesMessage
   | ReviewCompleteMessage
   | SummaryCompleteMessage
   | ReviewRejectedMessage
   | ReviewErrorMessage
   | HeartbeatPongMessage;
+
+export interface AgentPreferencesMessage extends MessageBase {
+  type: 'agent_preferences';
+  repoConfig: RepoConfig;
+}
 
 export type ReviewVerdict = 'approve' | 'request_changes' | 'comment';
 

--- a/packages/shared/src/repo-config.test.ts
+++ b/packages/shared/src/repo-config.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import type { RepoFilterMode, RepoConfig, Agent } from './types.js';
+import type { AgentPreferencesMessage } from './protocol.js';
+import type { AgentResponse, CreateAgentRequest } from './api.js';
+
+describe('RepoConfig types', () => {
+  it('RepoFilterMode accepts all valid modes', () => {
+    const modes: RepoFilterMode[] = ['all', 'own', 'whitelist', 'blacklist'];
+    expect(modes).toHaveLength(4);
+  });
+
+  it('RepoConfig with mode only (no list)', () => {
+    const config: RepoConfig = { mode: 'all' };
+    expect(config.mode).toBe('all');
+    expect(config.list).toBeUndefined();
+  });
+
+  it('RepoConfig with whitelist mode and list', () => {
+    const config: RepoConfig = {
+      mode: 'whitelist',
+      list: ['OpenCara/OpenCara', 'myorg/my-project'],
+    };
+    expect(config.mode).toBe('whitelist');
+    expect(config.list).toEqual(['OpenCara/OpenCara', 'myorg/my-project']);
+  });
+
+  it('RepoConfig with blacklist mode and list', () => {
+    const config: RepoConfig = {
+      mode: 'blacklist',
+      list: ['spam-org/spam-repo'],
+    };
+    expect(config.mode).toBe('blacklist');
+    expect(config.list).toEqual(['spam-org/spam-repo']);
+  });
+
+  it('RepoConfig with own mode', () => {
+    const config: RepoConfig = { mode: 'own' };
+    expect(config.mode).toBe('own');
+  });
+
+  it('Agent interface includes repo_config field', () => {
+    const agent: Agent = {
+      id: 'agent-1',
+      user_id: 'user-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      reputation_score: 0.5,
+      status: 'online',
+      last_heartbeat_at: null,
+      repo_config: { mode: 'whitelist', list: ['owner/repo'] },
+      created_at: '2024-01-01T00:00:00Z',
+    };
+    expect(agent.repo_config).toEqual({ mode: 'whitelist', list: ['owner/repo'] });
+  });
+
+  it('Agent interface allows null repo_config', () => {
+    const agent: Agent = {
+      id: 'agent-1',
+      user_id: 'user-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      reputation_score: 0.5,
+      status: 'online',
+      last_heartbeat_at: null,
+      repo_config: null,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+    expect(agent.repo_config).toBeNull();
+  });
+});
+
+describe('AgentPreferencesMessage protocol type', () => {
+  it('creates a valid agent_preferences message', () => {
+    const msg: AgentPreferencesMessage = {
+      id: 'msg-1',
+      timestamp: Date.now(),
+      type: 'agent_preferences',
+      repoConfig: { mode: 'whitelist', list: ['owner/repo'] },
+    };
+    expect(msg.type).toBe('agent_preferences');
+    expect(msg.repoConfig.mode).toBe('whitelist');
+    expect(msg.repoConfig.list).toEqual(['owner/repo']);
+  });
+
+  it('creates message with all mode (no list)', () => {
+    const msg: AgentPreferencesMessage = {
+      id: 'msg-2',
+      timestamp: Date.now(),
+      type: 'agent_preferences',
+      repoConfig: { mode: 'all' },
+    };
+    expect(msg.type).toBe('agent_preferences');
+    expect(msg.repoConfig.mode).toBe('all');
+    expect(msg.repoConfig.list).toBeUndefined();
+  });
+});
+
+describe('API types include repo config', () => {
+  it('AgentResponse includes repoConfig field', () => {
+    const response: AgentResponse = {
+      id: 'agent-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      status: 'online',
+      repoConfig: { mode: 'own' },
+      createdAt: '2024-01-01T00:00:00Z',
+    };
+    expect(response.repoConfig).toEqual({ mode: 'own' });
+  });
+
+  it('AgentResponse allows null repoConfig', () => {
+    const response: AgentResponse = {
+      id: 'agent-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      status: 'online',
+      repoConfig: null,
+      createdAt: '2024-01-01T00:00:00Z',
+    };
+    expect(response.repoConfig).toBeNull();
+  });
+
+  it('CreateAgentRequest with repoConfig', () => {
+    const request: CreateAgentRequest = {
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      repoConfig: { mode: 'blacklist', list: ['spam/repo'] },
+    };
+    expect(request.repoConfig).toEqual({ mode: 'blacklist', list: ['spam/repo'] });
+  });
+
+  it('CreateAgentRequest without repoConfig (backward compatible)', () => {
+    const request: CreateAgentRequest = {
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+    };
+    expect(request.repoConfig).toBeUndefined();
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -13,6 +13,13 @@ export interface User {
 
 export type AgentStatus = 'online' | 'offline';
 
+export type RepoFilterMode = 'all' | 'own' | 'whitelist' | 'blacklist';
+
+export interface RepoConfig {
+  mode: RepoFilterMode;
+  list?: string[]; // owner/repo entries for whitelist/blacklist modes
+}
+
 export interface Agent {
   id: string;
   user_id: string;
@@ -21,6 +28,7 @@ export interface Agent {
   reputation_score: number;
   status: AgentStatus;
   last_heartbeat_at: string | null;
+  repo_config: RepoConfig | null;
   created_at: string;
 }
 

--- a/packages/worker/src/__tests__/agents.test.ts
+++ b/packages/worker/src/__tests__/agents.test.ts
@@ -66,6 +66,7 @@ describe('handleListAgents', () => {
       model: 'gpt-4',
       tool: 'cline',
       status: 'online',
+      repoConfig: null,
       createdAt: '2024-01-01',
     });
   });

--- a/packages/worker/src/handlers/agents.ts
+++ b/packages/worker/src/handlers/agents.ts
@@ -31,6 +31,7 @@ export async function handleListAgents(user: User, supabase: SupabaseClient): Pr
     model: agent.model as string,
     tool: agent.tool as string,
     status: agent.status as 'online' | 'offline',
+    repoConfig: (agent.repo_config as AgentResponse['repoConfig']) ?? null,
     createdAt: agent.created_at as string,
   }));
 
@@ -60,6 +61,7 @@ export async function handleCreateAgent(
       user_id: user.id,
       model: body.model,
       tool: body.tool,
+      ...(body.repoConfig ? { repo_config: body.repoConfig } : {}),
     })
     .select()
     .single();
@@ -74,6 +76,7 @@ export async function handleCreateAgent(
       model: data.model,
       tool: data.tool,
       status: data.status,
+      repoConfig: data.repo_config ?? null,
       createdAt: data.created_at,
     } satisfies CreateAgentResponse,
     201,


### PR DESCRIPTION
Closes #113

## Summary
- Add `RepoFilterMode` and `RepoConfig` types to `packages/shared/src/types.ts`
- Add `repo_config` field to `Agent` database entity interface
- Add `AgentPreferencesMessage` to WebSocket protocol (`agent_preferences` message type)
- Add `repoConfig` to `AgentResponse` and `CreateAgentRequest` API types
- Update worker agent handler to include `repo_config` in responses and accept on create
- Update all downstream `AgentResponse` constructions in CLI and tests for compatibility
- Add 13 tests covering type validation for all modes and backward compatibility

## Test plan
- [x] All 815 existing tests pass
- [x] 13 new tests for `RepoConfig`, `AgentPreferencesMessage`, and API type validation
- [x] Build passes across all packages
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Prettier check passes on all changed files