### PR TITLE
[worker-dev] Add default reputation scores per model

### DIFF
--- a/packages/shared/src/__tests__/index.test.ts
+++ b/packages/shared/src/__tests__/index.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getVersion, API_KEY_PREFIX } from '../index.js';
+import {
+  getVersion,
+  API_KEY_PREFIX,
+  DEFAULT_REGISTRY,
+  DEFAULT_REPUTATION_FALLBACK,
+  getModelDefaultReputation,
+} from '../index.js';
 
 describe('shared', () => {
   it('returns version string', () => {
@@ -20,5 +26,34 @@ describe('shared', () => {
     const mod = await import('../index.js');
     expect(mod.API_KEY_PREFIX).toBeDefined();
     expect(mod.getVersion).toBeDefined();
+  });
+});
+
+describe('getModelDefaultReputation', () => {
+  it('returns correct reputation for known models', () => {
+    expect(getModelDefaultReputation('claude-opus-4-6')).toBe(0.8);
+    expect(getModelDefaultReputation('claude-sonnet-4-6')).toBe(0.7);
+    expect(getModelDefaultReputation('gemini-2.5-pro')).toBe(0.7);
+    expect(getModelDefaultReputation('qwen3.5-plus')).toBe(0.6);
+    expect(getModelDefaultReputation('glm-5')).toBe(0.5);
+    expect(getModelDefaultReputation('kimi-k2.5')).toBe(0.5);
+    expect(getModelDefaultReputation('minimax-m2.5')).toBe(0.5);
+  });
+
+  it('returns DEFAULT_REPUTATION_FALLBACK for unknown models', () => {
+    expect(getModelDefaultReputation('unknown-model')).toBe(DEFAULT_REPUTATION_FALLBACK);
+    expect(getModelDefaultReputation('')).toBe(DEFAULT_REPUTATION_FALLBACK);
+    expect(getModelDefaultReputation('gpt-99')).toBe(DEFAULT_REPUTATION_FALLBACK);
+  });
+
+  it('DEFAULT_REPUTATION_FALLBACK is 0.5', () => {
+    expect(DEFAULT_REPUTATION_FALLBACK).toBe(0.5);
+  });
+
+  it('all registry models have defaultReputation between 0 and 1', () => {
+    for (const model of DEFAULT_REGISTRY.models) {
+      expect(model.defaultReputation).toBeGreaterThanOrEqual(0);
+      expect(model.defaultReputation).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -134,6 +134,7 @@ export interface ModelRegistryEntry {
   name: string;
   displayName: string;
   tools: string[];
+  defaultReputation: number;
 }
 
 /** GET /api/registry — response */
@@ -175,26 +176,67 @@ export const DEFAULT_REGISTRY: RegistryResponse = {
     },
   ],
   models: [
-    { name: 'claude-opus-4-6', displayName: 'Claude Opus 4.6', tools: ['claude'] },
+    {
+      name: 'claude-opus-4-6',
+      displayName: 'Claude Opus 4.6',
+      tools: ['claude'],
+      defaultReputation: 0.8,
+    },
     {
       name: 'claude-opus-4-6[1m]',
       displayName: 'Claude Opus 4.6 (1M context)',
       tools: ['claude'],
+      defaultReputation: 0.8,
     },
-    { name: 'claude-sonnet-4-6', displayName: 'Claude Sonnet 4.6', tools: ['claude'] },
+    {
+      name: 'claude-sonnet-4-6',
+      displayName: 'Claude Sonnet 4.6',
+      tools: ['claude'],
+      defaultReputation: 0.7,
+    },
     {
       name: 'claude-sonnet-4-6[1m]',
       displayName: 'Claude Sonnet 4.6 (1M context)',
       tools: ['claude'],
+      defaultReputation: 0.7,
     },
-    { name: 'gpt-5-codex', displayName: 'GPT-5 Codex', tools: ['codex'] },
-    { name: 'gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', tools: ['gemini'] },
-    { name: 'qwen3.5-plus', displayName: 'Qwen 3.5 Plus', tools: ['qwen'] },
-    { name: 'glm-5', displayName: 'GLM-5', tools: ['qwen'] },
-    { name: 'kimi-k2.5', displayName: 'Kimi K2.5', tools: ['qwen'] },
-    { name: 'minimax-m2.5', displayName: 'Minimax M2.5', tools: ['qwen'] },
+    {
+      name: 'gpt-5-codex',
+      displayName: 'GPT-5 Codex',
+      tools: ['codex'],
+      defaultReputation: 0.7,
+    },
+    {
+      name: 'gemini-2.5-pro',
+      displayName: 'Gemini 2.5 Pro',
+      tools: ['gemini'],
+      defaultReputation: 0.7,
+    },
+    {
+      name: 'qwen3.5-plus',
+      displayName: 'Qwen 3.5 Plus',
+      tools: ['qwen'],
+      defaultReputation: 0.6,
+    },
+    { name: 'glm-5', displayName: 'GLM-5', tools: ['qwen'], defaultReputation: 0.5 },
+    { name: 'kimi-k2.5', displayName: 'Kimi K2.5', tools: ['qwen'], defaultReputation: 0.5 },
+    {
+      name: 'minimax-m2.5',
+      displayName: 'Minimax M2.5',
+      tools: ['qwen'],
+      defaultReputation: 0.5,
+    },
   ],
 };
+
+/** Default reputation for models not in the registry. */
+export const DEFAULT_REPUTATION_FALLBACK = 0.5;
+
+/** Look up the default reputation for a model name. Returns DEFAULT_REPUTATION_FALLBACK for unknown models. */
+export function getModelDefaultReputation(modelName: string): number {
+  const entry = DEFAULT_REGISTRY.models.find((m) => m.name === modelName);
+  return entry?.defaultReputation ?? DEFAULT_REPUTATION_FALLBACK;
+}
 
 /** POST /auth/anonymous — request */
 export interface AnonymousRegisterRequest {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,7 +42,7 @@ export type {
   RegistryResponse,
 } from './api.js';
 
-export { DEFAULT_REGISTRY } from './api.js';
+export { DEFAULT_REGISTRY, DEFAULT_REPUTATION_FALLBACK, getModelDefaultReputation } from './api.js';
 
 // Privacy-preserving rater hash utility
 export { computeRaterHash } from './rater-hash.js';

--- a/packages/worker/src/__tests__/e2e/08-registry.test.ts
+++ b/packages/worker/src/__tests__/e2e/08-registry.test.ts
@@ -44,16 +44,25 @@ describe('E2E: Registry (GET /api/registry)', () => {
     const req = new Request('https://api.opencara.dev/api/registry', { method: 'GET' });
     const res = await ctx.workerFetch(req);
     const body = (await res.json()) as {
-      models: Array<{ name: string; displayName: string; tools: string[] }>;
+      models: Array<{
+        name: string;
+        displayName: string;
+        tools: string[];
+        defaultReputation: number;
+      }>;
       tools: Array<{ name: string; displayName: string; binary: string; commandTemplate: string }>;
     };
 
-    // Each model should have name, displayName, and tools array
+    // Each model should have name, displayName, tools array, and defaultReputation
     for (const model of body.models) {
       expect(model).toHaveProperty('name');
       expect(model).toHaveProperty('displayName');
       expect(model).toHaveProperty('tools');
       expect(Array.isArray(model.tools)).toBe(true);
+      expect(model).toHaveProperty('defaultReputation');
+      expect(typeof model.defaultReputation).toBe('number');
+      expect(model.defaultReputation).toBeGreaterThanOrEqual(0);
+      expect(model.defaultReputation).toBeLessThanOrEqual(1);
     }
 
     // Each tool should have name, displayName, binary, and commandTemplate

--- a/packages/worker/src/__tests__/registry.test.ts
+++ b/packages/worker/src/__tests__/registry.test.ts
@@ -50,4 +50,27 @@ describe('handleGetRegistry', () => {
       expect(typeof tool.tokenParser).toBe('string');
     }
   });
+
+  it('each model has a defaultReputation between 0 and 1', async () => {
+    const { models } = await handleGetRegistry().json();
+    for (const model of models) {
+      expect(typeof model.defaultReputation).toBe('number');
+      expect(model.defaultReputation).toBeGreaterThanOrEqual(0);
+      expect(model.defaultReputation).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('returns expected default reputation values for known models', async () => {
+    const { models } = await handleGetRegistry().json();
+    const byName = Object.fromEntries(
+      models.map((m: { name: string; defaultReputation: number }) => [m.name, m.defaultReputation]),
+    );
+    expect(byName['claude-opus-4-6']).toBe(0.8);
+    expect(byName['claude-sonnet-4-6']).toBe(0.7);
+    expect(byName['gemini-2.5-pro']).toBe(0.7);
+    expect(byName['qwen3.5-plus']).toBe(0.6);
+    expect(byName['glm-5']).toBe(0.5);
+    expect(byName['kimi-k2.5']).toBe(0.5);
+    expect(byName['minimax-m2.5']).toBe(0.5);
+  });
 });

--- a/packages/worker/src/__tests__/task-distribution.test.ts
+++ b/packages/worker/src/__tests__/task-distribution.test.ts
@@ -113,11 +113,25 @@ describe('filterByAccessList', () => {
 });
 
 describe('agentWeight', () => {
-  it('returns constant 1 (reputation_score removed from agents table)', () => {
-    expect(agentWeight()).toBe(1);
-    expect(agentWeight(0.8)).toBe(1);
-    expect(agentWeight(-2)).toBe(1);
-    expect(agentWeight(0)).toBe(1);
+  it('returns model default reputation for known models', () => {
+    expect(agentWeight('claude-opus-4-6')).toBe(0.8);
+    expect(agentWeight('claude-sonnet-4-6')).toBe(0.7);
+    expect(agentWeight('gemini-2.5-pro')).toBe(0.7);
+    expect(agentWeight('qwen3.5-plus')).toBe(0.6);
+    expect(agentWeight('glm-5')).toBe(0.5);
+    expect(agentWeight('kimi-k2.5')).toBe(0.5);
+    expect(agentWeight('minimax-m2.5')).toBe(0.5);
+  });
+
+  it('returns 0.5 (DEFAULT_REPUTATION_FALLBACK) for unknown models', () => {
+    expect(agentWeight('unknown-model')).toBe(0.5);
+    expect(agentWeight('')).toBe(0.5);
+  });
+
+  it('clamps weight to minimum 0.1', () => {
+    // All current models have >= 0.5, so test indirectly:
+    // getModelDefaultReputation returns 0.5 for unknown models, which is >= 0.1
+    expect(agentWeight('anything')).toBeGreaterThanOrEqual(0.1);
   });
 });
 
@@ -150,28 +164,32 @@ describe('weightedRandomSelect', () => {
     expect(result1.map((a) => a.id)).toEqual(result2.map((a) => a.id));
   });
 
-  it('all agents have equal selection probability (agentWeight returns constant 1)', () => {
-    const agents = [makeAgent({ id: 'a' }), makeAgent({ id: 'b' })];
+  it('higher-reputation models are selected more often', () => {
+    const agents = [
+      makeAgent({ id: 'opus', model: 'claude-opus-4-6' }), // 0.8
+      makeAgent({ id: 'glm', model: 'glm-5' }), // 0.5
+    ];
 
-    const counts: Record<string, number> = { a: 0, b: 0 };
-    const N = 1000;
+    const counts: Record<string, number> = { opus: 0, glm: 0 };
+    const N = 2000;
 
     for (let i = 0; i < N; i++) {
       const result = weightedRandomSelect(agents, 1, seededRng(i));
       counts[result[0].id]++;
     }
 
-    // Both agents should be selected with roughly equal probability
-    expect(counts['a']).toBeGreaterThan(0);
-    expect(counts['b']).toBeGreaterThan(0);
-    // Neither should dominate (max < 3x min)
-    const min = Math.min(counts['a'], counts['b']);
-    const max = Math.max(counts['a'], counts['b']);
-    expect(max).toBeLessThan(min * 3);
+    // Both should be selected, but opus (0.8) should be selected more than glm (0.5)
+    expect(counts['opus']).toBeGreaterThan(0);
+    expect(counts['glm']).toBeGreaterThan(0);
+    expect(counts['opus']).toBeGreaterThan(counts['glm']);
   });
 
-  it('all agents get selected regardless of former reputation field', () => {
-    const agents = [makeAgent({ id: 'a' }), makeAgent({ id: 'b' }), makeAgent({ id: 'c' })];
+  it('all agents get selected regardless of model reputation', () => {
+    const agents = [
+      makeAgent({ id: 'a', model: 'claude-opus-4-6' }),
+      makeAgent({ id: 'b', model: 'glm-5' }),
+      makeAgent({ id: 'c', model: 'unknown-model' }),
+    ];
 
     const counts: Record<string, number> = { a: 0, b: 0, c: 0 };
     const N = 1000;
@@ -186,11 +204,8 @@ describe('weightedRandomSelect', () => {
     expect(counts['c']).toBeGreaterThan(0);
   });
 
-  it('distributes tasks fairly across agents with similar reputation', () => {
-    // All agents have the same reputation — should be roughly uniform
-    const agents = Array.from({ length: 5 }, (_, i) =>
-      makeAgent({ id: `a${i}`, reputationScore: 1.0 }),
-    );
+  it('distributes fairly across agents with same model (same weight)', () => {
+    const agents = Array.from({ length: 5 }, (_, i) => makeAgent({ id: `a${i}`, model: 'glm-5' }));
 
     const counts: Record<string, number> = {};
     agents.forEach((a) => (counts[a.id] = 0));
@@ -201,14 +216,10 @@ describe('weightedRandomSelect', () => {
       counts[result[0].id]++;
     }
 
-    // Each agent should get roughly N/5 = 400 selections
-    // With equal weights, no single agent should dominate
     const values = Object.values(counts);
     const min = Math.min(...values);
     const max = Math.max(...values);
-    // Allow reasonable variance — max should not exceed 3x min
     expect(max).toBeLessThan(min * 3);
-    // All agents should be selected at least once
     expect(min).toBeGreaterThan(0);
   });
 });
@@ -257,9 +268,9 @@ describe('selectAgents', () => {
 
   it('prioritizes preferred models over preferred tools', () => {
     const mixed = [
-      makeAgent({ id: 'a1', model: 'gpt-4', tool: 'cursor', reputationScore: 0.5 }),
-      makeAgent({ id: 'a2', model: 'claude-opus-4-6', tool: 'vscode', reputationScore: 0.9 }),
-      makeAgent({ id: 'a3', model: 'glm-5', tool: 'cursor', reputationScore: 0.7 }),
+      makeAgent({ id: 'a1', model: 'glm-5', tool: 'cursor' }),
+      makeAgent({ id: 'a2', model: 'claude-opus-4-6', tool: 'vscode' }),
+      makeAgent({ id: 'a3', model: 'kimi-k2.5', tool: 'cursor' }),
     ];
     // With reviewCount=2 and model pref claude-opus-4-6: a2 gets model tier (guaranteed), then tool tier has a1 and a3
     const result = selectAgents(mixed, 2, ['claude-opus-4-6'], ['cursor'], seededRng(42));
@@ -272,11 +283,11 @@ describe('selectAgents', () => {
 
   it('selects by preferred models only', () => {
     const mixed = [
-      makeAgent({ id: 'a1', model: 'gpt-4', reputationScore: 0.9 }),
-      makeAgent({ id: 'a2', model: 'claude-opus-4-6', reputationScore: 0.5 }),
-      makeAgent({ id: 'a3', model: 'glm-5', reputationScore: 0.7 }),
+      makeAgent({ id: 'a1', model: 'glm-5' }),
+      makeAgent({ id: 'a2', model: 'claude-opus-4-6' }),
+      makeAgent({ id: 'a3', model: 'kimi-k2.5' }),
     ];
-    const result = selectAgents(mixed, 2, ['claude-opus-4-6', 'glm-5'], [], seededRng(42));
+    const result = selectAgents(mixed, 2, ['claude-opus-4-6', 'kimi-k2.5'], [], seededRng(42));
     // Both model matches should be selected since there are exactly 2
     expect(result).toHaveLength(2);
     const ids = result.map((a) => a.id).sort();
@@ -285,7 +296,7 @@ describe('selectAgents', () => {
 
   it('distributes across all agents when no preferences given', () => {
     const manyAgents = Array.from({ length: 5 }, (_, i) =>
-      makeAgent({ id: `a${i}`, reputationScore: 1.0 }),
+      makeAgent({ id: `a${i}`, model: 'glm-5' }),
     );
 
     const counts: Record<string, number> = {};
@@ -303,26 +314,27 @@ describe('selectAgents', () => {
     }
   });
 
-  it('all agents selected with equal probability (reputation_score removed)', () => {
-    const agents = [makeAgent({ id: 'a' }), makeAgent({ id: 'b' }), makeAgent({ id: 'c' })];
+  it('higher-reputation models selected more often in selectAgents', () => {
+    const agents = [
+      makeAgent({ id: 'opus', model: 'claude-opus-4-6' }), // weight 0.8
+      makeAgent({ id: 'glm', model: 'glm-5' }), // weight 0.5
+      makeAgent({ id: 'unknown', model: 'no-such-model' }), // weight 0.5
+    ];
 
-    const counts: Record<string, number> = { a: 0, b: 0, c: 0 };
-    const N = 1000;
+    const counts: Record<string, number> = { opus: 0, glm: 0, unknown: 0 };
+    const N = 2000;
 
     for (let i = 0; i < N; i++) {
       const result = selectAgents(agents, 1, [], [], seededRng(i));
       counts[result[0].id]++;
     }
 
-    // All agents should be selected with roughly equal probability
+    // All agents should be selected
     for (const agent of agents) {
       expect(counts[agent.id]).toBeGreaterThan(0);
     }
-    // No agent should dominate
-    const values = Object.values(counts);
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    expect(max).toBeLessThan(min * 3);
+    // Opus should be selected more than the lower-reputation models
+    expect(counts['opus']).toBeGreaterThan(counts['glm']);
   });
 });
 

--- a/packages/worker/src/summarization.ts
+++ b/packages/worker/src/summarization.ts
@@ -1,3 +1,4 @@
+import { getModelDefaultReputation } from '@opencara/shared';
 import type { SummaryReview, ReviewVerdict } from '@opencara/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Env } from './env.js';
@@ -181,7 +182,9 @@ export async function fetchCompletedReviews(
 }
 
 /**
- * Select a summary agent: random among online agents not involved in this review.
+ * Select a summary agent: prefer online agents with higher model reputation, excluding
+ * agents already involved in this review. Uses weighted random selection based on
+ * model default reputation.
  */
 export async function selectSummaryAgent(
   supabase: SupabaseClient,
@@ -190,7 +193,7 @@ export async function selectSummaryAgent(
   // Exclude anonymous agents from synthesizer selection
   const { data } = await supabase
     .from('agents')
-    .select('id, users!inner(is_anonymous)')
+    .select('id, model, users!inner(is_anonymous)')
     .eq('status', 'online');
 
   if (!data || data.length === 0) return null;
@@ -202,9 +205,22 @@ export async function selectSummaryAgent(
 
   if (candidates.length === 0) return null;
 
-  // Random selection (reputation_score removed from agents)
-  const idx = Math.floor(Math.random() * candidates.length);
-  return candidates[idx].id as string;
+  // Weighted random selection: higher-reputation models are more likely to be chosen as synthesizer
+  const weighted = candidates.map((c) => {
+    const model = (c.model as string) ?? '';
+    const weight = Math.max(0.1, getModelDefaultReputation(model));
+    return { id: c.id as string, weight };
+  });
+
+  const totalWeight = weighted.reduce((sum, w) => sum + w.weight, 0);
+  let roll = Math.random() * totalWeight;
+
+  for (const entry of weighted) {
+    roll -= entry.weight;
+    if (roll <= 0) return entry.id;
+  }
+
+  return weighted[weighted.length - 1].id;
 }
 
 /**

--- a/packages/worker/src/task-distribution.ts
+++ b/packages/worker/src/task-distribution.ts
@@ -1,3 +1,4 @@
+import { getModelDefaultReputation } from '@opencara/shared';
 import type { RepoConfig, ReviewConfig } from '@opencara/shared';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Env } from './env.js';
@@ -142,17 +143,18 @@ export function isValidRepoConfig(value: unknown): value is RepoConfig {
 export const MAX_AGENTS_PER_TASK = 10;
 
 /**
- * Compute a weight for weighted random selection.
- * With reputation_score removed from agents table, all agents get equal weight.
- * This can be enhanced later with computed reputation from reputation_history.
+ * Compute a weight for weighted random selection based on model default reputation.
+ * Uses the model's default reputation from the registry when no earned reputation exists.
+ * Weight is clamped to [0.1, 1] to ensure all agents have some chance of selection.
  */
-export function agentWeight(_reputationScore?: number): number {
-  return 1;
+export function agentWeight(model: string): number {
+  const rep = getModelDefaultReputation(model);
+  return Math.max(0.1, Math.min(1, rep));
 }
 
 /**
  * Weighted reservoir sampling: select `count` items from `agents`.
- * Currently uses equal weights since reputation_score was removed from agents table.
+ * Uses model default reputation as weight — higher-reputation models are more likely to be selected.
  * Accepts an optional `rng` function (returns [0,1)) for deterministic testing.
  */
 export function weightedRandomSelect(
@@ -164,7 +166,7 @@ export function weightedRandomSelect(
 
   const keyed = agents.map((agent) => ({
     agent,
-    key: Math.pow(rng(), 1 / agentWeight()),
+    key: Math.pow(rng(), 1 / agentWeight(agent.model)),
   }));
 
   keyed.sort((a, b) => b.key - a.key);


### PR DESCRIPTION
Closes #131

## Summary
- Added `defaultReputation` field to `ModelRegistryEntry` in `packages/shared` with hardcoded scores per model (Option A from issue)
- `agentWeight()` now uses the model's default reputation from the registry for weighted random selection (higher-quality models selected more often)
- `selectSummaryAgent()` uses weighted random selection based on model reputation for synthesizer role
- `GET /api/registry` returns `defaultReputation` per model
- `getModelDefaultReputation()` helper exported from shared for easy lookups
- Unknown models default to 0.5 via `DEFAULT_REPUTATION_FALLBACK`

## Default Reputation Scores
| Model | Score |
|-------|-------|
| claude-opus-4-6 | 0.8 |
| claude-sonnet-4-6 | 0.7 |
| gemini-2.5-pro | 0.7 |
| gpt-5-codex | 0.7 |
| qwen3.5-plus | 0.6 |
| glm-5 / kimi-k2.5 / minimax-m2.5 | 0.5 |
| Unknown models | 0.5 |

## Test plan
- [x] `agentWeight()` returns correct reputation for known/unknown models
- [x] `weightedRandomSelect` favors higher-reputation models statistically
- [x] `selectAgents` weighted selection verified with model reputation
- [x] Registry endpoint returns `defaultReputation` per model
- [x] `getModelDefaultReputation` helper tested for known and unknown models
- [x] All 941 tests pass, lint/format/typecheck clean