### PR TITLE
[cli-dev] Parse and send repo config preferences from local config

### DIFF
--- a/packages/cli/src/__tests__/agent-start.test.ts
+++ b/packages/cli/src/__tests__/agent-start.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { buildWsUrl, handleMessage, type ConsumptionDeps } from '../commands/agent.js';
+import {
+  buildWsUrl,
+  handleMessage,
+  syncAgentToServer,
+  type ConsumptionDeps,
+} from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
+import type { AgentResponse } from '@opencara/shared';
 import { createSessionTracker } from '../consumption.js';
 import { ApiClient } from '../http.js';
 
@@ -358,13 +364,44 @@ describe('handleMessage', () => {
     consoleSpy.mockRestore();
   });
 
-  it('handles connected message', () => {
+  it('handles connected message and sends agent_preferences with default repo config', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const ws = { send: vi.fn() };
 
     handleMessage(ws, { type: 'connected', version: '1' });
 
     expect(consoleSpy).toHaveBeenCalledWith('Authenticated. Protocol v1');
+
+    // Should send agent_preferences
+    expect(ws.send).toHaveBeenCalledOnce();
+    const sent = JSON.parse(ws.send.mock.calls[0][0]);
+    expect(sent.type).toBe('agent_preferences');
+    expect(sent.repoConfig).toEqual({ mode: 'all' });
+    expect(sent.id).toBeDefined();
+    expect(sent.timestamp).toBeTypeOf('number');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('sends agent_preferences with custom repo config on connected', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const ws = { send: vi.fn() };
+
+    const repoConfig = { mode: 'whitelist' as const, list: ['org/repo'] };
+    handleMessage(
+      ws,
+      { type: 'connected', version: '1' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      repoConfig,
+    );
+
+    const sent = JSON.parse(ws.send.mock.calls[0][0]);
+    expect(sent.type).toBe('agent_preferences');
+    expect(sent.repoConfig).toEqual({ mode: 'whitelist', list: ['org/repo'] });
+
     consoleSpy.mockRestore();
   });
 
@@ -599,5 +636,66 @@ describe('handleMessage', () => {
     );
     expect(verboseCalls).toHaveLength(0);
     consoleSpy.mockRestore();
+  });
+});
+
+describe('syncAgentToServer', () => {
+  function makeServerAgent(overrides?: Partial<AgentResponse>): AgentResponse {
+    return {
+      id: 'agent-1',
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+      status: 'online',
+      repoConfig: null,
+      createdAt: '2024-01-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('returns existing agent when model+tool match', async () => {
+    const client = { post: vi.fn() } as unknown as ApiClient;
+    const result = await syncAgentToServer(client, [makeServerAgent()], {
+      model: 'claude-sonnet-4-6',
+      tool: 'claude-code',
+    });
+
+    expect(result.agentId).toBe('agent-1');
+    expect(result.created).toBe(false);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('creates new agent without repoConfig when repos not specified', async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({ id: 'new-agent' }),
+    } as unknown as ApiClient;
+
+    const result = await syncAgentToServer(client, [], { model: 'gpt-4', tool: 'copilot' });
+
+    expect(result.agentId).toBe('new-agent');
+    expect(result.created).toBe(true);
+    expect(client.post).toHaveBeenCalledWith('/api/agents', {
+      model: 'gpt-4',
+      tool: 'copilot',
+    });
+  });
+
+  it('creates new agent with repoConfig when repos specified', async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({ id: 'new-agent' }),
+    } as unknown as ApiClient;
+
+    const result = await syncAgentToServer(client, [], {
+      model: 'gpt-4',
+      tool: 'copilot',
+      repos: { mode: 'whitelist', list: ['org/repo'] },
+    });
+
+    expect(result.agentId).toBe('new-agent');
+    expect(result.created).toBe(true);
+    expect(client.post).toHaveBeenCalledWith('/api/agents', {
+      model: 'gpt-4',
+      tool: 'copilot',
+      repoConfig: { mode: 'whitelist', list: ['org/repo'] },
+    });
   });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -18,6 +18,7 @@ import {
   ensureConfigDir,
   requireApiKey,
   resolveAgentLimits,
+  RepoConfigError,
   CONFIG_DIR,
   CONFIG_FILE,
   DEFAULT_PLATFORM_URL,
@@ -509,6 +510,228 @@ agents:
         reviews_per_day: 10,
       });
       expect(config.agents![1].limits).toBeUndefined();
+    });
+  });
+
+  describe('repo config parsing', () => {
+    it('defaults to undefined repos when omitted', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toBeUndefined();
+    });
+
+    it('parses repos with mode: all', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: all
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({ mode: 'all' });
+    });
+
+    it('parses repos with mode: own', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: own
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({ mode: 'own' });
+    });
+
+    it('parses repos with mode: whitelist and list', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: whitelist
+      list:
+        - OpenCara/OpenCara
+        - myorg/my-project
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({
+        mode: 'whitelist',
+        list: ['OpenCara/OpenCara', 'myorg/my-project'],
+      });
+    });
+
+    it('parses repos with mode: blacklist and list', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: blacklist
+      list:
+        - spam-org/spam-repo
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({
+        mode: 'blacklist',
+        list: ['spam-org/spam-repo'],
+      });
+    });
+
+    it('throws RepoConfigError for invalid mode', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: invalid
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('must be one of: all, own, whitelist, blacklist');
+    });
+
+    it('throws RepoConfigError when mode is missing', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      list:
+        - foo/bar
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('mode is required');
+    });
+
+    it('throws RepoConfigError when repos is not an object', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos: just-a-string
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('must be an object');
+    });
+
+    it('throws RepoConfigError when whitelist has no list', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: whitelist
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('list is required and must be non-empty');
+    });
+
+    it('throws RepoConfigError when blacklist has empty list', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: blacklist
+      list: []
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('list is required and must be non-empty');
+    });
+
+    it('throws RepoConfigError for invalid owner/repo format', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: whitelist
+      list:
+        - invalid-format
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow("must match 'owner/repo' format");
+    });
+
+    it('throws RepoConfigError for list entry with multiple slashes', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: whitelist
+      list:
+        - org/repo/extra
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow("must match 'owner/repo' format");
+    });
+
+    it('does not require list for mode: all', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: all
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({ mode: 'all' });
+      expect(config.agents![0].repos!.list).toBeUndefined();
+    });
+
+    it('does not require list for mode: own', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude-code
+    repos:
+      mode: own
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({ mode: 'own' });
+      expect(config.agents![0].repos!.list).toBeUndefined();
+    });
+
+    it('saveConfig persists repos field on agents', () => {
+      saveConfig({
+        apiKey: 'cr_test',
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        limits: null,
+        agentCommand: null,
+        agents: [
+          {
+            model: 'claude-opus-4-6',
+            tool: 'claude-code',
+            repos: { mode: 'whitelist', list: ['org/repo'] },
+          },
+        ],
+      });
+
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(written).toContain('repos');
+      expect(written).toContain('whitelist');
+      expect(written).toContain('org/repo');
     });
   });
 });

--- a/packages/cli/src/__tests__/stats.test.ts
+++ b/packages/cli/src/__tests__/stats.test.ts
@@ -31,6 +31,7 @@ import {
   formatTrustTier,
   formatReviewQuality,
   formatConsumption,
+  formatRepoConfig,
   statsCommand,
 } from '../commands/stats.js';
 
@@ -246,12 +247,48 @@ describe('stats command', () => {
     });
   });
 
+  describe('formatRepoConfig', () => {
+    it('shows default when repoConfig is null', () => {
+      expect(formatRepoConfig(null)).toContain('all (default)');
+    });
+
+    it('shows all mode', () => {
+      expect(formatRepoConfig({ mode: 'all' })).toContain('all');
+    });
+
+    it('shows own mode', () => {
+      expect(formatRepoConfig({ mode: 'own' })).toContain('own repos only');
+    });
+
+    it('shows whitelist with repos', () => {
+      const output = formatRepoConfig({ mode: 'whitelist', list: ['org/repo1', 'org/repo2'] });
+      expect(output).toContain('whitelist');
+      expect(output).toContain('org/repo1, org/repo2');
+    });
+
+    it('shows blacklist with repos', () => {
+      const output = formatRepoConfig({ mode: 'blacklist', list: ['spam/repo'] });
+      expect(output).toContain('blacklist');
+      expect(output).toContain('spam/repo');
+    });
+  });
+
   describe('formatAgentStats', () => {
     it('displays agent info and consumption', () => {
       const output = formatAgentStats(makeAgent(), makeConsumption());
       expect(output).toContain('Agent: agent-1 (claude-sonnet-4-6 / claude-code)');
+      expect(output).toContain('Repos:');
       expect(output).toContain('Tokens:');
       expect(output).toContain('125,430 total');
+    });
+
+    it('displays repo config when agent has one', () => {
+      const output = formatAgentStats(
+        makeAgent({ repoConfig: { mode: 'whitelist', list: ['org/repo'] } }),
+        makeConsumption(),
+      );
+      expect(output).toContain('whitelist');
+      expect(output).toContain('org/repo');
     });
 
     it('displays trust tier when agent stats provided', () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -12,6 +12,7 @@ import {
   type PlatformMessage,
   type ReviewRequestMessage,
   type SummaryRequestMessage,
+  type RepoConfig,
 } from '@opencara/shared';
 import {
   loadConfig,
@@ -85,6 +86,7 @@ export const STABILITY_THRESHOLD_MAX_MS = 300_000;
 export interface StartAgentOptions {
   verbose?: boolean;
   stabilityThresholdMs?: number;
+  repoConfig?: RepoConfig;
 }
 
 /** Interval for sending RFC 6455 WebSocket ping frames to keep the proxy layer alive */
@@ -100,6 +102,7 @@ export function startAgent(
 ): void {
   const verbose = options?.verbose ?? false;
   const stabilityThreshold = options?.stabilityThresholdMs ?? CONNECTION_STABILITY_THRESHOLD_MS;
+  const repoConfig = options?.repoConfig;
   let attempt = 0;
   let intentionalClose = false;
   let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
@@ -196,7 +199,7 @@ export function startAgent(
         return;
       }
 
-      handleMessage(ws, msg, resetHeartbeatTimer, reviewDeps, consumptionDeps, verbose);
+      handleMessage(ws, msg, resetHeartbeatTimer, reviewDeps, consumptionDeps, verbose, repoConfig);
     });
 
     ws.on('close', (code, reason) => {
@@ -310,10 +313,18 @@ export function handleMessage(
   reviewDeps?: ReviewExecutorDeps,
   consumptionDeps?: ConsumptionDeps,
   verbose?: boolean,
+  repoConfig?: RepoConfig,
 ): void {
   switch (msg.type) {
     case 'connected':
       console.log(`Authenticated. Protocol v${msg.version ?? 'unknown'}`);
+      // Send agent preferences (repo config) to the platform
+      trySend(ws, {
+        type: 'agent_preferences',
+        id: crypto.randomUUID(),
+        timestamp: Date.now(),
+        repoConfig: repoConfig ?? { mode: 'all' },
+      });
       break;
 
     case 'heartbeat_ping':
@@ -533,6 +544,9 @@ async function syncAgentToServer(
   }
 
   const body: CreateAgentRequest = { model: localAgent.model, tool: localAgent.tool };
+  if (localAgent.repos) {
+    body.repoConfig = localAgent.repos;
+  }
   const created = await client.post<CreateAgentResponse>('/api/agents', body);
   return { agentId: created.id, created: true };
 }
@@ -950,6 +964,7 @@ agentCommand
           startAgent(agentId, config.platformUrl, apiKey, reviewDeps, consumptionDeps, {
             verbose: opts.verbose,
             stabilityThresholdMs,
+            repoConfig: selected.local.repos,
           });
           startedCount++;
         }

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -5,6 +5,7 @@ import type {
   AgentResponse,
   AgentStatsResponse,
   TrustTierInfo,
+  RepoConfig,
 } from '@opencara/shared';
 import { loadConfig, requireApiKey, type ConsumptionLimits } from '../config.js';
 import { ApiClient } from '../http.js';
@@ -33,6 +34,22 @@ function formatReviewQuality(stats: AgentStatsResponse['stats']): string {
     lines.push(`  Quality:  No ratings yet`);
   }
   return lines.join('\n');
+}
+
+function formatRepoConfig(repoConfig: RepoConfig | null): string {
+  if (!repoConfig) return '  Repos:    all (default)';
+  switch (repoConfig.mode) {
+    case 'all':
+      return '  Repos:    all';
+    case 'own':
+      return '  Repos:    own repos only';
+    case 'whitelist':
+      return `  Repos:    whitelist (${repoConfig.list?.join(', ') ?? 'none'})`;
+    case 'blacklist':
+      return `  Repos:    blacklist (${repoConfig.list?.join(', ') ?? 'none'})`;
+    default:
+      return `  Repos:    ${repoConfig.mode}`;
+  }
 }
 
 function formatConsumption(
@@ -67,6 +84,7 @@ function formatAgentStats(
 ): string {
   const lines: string[] = [];
   lines.push(`Agent: ${agent.id} (${agent.model} / ${agent.tool})`);
+  lines.push(formatRepoConfig(agent.repoConfig));
 
   if (agentStats) {
     lines.push(formatTrustTier(agentStats.agent.trustTier));
@@ -78,7 +96,13 @@ function formatAgentStats(
   return lines.join('\n');
 }
 
-export { formatAgentStats, formatTrustTier, formatReviewQuality, formatConsumption };
+export {
+  formatAgentStats,
+  formatTrustTier,
+  formatReviewQuality,
+  formatConsumption,
+  formatRepoConfig,
+};
 
 async function fetchAgentStats(
   client: ApiClient,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { parse, stringify } from 'yaml';
+import type { RepoConfig, RepoFilterMode } from '@opencara/shared';
 
 export interface ConsumptionLimits {
   tokens_per_day?: number;
@@ -14,6 +15,7 @@ export interface LocalAgentConfig {
   tool: string;
   command?: string;
   limits?: ConsumptionLimits;
+  repos?: RepoConfig;
 }
 
 export interface CliConfig {
@@ -47,6 +49,57 @@ function parseLimits(data: Record<string, unknown>): ConsumptionLimits | null {
   return limits;
 }
 
+const VALID_REPO_MODES: RepoFilterMode[] = ['all', 'own', 'whitelist', 'blacklist'];
+const REPO_PATTERN = /^[^/]+\/[^/]+$/;
+
+export class RepoConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RepoConfigError';
+  }
+}
+
+function parseRepoConfig(obj: Record<string, unknown>, index: number): RepoConfig | undefined {
+  const raw = obj.repos;
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'object') {
+    throw new RepoConfigError(`agents[${index}].repos must be an object`);
+  }
+
+  const reposObj = raw as Record<string, unknown>;
+  const mode = reposObj.mode;
+
+  if (mode === undefined) {
+    throw new RepoConfigError(`agents[${index}].repos.mode is required`);
+  }
+  if (typeof mode !== 'string' || !VALID_REPO_MODES.includes(mode as RepoFilterMode)) {
+    throw new RepoConfigError(
+      `agents[${index}].repos.mode must be one of: ${VALID_REPO_MODES.join(', ')}`,
+    );
+  }
+
+  const config: RepoConfig = { mode: mode as RepoFilterMode };
+
+  if (mode === 'whitelist' || mode === 'blacklist') {
+    const list = reposObj.list;
+    if (!Array.isArray(list) || list.length === 0) {
+      throw new RepoConfigError(
+        `agents[${index}].repos.list is required and must be non-empty for mode '${mode}'`,
+      );
+    }
+    for (let j = 0; j < list.length; j++) {
+      if (typeof list[j] !== 'string' || !REPO_PATTERN.test(list[j])) {
+        throw new RepoConfigError(
+          `agents[${index}].repos.list[${j}] must match 'owner/repo' format`,
+        );
+      }
+    }
+    config.list = list as string[];
+  }
+
+  return config;
+}
+
 function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
   if (!('agents' in data)) return null;
   const raw = data.agents;
@@ -68,6 +121,8 @@ function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
     if (typeof obj.command === 'string') agent.command = obj.command;
     const agentLimits = parseLimits(obj);
     if (agentLimits) agent.limits = agentLimits;
+    const repoConfig = parseRepoConfig(obj, i);
+    if (repoConfig) agent.repos = repoConfig;
     agents.push(agent);
   }
   return agents;


### PR DESCRIPTION
Closes #115

## Summary
- Added `repos` config field to `~/.opencara/config.yml` agent entries with validation for mode (`all`/`own`/`whitelist`/`blacklist`), required list for whitelist/blacklist, and `owner/repo` format checking
- Sends `agent_preferences` message with `repoConfig` on every WebSocket connect (after `connected` message)
- Includes `repoConfig` in `POST /api/agents` when creating new agents
- Displays repo filter mode in `opencara stats` output
- Throws `RepoConfigError` on startup for invalid configurations

## Test plan
- [x] Config parsing: mode all/own/whitelist/blacklist correctly parsed from YAML
- [x] Validation: invalid mode, missing list, empty list, bad owner/repo format all throw RepoConfigError
- [x] Default: omitted repos field defaults to undefined (sent as `{ mode: 'all' }` on connect)
- [x] WebSocket: `agent_preferences` sent on `connected` with correct repoConfig
- [x] Agent registration: `repoConfig` included in POST body when repos configured
- [x] Stats display: `formatRepoConfig` shows correct output for all modes
- [x] saveConfig persists repos field
- [x] All 894 existing tests pass
- [x] Build, lint, format, typecheck all pass