### PR TITLE
[server-dev] Fix reject/error to free claim slots + add state machine validation

### DIFF
--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -508,12 +508,59 @@ APPROVE`;
       const rejectedClaim = claims.find((c) => c.agent_id === 'agent-1');
       expect(rejectedClaim?.status).toBe('rejected');
 
-      // Agent 1 already has a claim, so polling again shouldn't show it
-      const poll1 = await poll('agent-1');
-      expect(poll1.tasks).toHaveLength(0);
+      // Task slot should be freed — agent 2 can now claim it
+      const poll2 = await poll('agent-2');
+      expect(poll2.tasks).toHaveLength(1);
+      expect(poll2.tasks[0].role).toBe('summary');
 
-      // But agent 2 won't see it either because there's already a claim (rejected but present)
-      // This is correct behavior — rejected claims occupy the slot to prevent infinite retries
+      // Agent 2 claims and completes
+      const claimRes = await claim('task-reject', 'agent-2', 'summary');
+      expect(claimRes.claimed).toBe(true);
+    });
+
+    it('agent rejects → new agent claims freed slot → completes review', async () => {
+      await store.createTask(makeTask({ id: 'task-reject-e2e', review_count: 2 }));
+
+      // Agent 1 claims review, then rejects
+      await claim('task-reject-e2e', 'agent-1', 'review');
+      await api('POST', '/api/tasks/task-reject-e2e/reject', {
+        agent_id: 'agent-1',
+        reason: 'Diff too large',
+      });
+
+      // Agent 2 claims the freed review slot
+      const poll2 = await poll('agent-2');
+      expect(poll2.tasks).toHaveLength(1);
+      expect(poll2.tasks[0].role).toBe('review');
+
+      const claimRes = await claim('task-reject-e2e', 'agent-2', 'review');
+      expect(claimRes.claimed).toBe(true);
+
+      // Agent 2 completes the review
+      await submitResult('task-reject-e2e', 'agent-2', 'review', 'Looks good', 'approve');
+
+      // Summary slot now available
+      const pollSynth = await poll('agent-3');
+      expect(pollSynth.tasks).toHaveLength(1);
+      expect(pollSynth.tasks[0].role).toBe('summary');
+    });
+
+    it('same agent can re-claim after rejection', async () => {
+      await store.createTask(makeTask({ id: 'task-reclaim' }));
+
+      // Agent claims then rejects
+      await claim('task-reclaim', 'agent-1', 'summary');
+      await api('POST', '/api/tasks/task-reclaim/reject', {
+        agent_id: 'agent-1',
+        reason: 'Transient error',
+      });
+
+      // Same agent can re-claim (removed from claimed_agents)
+      const pollRes = await poll('agent-1');
+      expect(pollRes.tasks).toHaveLength(1);
+
+      const claimRes = await claim('task-reclaim', 'agent-1', 'summary');
+      expect(claimRes.claimed).toBe(true);
     });
   });
 
@@ -522,7 +569,7 @@ APPROVE`;
   // ═══════════════════════════════════════════════════════════
 
   describe('error flow', () => {
-    it('error claim is recorded correctly', async () => {
+    it('error claim is recorded correctly and frees slot', async () => {
       await store.createTask(makeTask({ id: 'task-error', review_count: 3 }));
 
       await claim('task-error', 'agent-crash', 'review');
@@ -534,6 +581,33 @@ APPROVE`;
       const claims = await store.getClaims('task-error');
       const errClaim = claims.find((c) => c.agent_id === 'agent-crash');
       expect(errClaim?.status).toBe('error');
+
+      // Slot should be freed — task counters updated
+      const task = await store.getTask('task-error');
+      expect(task?.review_claims).toBe(0);
+      expect(task?.claimed_agents).toEqual([]);
+
+      // Another agent can now claim the freed slot
+      const pollRes = await poll('agent-replacement');
+      expect(pollRes.tasks).toHaveLength(1);
+      expect(pollRes.tasks[0].role).toBe('review');
+
+      const claimRes = await claim('task-error', 'agent-replacement', 'review');
+      expect(claimRes.claimed).toBe(true);
+    });
+
+    it('error on reject/error endpoints returns 404 for missing claims', async () => {
+      const rejectRes = await api('POST', '/api/tasks/task-missing/reject', {
+        agent_id: 'ghost',
+        reason: 'test',
+      });
+      expect(rejectRes.status).toBe(404);
+
+      const errorRes = await api('POST', '/api/tasks/task-missing/error', {
+        agent_id: 'ghost',
+        error: 'test',
+      });
+      expect(errorRes.status).toBe(404);
     });
   });
 

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -256,6 +256,14 @@ describe('Task Routes', () => {
 
   describe('POST /api/tasks/:taskId/reject', () => {
     it('marks claim as rejected', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1'],
+          review_claims: 1,
+          status: 'reviewing',
+        }),
+      );
       await store.createClaim({
         id: 'task-1:agent-1',
         task_id: 'task-1',
@@ -274,10 +282,158 @@ describe('Task Routes', () => {
       const claims = await store.getClaims('task-1');
       expect(claims[0].status).toBe('rejected');
     });
+
+    it('returns 404 for missing claim', async () => {
+      const res = await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'nonexistent',
+        reason: 'test',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 409 if claim is completed', async () => {
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'completed',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'test',
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it('is idempotent — double reject returns 200', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1'],
+          review_claims: 1,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // First reject
+      const res1 = await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'test',
+      });
+      expect(res1.status).toBe(200);
+
+      // Second reject — idempotent
+      const res2 = await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'test again',
+      });
+      expect(res2.status).toBe(200);
+    });
+
+    it('frees review slot (review_claims decremented, agent removed from claimed_agents)', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1', 'agent-2'],
+          review_claims: 2,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'Cannot access diff',
+      });
+
+      const task = await store.getTask('task-1');
+      expect(task?.review_claims).toBe(1);
+      expect(task?.claimed_agents).toEqual(['agent-2']);
+    });
+
+    it('frees summary slot', async () => {
+      await store.createTask(
+        makeTask({
+          claimed_agents: ['agent-1'],
+          summary_claimed: true,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'test',
+      });
+
+      const task = await store.getTask('task-1');
+      expect(task?.summary_claimed).toBe(false);
+      expect(task?.claimed_agents).toEqual([]);
+    });
+
+    it('counter underflow protection — reject when review_claims is already 0', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1'],
+          review_claims: 0, // already 0 (edge case)
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-1',
+        reason: 'test',
+      });
+
+      const task = await store.getTask('task-1');
+      expect(task?.review_claims).toBe(0); // Math.max(0, -1) = 0
+    });
   });
 
   describe('POST /api/tasks/:taskId/error', () => {
     it('marks claim as error', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1'],
+          review_claims: 1,
+          status: 'reviewing',
+        }),
+      );
       await store.createClaim({
         id: 'task-1:agent-1',
         task_id: 'task-1',
@@ -295,6 +451,84 @@ describe('Task Routes', () => {
 
       const claims = await store.getClaims('task-1');
       expect(claims[0].status).toBe('error');
+    });
+
+    it('returns 404 for missing claim', async () => {
+      const res = await request('POST', '/api/tasks/task-1/error', {
+        agent_id: 'nonexistent',
+        error: 'test',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 409 if claim is completed', async () => {
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'completed',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/task-1/error', {
+        agent_id: 'agent-1',
+        error: 'test',
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it('is idempotent — double error returns 200', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          claimed_agents: ['agent-1'],
+          review_claims: 1,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await request('POST', '/api/tasks/task-1/error', { agent_id: 'agent-1', error: 'crash' });
+      const res2 = await request('POST', '/api/tasks/task-1/error', {
+        agent_id: 'agent-1',
+        error: 'crash again',
+      });
+      expect(res2.status).toBe(200);
+    });
+
+    it('frees summary slot on error', async () => {
+      await store.createTask(
+        makeTask({
+          claimed_agents: ['agent-1'],
+          summary_claimed: true,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await request('POST', '/api/tasks/task-1/error', {
+        agent_id: 'agent-1',
+        error: 'crash',
+      });
+
+      const task = await store.getTask('task-1');
+      expect(task?.summary_claimed).toBe(false);
+      expect(task?.claimed_agents).toEqual([]);
     });
   });
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -290,7 +290,10 @@ export function taskRoutes(store: TaskStore) {
     });
 
     // Update task counters atomically (avoids KV list consistency issues)
-    const claimedAgents = [...(task.claimed_agents ?? []), agent_id];
+    const claimedAgents = task.claimed_agents ?? [];
+    if (!claimedAgents.includes(agent_id)) {
+      claimedAgents.push(agent_id);
+    }
     const taskUpdates: Partial<ReviewTask> = {
       claimed_agents: claimedAgents,
       status: task.status === 'pending' ? 'reviewing' : task.status,
@@ -382,9 +385,37 @@ export function taskRoutes(store: TaskStore) {
     const { agent_id, reason } = body;
 
     const claimId = `${taskId}:${agent_id}`;
-    await store.updateClaim(claimId, { status: 'rejected' });
-    console.log(`Task ${taskId}: agent ${agent_id} rejected — ${reason}`);
+    const claim = await store.getClaim(claimId);
 
+    if (!claim) {
+      return c.json({ error: 'Claim not found' }, 404);
+    }
+
+    if (claim.status !== 'pending') {
+      // Idempotent: already rejected → return 200
+      if (claim.status === 'rejected') {
+        return c.json({ success: true });
+      }
+      return c.json({ error: `Claim is ${claim.status}, expected pending` }, 409);
+    }
+
+    await store.updateClaim(claimId, { status: 'rejected' });
+
+    // Free the slot so another agent can claim it
+    const task = await store.getTask(taskId);
+    if (task) {
+      const updates: Partial<ReviewTask> = {
+        claimed_agents: (task.claimed_agents ?? []).filter((id) => id !== agent_id),
+      };
+      if (claim.role === 'review') {
+        updates.review_claims = Math.max(0, (task.review_claims ?? 0) - 1);
+      } else if (claim.role === 'summary') {
+        updates.summary_claimed = false;
+      }
+      await store.updateTask(taskId, updates);
+    }
+
+    console.log(`Task ${taskId}: agent ${agent_id} rejected — ${reason}`);
     return c.json({ success: true });
   });
 
@@ -396,9 +427,37 @@ export function taskRoutes(store: TaskStore) {
     const { agent_id, error } = body;
 
     const claimId = `${taskId}:${agent_id}`;
-    await store.updateClaim(claimId, { status: 'error' });
-    console.error(`Task ${taskId}: agent ${agent_id} error — ${error}`);
+    const claim = await store.getClaim(claimId);
 
+    if (!claim) {
+      return c.json({ error: 'Claim not found' }, 404);
+    }
+
+    if (claim.status !== 'pending') {
+      // Idempotent: already errored → return 200
+      if (claim.status === 'error') {
+        return c.json({ success: true });
+      }
+      return c.json({ error: `Claim is ${claim.status}, expected pending` }, 409);
+    }
+
+    await store.updateClaim(claimId, { status: 'error' });
+
+    // Free the slot so another agent can claim it
+    const task = await store.getTask(taskId);
+    if (task) {
+      const updates: Partial<ReviewTask> = {
+        claimed_agents: (task.claimed_agents ?? []).filter((id) => id !== agent_id),
+      };
+      if (claim.role === 'review') {
+        updates.review_claims = Math.max(0, (task.review_claims ?? 0) - 1);
+      } else if (claim.role === 'summary') {
+        updates.summary_claimed = false;
+      }
+      await store.updateTask(taskId, updates);
+    }
+
+    console.error(`Task ${taskId}: agent ${agent_id} error — ${error}`);
     return c.json({ success: true });
   });
 


### PR DESCRIPTION
Closes #175

## Summary
- Add claim state machine validation on reject/error endpoints: 404 for missing claims, 409 for invalid state transitions, idempotent 200 for already-terminal claims
- Free slots on reject/error: decrement `review_claims` / clear `summary_claimed`, remove agent from `claimed_agents` so replacement agents can fill the slot
- Counter underflow protection with `Math.max(0, ...)`
- Deduplicate `claimed_agents` array on claim (safety net for race conditions)
- Re-claim semantics: rejected/errored agents can re-claim the same task on next poll cycle

## Test plan
- [x] Unit: reject returns 404 for missing claim
- [x] Unit: reject returns 409 for completed claim
- [x] Unit: double-reject is idempotent (200)
- [x] Unit: reject frees review slot (review_claims decremented, agent removed)
- [x] Unit: reject frees summary slot (summary_claimed=false)
- [x] Unit: counter underflow protection (reject when review_claims=0)
- [x] Unit: error returns 404 for missing claim
- [x] Unit: error returns 409 for completed claim
- [x] Unit: double-error is idempotent (200)
- [x] Unit: error frees summary slot
- [x] Integration: rejected claim frees slot for another agent
- [x] Integration: agent rejects -> new agent claims freed slot -> completes review
- [x] Integration: same agent can re-claim after rejection
- [x] Integration: error frees slot and another agent can claim it
- [x] Integration: 404 on missing claims for reject/error
- [x] All 320 tests pass, lint/format/typecheck clean