### PR TITLE
Use OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -64,8 +64,6 @@ jobs:
         if: steps.bump.outputs.type != 'none'
         working-directory: packages/cli
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Commit version bump and create release
         if: steps.bump.outputs.type != 'none'
         run: |


### PR DESCRIPTION
Remove NPM_TOKEN secret dependency. Use npm OIDC trusted publishing via `id-token: write` permission + `--provenance` flag.

Requires trusted publisher configured on npmjs.com:
- Repository: OpenCara/OpenCara
- Workflow: publish-cli.yml

This PR has a `feat/` prefix so merging it will trigger a minor version bump (0.1.0 → 0.2.0) and publish to npm — testing the full pipeline.