### PR TITLE
[server-dev] Harden KV store: safe JSON parsing + TTL on terminal entries

### DIFF
--- a/packages/server/src/__tests__/store-kv.test.ts
+++ b/packages/server/src/__tests__/store-kv.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { KVTaskStore, safeParseJson } from '../store/kv.js';
+import type { ReviewTask, TaskClaim } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+
+// ── Mock KVNamespace ───────────────────────────────────────────────
+
+type PutOptions = { expirationTtl?: number };
+
+class MockKV {
+  private data = new Map<string, string>();
+  /** Track put calls with their options for TTL assertions */
+  putCalls: Array<{ key: string; value: string; options?: PutOptions }> = [];
+
+  async get(key: string): Promise<string | null> {
+    return this.data.get(key) ?? null;
+  }
+
+  async put(key: string, value: string, options?: PutOptions): Promise<void> {
+    this.putCalls.push({ key, value, options });
+    this.data.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.data.delete(key);
+  }
+
+  async list(opts: { prefix: string }): Promise<{ keys: Array<{ name: string }> }> {
+    const keys: Array<{ name: string }> = [];
+    for (const k of this.data.keys()) {
+      if (k.startsWith(opts.prefix)) {
+        keys.push({ name: k });
+      }
+    }
+    return { keys };
+  }
+
+  /** Inject raw string at a key (for corruption tests) */
+  _setRaw(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
+  return {
+    id: 'task-1',
+    owner: 'test-org',
+    repo: 'test-repo',
+    pr_number: 1,
+    pr_url: 'https://github.com/test-org/test-repo/pull/1',
+    diff_url: 'https://github.com/test-org/test-repo/pull/1.diff',
+    base_ref: 'main',
+    head_ref: 'feature',
+    review_count: 1,
+    prompt: 'Review this PR',
+    timeout_at: Date.now() + 600_000,
+    status: 'pending',
+    github_installation_id: 123,
+    config: DEFAULT_REVIEW_CONFIG,
+    created_at: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeClaim(overrides: Partial<TaskClaim> = {}): TaskClaim {
+  return {
+    id: 'task-1:agent-1',
+    task_id: 'task-1',
+    agent_id: 'agent-1',
+    role: 'review',
+    status: 'pending',
+    created_at: Date.now(),
+    ...overrides,
+  };
+}
+
+const SEVEN_DAYS = 7 * 24 * 60 * 60;
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('safeParseJson', () => {
+  it('parses valid JSON', () => {
+    expect(safeParseJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('returns null on malformed JSON', () => {
+    expect(safeParseJson<unknown>('not json')).toBeNull();
+  });
+
+  it('returns custom fallback on malformed JSON', () => {
+    expect(safeParseJson<string[]>('bad', [])).toEqual([]);
+  });
+
+  it('logs a warning on malformed JSON', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    safeParseJson('bad');
+    expect(warnSpy).toHaveBeenCalledWith('KV: corrupted JSON entry, returning fallback');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('KVTaskStore', () => {
+  let kv: MockKV;
+  let store: KVTaskStore;
+
+  beforeEach(() => {
+    kv = new MockKV();
+    store = new KVTaskStore(kv as unknown as KVNamespace);
+  });
+
+  // ── getTask: corrupted JSON ──────────────────────────────────
+
+  describe('getTask — corrupted JSON', () => {
+    it('returns null when KV contains invalid JSON', async () => {
+      kv._setRaw('task:bad', '{corrupt');
+      const result = await store.getTask('bad');
+      expect(result).toBeNull();
+    });
+
+    it('returns parsed task for valid JSON', async () => {
+      const task = makeTask();
+      await store.createTask(task);
+      const result = await store.getTask('task-1');
+      expect(result).toEqual(task);
+    });
+  });
+
+  // ── getClaim: corrupted JSON ─────────────────────────────────
+
+  describe('getClaim — corrupted JSON', () => {
+    it('returns null when KV contains invalid JSON', async () => {
+      kv._setRaw('claim:task-1:agent-1', 'not-json');
+      const result = await store.getClaim('task-1:agent-1');
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── getClaims: corrupted entries ─────────────────────────────
+
+  describe('getClaims — corrupted entries', () => {
+    it('skips corrupted entries and returns valid ones', async () => {
+      // One valid, one corrupted
+      await store.createClaim(makeClaim({ task_id: 'task-1', agent_id: 'a1' }));
+      kv._setRaw('claim:task-1:bad', '{broken');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const claims = await store.getClaims('task-1');
+      expect(claims).toHaveLength(1);
+      expect(claims[0].agent_id).toBe('a1');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'KV: skipping corrupted claim entry at claim:task-1:bad',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('returns empty array when all entries are corrupted', async () => {
+      kv._setRaw('claim:task-1:a1', 'bad1');
+      kv._setRaw('claim:task-1:a2', 'bad2');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const claims = await store.getClaims('task-1');
+      expect(claims).toEqual([]);
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ── getTaskIndex: corrupted JSON ─────────────────────────────
+
+  describe('getTaskIndex — corrupted JSON', () => {
+    it('returns empty array when task_index is corrupted', async () => {
+      kv._setRaw('task_index', '{not-an-array');
+      const tasks = await store.listTasks();
+      expect(tasks).toEqual([]);
+    });
+  });
+
+  // ── updateClaim: corrupted JSON ──────────────────────────────
+
+  describe('updateClaim — corrupted JSON', () => {
+    it('returns early and logs warning when claim data is corrupted', async () => {
+      kv._setRaw('claim:task-1:agent-1', '{corrupt');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await store.updateClaim('task-1:agent-1', { status: 'completed' });
+
+      // Should not have written anything new (only the initial raw injection exists)
+      const putCallsForKey = kv.putCalls.filter((c) => c.key === 'claim:task-1:agent-1');
+      expect(putCallsForKey).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'KV: corrupted claim entry claim:task-1:agent-1, skipping update',
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ── updateTask: TTL on terminal states ───────────────────────
+
+  describe('updateTask — TTL on terminal states', () => {
+    it('sets expirationTtl when status transitions to completed', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { status: 'completed' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut).toBeDefined();
+      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('sets expirationTtl when status transitions to timeout', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { status: 'timeout' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('sets expirationTtl when status transitions to failed', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { status: 'failed' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('does NOT set expirationTtl for non-terminal status', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { status: 'reviewing' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut).toBeDefined();
+      expect(taskPut!.options).toBeUndefined();
+    });
+
+    it('does NOT set expirationTtl when updating non-status fields', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { prompt: 'Updated prompt' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut).toBeDefined();
+      expect(taskPut!.options).toBeUndefined();
+    });
+  });
+
+  // ── updateClaim: TTL on terminal statuses ────────────────────
+
+  describe('updateClaim — TTL on terminal statuses', () => {
+    it('sets expirationTtl when claim status transitions to completed', async () => {
+      await store.createClaim(makeClaim());
+      kv.putCalls = [];
+
+      await store.updateClaim('task-1:agent-1', { status: 'completed', review_text: 'LGTM' });
+
+      const claimPut = kv.putCalls.find((c) => c.key === 'claim:task-1:agent-1');
+      expect(claimPut).toBeDefined();
+      expect(claimPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('sets expirationTtl when claim status transitions to rejected', async () => {
+      await store.createClaim(makeClaim());
+      kv.putCalls = [];
+
+      await store.updateClaim('task-1:agent-1', { status: 'rejected' });
+
+      const claimPut = kv.putCalls.find((c) => c.key === 'claim:task-1:agent-1');
+      expect(claimPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('sets expirationTtl when claim status transitions to error', async () => {
+      await store.createClaim(makeClaim());
+      kv.putCalls = [];
+
+      await store.updateClaim('task-1:agent-1', { status: 'error' });
+
+      const claimPut = kv.putCalls.find((c) => c.key === 'claim:task-1:agent-1');
+      expect(claimPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+    });
+
+    it('does NOT set expirationTtl for non-terminal claim status', async () => {
+      await store.createClaim(makeClaim());
+      kv.putCalls = [];
+
+      await store.updateClaim('task-1:agent-1', { status: 'active' });
+
+      const claimPut = kv.putCalls.find((c) => c.key === 'claim:task-1:agent-1');
+      expect(claimPut).toBeDefined();
+      expect(claimPut!.options).toBeUndefined();
+    });
+  });
+});

--- a/packages/server/src/store/kv.ts
+++ b/packages/server/src/store/kv.ts
@@ -7,6 +7,22 @@ const CLAIM_PREFIX = 'claim:';
 const AGENT_PREFIX = 'agent:';
 const TASK_INDEX_KEY = 'task_index';
 
+/** TTL for terminal KV entries: 7 days in seconds */
+const TERMINAL_TTL = 7 * 24 * 60 * 60;
+
+const TERMINAL_TASK_STATES = ['completed', 'timeout', 'failed'];
+const TERMINAL_CLAIM_STATUSES = ['completed', 'rejected', 'error'];
+
+/** Safely parse JSON, returning fallback on malformed input. */
+export function safeParseJson<T>(raw: string, fallback: T | null = null): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    console.warn('KV: corrupted JSON entry, returning fallback');
+    return fallback;
+  }
+}
+
 /**
  * Cloudflare Workers KV-backed TaskStore.
  *
@@ -32,7 +48,7 @@ export class KVTaskStore implements TaskStore {
   async getTask(id: string): Promise<ReviewTask | null> {
     const raw = await this.kv.get(`${TASK_PREFIX}${id}`);
     if (!raw) return null;
-    return JSON.parse(raw) as ReviewTask;
+    return safeParseJson<ReviewTask>(raw);
   }
 
   async listTasks(filter?: TaskFilter): Promise<ReviewTask[]> {
@@ -60,11 +76,14 @@ export class KVTaskStore implements TaskStore {
     const task = await this.getTask(id);
     if (!task) return false;
     const updated = { ...task, ...updates };
-    await this.kv.put(`${TASK_PREFIX}${id}`, JSON.stringify(updated));
+
+    const options = TERMINAL_TASK_STATES.includes(updated.status)
+      ? { expirationTtl: TERMINAL_TTL }
+      : undefined;
+    await this.kv.put(`${TASK_PREFIX}${id}`, JSON.stringify(updated), options);
 
     // Remove from index when reaching terminal state to prevent unbounded growth
-    const terminalStates = ['completed', 'timeout', 'failed'];
-    if (updates.status && terminalStates.includes(updates.status)) {
+    if (updates.status && TERMINAL_TASK_STATES.includes(updates.status)) {
       const index = await this.getTaskIndex();
       const filtered = index.filter((tid) => tid !== id);
       await this.kv.put(TASK_INDEX_KEY, JSON.stringify(filtered));
@@ -96,7 +115,7 @@ export class KVTaskStore implements TaskStore {
   async getClaim(claimId: string): Promise<TaskClaim | null> {
     const raw = await this.kv.get(`${CLAIM_PREFIX}${claimId}`);
     if (!raw) return null;
-    return JSON.parse(raw) as TaskClaim;
+    return safeParseJson<TaskClaim>(raw);
   }
 
   async getClaims(taskId: string): Promise<TaskClaim[]> {
@@ -106,7 +125,12 @@ export class KVTaskStore implements TaskStore {
     for (const key of claimList.keys) {
       const raw = await this.kv.get(key.name);
       if (raw) {
-        claims.push(JSON.parse(raw) as TaskClaim);
+        const claim = safeParseJson<TaskClaim>(raw);
+        if (claim) {
+          claims.push(claim);
+        } else {
+          console.warn(`KV: skipping corrupted claim entry at ${key.name}`);
+        }
       }
     }
 
@@ -118,9 +142,17 @@ export class KVTaskStore implements TaskStore {
     const key = `${CLAIM_PREFIX}${claimId}`;
     const raw = await this.kv.get(key);
     if (!raw) return;
-    const claim = JSON.parse(raw) as TaskClaim;
+    const claim = safeParseJson<TaskClaim>(raw);
+    if (!claim) {
+      console.warn(`KV: corrupted claim entry ${key}, skipping update`);
+      return;
+    }
     const updated = { ...claim, ...updates };
-    await this.kv.put(key, JSON.stringify(updated));
+
+    const options = TERMINAL_CLAIM_STATUSES.includes(updated.status)
+      ? { expirationTtl: TERMINAL_TTL }
+      : undefined;
+    await this.kv.put(key, JSON.stringify(updated), options);
   }
 
   // ── Agent last-seen ────────────────────────────────────────────
@@ -140,6 +172,6 @@ export class KVTaskStore implements TaskStore {
   private async getTaskIndex(): Promise<string[]> {
     const raw = await this.kv.get(TASK_INDEX_KEY);
     if (!raw) return [];
-    return JSON.parse(raw) as string[];
+    return safeParseJson<string[]>(raw, []) ?? [];
   }
 }


### PR DESCRIPTION
Closes #173

## Summary
- Add `safeParseJson` helper wrapping all `JSON.parse` calls with try-catch — corrupted KV entries no longer crash the service
- `getTask`/`getClaim` return null on parse error (treated as missing); `getClaims` skips corrupted entries with per-key warning; `updateClaim` logs the corrupted key and returns early; `getTaskIndex` falls back to `[]`
- Add 7-day `expirationTtl` on terminal task states (`completed`/`timeout`/`failed`) and terminal claim statuses (`completed`/`rejected`/`error`) to prevent unbounded KV growth
- 20 new unit tests covering all corruption and TTL scenarios

## Test plan
- [x] `safeParseJson` returns null/fallback on malformed input
- [x] `getTask` returns null when KV contains invalid JSON
- [x] `getClaim` returns null when KV contains invalid JSON
- [x] `getClaims` skips corrupted entries, returns valid ones
- [x] `getTaskIndex` returns `[]` on corrupted index
- [x] `updateClaim` logs warning and returns early on corrupted data
- [x] `updateTask` sets `expirationTtl` when status is terminal
- [x] `updateClaim` sets `expirationTtl` when claim status is terminal
- [x] Non-terminal status updates do NOT set `expirationTtl`
- [x] All 353 tests pass, lint/format/typecheck clean