### PR TITLE
fix: prevent tsc --build from overwriting CLI tsup bundle

### DIFF
--- a/.claude/pm-notebook.md
+++ b/.claude/pm-notebook.md
@@ -1,16 +1,32 @@
 # PM State
 
-## Open Issues
+## PM Settings
 
-- #38 [worker-dev, low] Installation event handlers — project upsert and cleanup
-- #80 [cli-dev, low] Growth trends in stats
-- #81 [cli-dev, low] Expertise areas in stats
-- #90 [worker-dev, low] Dynamic tool/model registry
-- #129 [worker-dev+cli-dev, medium] Custom agent names in review logs
-- #130 [cli-dev, low] Clickable PR links in agent logs
-- #131 [worker-dev, medium] Default reputation scores per model
-- #133 [design, low] Evaluate migration to Rust or Go
-- #144 [cli-dev, medium] Run agent in container — Dockerfile, env config, docs
+- dispatch_confirmation: true # all dispatches require team lead approval
+
+## Open Issues (awaiting team lead approval to dispatch)
+
+- #38 [worker-dev, low, NOT APPROVED] Installation event handlers — project upsert and cleanup
+- #80 [cli-dev, low, NOT APPROVED] Growth trends in stats
+- #81 [cli-dev, low, NOT APPROVED] Expertise areas in stats
+- #90 [worker-dev, low, NOT APPROVED] Dynamic tool/model registry
+- #130 [cli-dev, low, NOT APPROVED] Clickable PR links in agent logs
+- #133 [design, low, NOT APPROVED] Evaluate migration to Rust or Go
+- #144 [cli-dev, medium, NOT APPROVED] Run agent in container (paused, partially done)
+- #148 [cli-dev, low, NOT APPROVED] Auto-detect AI tools for first-time config setup
+
+## In Progress
+
+(none)
+
+## QA Plan
+
+- #129 batched QA: PRs #149, #152, #151 all merged. Pending team lead approval to dispatch QA.
+
+## QA Results
+
+- PR #149 (#145 shared types displayName) — QA PASSED
+- PR #150 (#131 default model reputation) — QA PASSED, all checks green
 
 ## Closed Issues (processed)
 
@@ -19,7 +35,7 @@
 #57, #58, #61, #62, #63, #64, #65, #66, #67, #69, #70, #71, #72, #73,
 #80, #81, #82, #83, #84, #85, #86, #87, #88, #90, #95, #96, #99, #100,
 #101, #102, #111, #112, #113, #114, #115, #120, #121, #123, #124, #125,
-#126, #129, #130, #131, #132, #133, #135, #136
+#126, #129, #130, #131, #132, #133, #135, #136, #145, #146, #147
 
 ## Merged PRs (processed)
 
@@ -27,4 +43,4 @@
 #36, #37, #39, #42, #44, #45, #49, #50, #52, #54, #56, #59, #60,
 #68, #74, #75, #76, #77, #78, #79, #89, #91, #92, #93, #94, #97,
 #103, #104, #105, #106, #107, #108, #109, #110, #116, #117, #118,
-#119, #122, #127, #128, #134, #137, #138, #139, #140, #141, #142, #143
+#119, #122, #127, #128, #134, #137, #138, #139, #140, #141, #142, #143, #149, #150, #151, #152

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -59,84 +59,92 @@ Completed 50+ post-MVP items across these areas:
 - **CLI**: local tools (#47), token counting (#87), stats enrichment (#72), contributor profiles (#101)
 - **Rebrand**: OpenCrust -> OpenCara (#91,#92)
 
+## In Progress
+
+| #    | Agent   | Status | Description                                       |
+| ---- | ------- | ------ | ------------------------------------------------- |
+| #144 | cli-dev | PAUSED | Run agent in container — Dockerfile, config, docs |
+
 ## Open Issues
 
-| #    | Agent              | Priority | Description                                          |
-| ---- | ------------------ | -------- | ---------------------------------------------------- |
-| #129 | worker-dev+cli-dev | medium   | Custom agent names in review logs and comments       |
-| #131 | worker-dev         | medium   | Default reputation scores per model                  |
-| #144 | cli-dev            | medium   | Run agent in container — Dockerfile, config, docs    |
-| #38  | worker-dev         | low      | Installation event handlers — project upsert/cleanup |
-| #80  | cli-dev            | low      | Growth trends in stats                               |
-| #81  | cli-dev            | low      | Expertise areas in stats                             |
-| #90  | worker-dev         | low      | Dynamic tool/model registry                          |
-| #130 | cli-dev            | low      | Clickable PR links in agent logs                     |
-| #133 | design             | low      | Evaluate migration to Rust or Go                     |
+| #    | Agent      | Priority | Description                                          |
+| ---- | ---------- | -------- | ---------------------------------------------------- |
+| #38  | worker-dev | low      | Installation event handlers — project upsert/cleanup |
+| #80  | cli-dev    | low      | Growth trends in stats                               |
+| #81  | cli-dev    | low      | Expertise areas in stats                             |
+| #90  | worker-dev | low      | Dynamic tool/model registry                          |
+| #130 | cli-dev    | low      | Clickable PR links in agent logs                     |
+| #133 | design     | low      | Evaluate migration to Rust or Go                     |
+| #148 | cli-dev    | low      | Auto-detect AI tools for first-time config setup     |
 
 ## Merged PRs
 
-| PR   | Issue  | Agent      | Date  | Description                 |
-| ---- | ------ | ---------- | ----- | --------------------------- |
-| #2   | #1     | architect  | 03-16 | M0 Monorepo setup           |
-| #6   | #5     | worker-dev | 03-16 | M2 DB schema + auth         |
-| #7   | #4     | worker-dev | 03-16 | M1 Webhook endpoint         |
-| #10  | #8     | cli-dev    | 03-16 | M3 CLI connect              |
-| #12  | #9     | worker-dev | 03-16 | M4 Durable Objects          |
-| #15  | #11    | architect  | 03-16 | Test coverage 100%          |
-| #16  | #14    | cli-dev    | 03-16 | M5 CLI review engine        |
-| #17  | #13    | worker-dev | 03-16 | M5 Worker review posting    |
-| #21  | #18    | architect  | 03-16 | Fix typecheck/format        |
-| #22  | #20    | cli-dev    | 03-16 | M6 CLI summary engine       |
-| #23  | #19    | worker-dev | 03-16 | M6 Multi-agent dispatch     |
-| #28  | #26    | worker-dev | 03-16 | M9 Consumption API          |
-| #29  | #25    | worker-dev | 03-16 | M7 Reputation system        |
-| #30  | #27    | cli-dev    | 03-16 | M9 CLI stats                |
-| #36  | #33    | worker-dev | 03-16 | M8 OAuth callback           |
-| #37  | #31,32 | web-dev    | 03-16 | M8 Landing + leaderboard    |
-| #39  | #34    | web-dev    | 03-16 | M8 Dashboard                |
-| #42  | #40    | architect  | 03-16 | Deployment guide            |
-| #44  | #41    | web-dev    | 03-16 | Dashboard fixes             |
-| #45  | #43    | worker-dev | 03-16 | CORS + security             |
-| #49  | #47    | cli-dev    | 03-16 | Local tools refactor        |
-| #50  | #48    | worker-dev | 03-16 | Pending task pickup         |
-| #52  | #51    | worker-dev | 03-16 | WS auth disconnect fix      |
-| #54  | #53    | worker-dev | 03-16 | WS reconnect loop fix       |
-| #56  | #55    | worker-dev | 03-16 | WS re-entrance fix          |
-| #59  | #57,46 | worker-dev | 03-17 | E2E review loop fix         |
-| #60  | #58    | architect  | 03-17 | pnpm migration              |
-| #68  | #61,62 | cli-dev    | 03-17 | WS diagnostics + tool fix   |
-| #74  | #69    | architect  | 03-17 | Trust tier types            |
-| #75  | #70,35 | worker-dev | 03-17 | Project stats API           |
-| #76  | #63    | cli-dev    | 03-17 | Tool command templates      |
-| #77  | #71    | web-dev    | 03-17 | Web community page          |
-| #78  | #72    | cli-dev    | 03-17 | Stats enrichment            |
-| #79  | #73    | cli-dev    | 03-17 | Stability threshold         |
-| #89  | #86    | cli-dev    | 03-17 | Local-config agents         |
-| #91  | --     | direct     | 03-17 | Rebrand to OpenCara         |
-| #92  | --     | direct     | 03-17 | Post-rebrand fixes          |
-| #93  | #82,83 | direct     | 03-17 | PR Review API               |
-| #94  | #87    | direct     | 03-17 | Token counting fix          |
-| #97  | #95,96 | direct     | 03-17 | Inline PR review comments   |
-| #103 | #99    | direct     | 03-17 | Trigger control             |
-| #104 | #84    | direct     | 03-17 | preferred_models            |
-| #105 | #102   | direct     | 03-17 | WebSocket ping frames       |
-| #106 | #101   | direct     | 03-17 | Contributor profiles        |
-| #107 | #100   | direct     | 03-17 | Drop diff_content storage   |
-| #108 | #88    | direct     | 03-17 | Timeout comment + retry     |
-| #109 | #85    | direct     | 03-17 | --all agent start           |
-| #110 | --     | direct     | 03-18 | E2E tests + synthesizer     |
-| #116 | #113   | architect  | 03-18 | Repo config types           |
-| #117 | #111   | worker-dev | 03-18 | Load balancing              |
-| #118 | #114   | worker-dev | 03-18 | Repo filtering              |
-| #119 | #115   | cli-dev    | 03-18 | Repo config CLI             |
-| #122 | #121   | architect  | 03-18 | Schema simplification       |
-| #127 | #124   | architect  | 03-18 | Anonymous agent types       |
-| #128 | #125   | worker-dev | 03-18 | Anonymous registration      |
-| #134 | #126   | cli-dev    | 03-18 | Anonymous CLI support       |
-| #137 | #136   | worker-dev | 03-18 | Synthesizer inline comments |
-| #138 | #132   | architect  | 03-18 | npm publish CI              |
-| #139 | #135   | worker-dev | 03-18 | Agent details in reviews    |
-| #140 | --     | direct     | 03-18 | OIDC npm publishing         |
-| #141 | --     | direct     | 03-18 | Test publish pipeline       |
-| #142 | --     | direct     | 03-18 | npm publish with token      |
-| #143 | --     | direct     | 03-18 | Test OIDC publishing        |
+| PR   | Issue  | Agent      | Date  | Description                   |
+| ---- | ------ | ---------- | ----- | ----------------------------- |
+| #2   | #1     | architect  | 03-16 | M0 Monorepo setup             |
+| #6   | #5     | worker-dev | 03-16 | M2 DB schema + auth           |
+| #7   | #4     | worker-dev | 03-16 | M1 Webhook endpoint           |
+| #10  | #8     | cli-dev    | 03-16 | M3 CLI connect                |
+| #12  | #9     | worker-dev | 03-16 | M4 Durable Objects            |
+| #15  | #11    | architect  | 03-16 | Test coverage 100%            |
+| #16  | #14    | cli-dev    | 03-16 | M5 CLI review engine          |
+| #17  | #13    | worker-dev | 03-16 | M5 Worker review posting      |
+| #21  | #18    | architect  | 03-16 | Fix typecheck/format          |
+| #22  | #20    | cli-dev    | 03-16 | M6 CLI summary engine         |
+| #23  | #19    | worker-dev | 03-16 | M6 Multi-agent dispatch       |
+| #28  | #26    | worker-dev | 03-16 | M9 Consumption API            |
+| #29  | #25    | worker-dev | 03-16 | M7 Reputation system          |
+| #30  | #27    | cli-dev    | 03-16 | M9 CLI stats                  |
+| #36  | #33    | worker-dev | 03-16 | M8 OAuth callback             |
+| #37  | #31,32 | web-dev    | 03-16 | M8 Landing + leaderboard      |
+| #39  | #34    | web-dev    | 03-16 | M8 Dashboard                  |
+| #42  | #40    | architect  | 03-16 | Deployment guide              |
+| #44  | #41    | web-dev    | 03-16 | Dashboard fixes               |
+| #45  | #43    | worker-dev | 03-16 | CORS + security               |
+| #49  | #47    | cli-dev    | 03-16 | Local tools refactor          |
+| #50  | #48    | worker-dev | 03-16 | Pending task pickup           |
+| #52  | #51    | worker-dev | 03-16 | WS auth disconnect fix        |
+| #54  | #53    | worker-dev | 03-16 | WS reconnect loop fix         |
+| #56  | #55    | worker-dev | 03-16 | WS re-entrance fix            |
+| #59  | #57,46 | worker-dev | 03-17 | E2E review loop fix           |
+| #60  | #58    | architect  | 03-17 | pnpm migration                |
+| #68  | #61,62 | cli-dev    | 03-17 | WS diagnostics + tool fix     |
+| #74  | #69    | architect  | 03-17 | Trust tier types              |
+| #75  | #70,35 | worker-dev | 03-17 | Project stats API             |
+| #76  | #63    | cli-dev    | 03-17 | Tool command templates        |
+| #77  | #71    | web-dev    | 03-17 | Web community page            |
+| #78  | #72    | cli-dev    | 03-17 | Stats enrichment              |
+| #79  | #73    | cli-dev    | 03-17 | Stability threshold           |
+| #89  | #86    | cli-dev    | 03-17 | Local-config agents           |
+| #91  | --     | direct     | 03-17 | Rebrand to OpenCara           |
+| #92  | --     | direct     | 03-17 | Post-rebrand fixes            |
+| #93  | #82,83 | direct     | 03-17 | PR Review API                 |
+| #94  | #87    | direct     | 03-17 | Token counting fix            |
+| #97  | #95,96 | direct     | 03-17 | Inline PR review comments     |
+| #103 | #99    | direct     | 03-17 | Trigger control               |
+| #104 | #84    | direct     | 03-17 | preferred_models              |
+| #105 | #102   | direct     | 03-17 | WebSocket ping frames         |
+| #106 | #101   | direct     | 03-17 | Contributor profiles          |
+| #107 | #100   | direct     | 03-17 | Drop diff_content storage     |
+| #108 | #88    | direct     | 03-17 | Timeout comment + retry       |
+| #109 | #85    | direct     | 03-17 | --all agent start             |
+| #110 | --     | direct     | 03-18 | E2E tests + synthesizer       |
+| #116 | #113   | architect  | 03-18 | Repo config types             |
+| #117 | #111   | worker-dev | 03-18 | Load balancing                |
+| #118 | #114   | worker-dev | 03-18 | Repo filtering                |
+| #119 | #115   | cli-dev    | 03-18 | Repo config CLI               |
+| #122 | #121   | architect  | 03-18 | Schema simplification         |
+| #127 | #124   | architect  | 03-18 | Anonymous agent types         |
+| #128 | #125   | worker-dev | 03-18 | Anonymous registration        |
+| #134 | #126   | cli-dev    | 03-18 | Anonymous CLI support         |
+| #137 | #136   | worker-dev | 03-18 | Synthesizer inline comments   |
+| #138 | #132   | architect  | 03-18 | npm publish CI                |
+| #139 | #135   | worker-dev | 03-18 | Agent details in reviews      |
+| #140 | --     | direct     | 03-18 | OIDC npm publishing           |
+| #141 | --     | direct     | 03-18 | Test publish pipeline         |
+| #142 | --     | direct     | 03-18 | npm publish with token        |
+| #143 | --     | direct     | 03-18 | Test OIDC publishing          |
+| #149 | #145   | architect  | 03-18 | Shared types: displayName     |
+| #150 | #131   | worker-dev | 03-18 | Default model reputation      |
+| #151 | #147   | cli-dev    | 03-18 | Parse + send agent names      |
+| #152 | #146   | worker-dev | 03-18 | Persist + display agent names |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencara",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,6 +4,7 @@
     "composite": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "emitDeclarationOnly": true,
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
## Summary
- `tsc --build` (typecheck) was outputting `.js` files to `dist/`, overwriting the tsup bundle with unbundled individual files
- This caused `ERR_MODULE_NOT_FOUND` for `reconnect.js` when running the CLI after `pnpm run typecheck`
- Added `emitDeclarationOnly: true` to CLI tsconfig so tsc only emits `.d.ts` files
- Bump version to 0.6.1

## Test plan
- [x] `pnpm build` creates tsup bundle
- [x] `pnpm run typecheck` no longer overwrites the bundle (only `.d.ts` files emitted)
- [x] `npx opencara --version` works after build+typecheck sequence
- [x] 979 tests pass, lint/format/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)