### PR TITLE
[server-dev] Add retry logic and error handling for GitHub API calls

### DIFF
--- a/packages/server/src/__tests__/github-fetch.test.ts
+++ b/packages/server/src/__tests__/github-fetch.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { githubFetch } from '../github/fetch.js';
+
+describe('githubFetch', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper: start githubFetch, advance fake timers to flush all retry delays,
+   * then return the result. This avoids real-time waits in tests.
+   */
+  async function fetchWithTimers(url: string, options?: Parameters<typeof githubFetch>[1]) {
+    const promise = githubFetch(url, options);
+    // Advance timers enough to cover max retries: 1s + 2s + 4s = 7s
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(4000);
+    }
+    return promise;
+  }
+
+  // ── Headers ───────────────────────────────────────────────
+
+  describe('headers', () => {
+    it('sets standard GitHub headers', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['User-Agent']).toBe('OpenCara-Server');
+      expect(init.headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+      expect(init.headers['Accept']).toBe('application/vnd.github+json');
+    });
+
+    it('sets Authorization header when token provided', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test', { token: 'ghs_abc123' });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Authorization']).toBe('Bearer ghs_abc123');
+    });
+
+    it('does not set Authorization header when no token', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Authorization']).toBeUndefined();
+    });
+
+    it('uses custom accept header', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test', {
+        accept: 'application/vnd.github.diff',
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Accept']).toBe('application/vnd.github.diff');
+    });
+
+    it('sets Content-Type for POST requests', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test', {
+        method: 'POST',
+        body: JSON.stringify({ data: 1 }),
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('does not set Content-Type for GET requests', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['Content-Type']).toBeUndefined();
+    });
+  });
+
+  // ── Successful responses ──────────────────────────────────
+
+  describe('successful responses', () => {
+    it('returns response on 200', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns response on 201', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('created', { status: 201 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test', { method: 'POST' });
+
+      expect(res.status).toBe(201);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Non-retryable errors ──────────────────────────────────
+
+  describe('non-retryable errors', () => {
+    it('does NOT retry 400 Bad Request', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('bad', { status: 400 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(400);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry 401 Unauthorized', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('unauth', { status: 401 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(401);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry 403 Forbidden', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(403);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry 404 Not Found', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(404);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry 422 Unprocessable Entity', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('invalid', { status: 422 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(422);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Retryable errors ──────────────────────────────────────
+
+  describe('retryable errors', () => {
+    it('retries on 500 Internal Server Error and succeeds', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('error', { status: 500 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 502 Bad Gateway and succeeds', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('error', { status: 502 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 503 Service Unavailable and succeeds', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('error', { status: 503 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 429 Rate Limit and succeeds', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns error response after all retries exhausted (4 attempts total)', async () => {
+      fetchMock.mockResolvedValue(new Response('error', { status: 500 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(500);
+      // 1 initial + 3 retries = 4 total
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('respects Retry-After header (seconds)', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response('rate limited', {
+            status: 429,
+            headers: { 'Retry-After': '2' },
+          }),
+        )
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Network errors ────────────────────────────────────────
+
+  describe('network errors', () => {
+    it('retries on network error and succeeds', async () => {
+      fetchMock
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after all network error retries exhausted', async () => {
+      vi.useRealTimers();
+
+      // Use real timers with mockRejectedValueOnce (each call creates a fresh rejection)
+      fetchMock
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockRejectedValueOnce(new TypeError('fetch failed'));
+
+      await expect(githubFetch('https://api.github.com/test')).rejects.toThrow('fetch failed');
+
+      // 1 initial + 3 retries = 4 total
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      // Re-enable fake timers for subsequent tests
+      vi.useFakeTimers();
+    }, 15000);
+
+    it('retries network error then handles 500 retry', async () => {
+      fetchMock
+        .mockRejectedValueOnce(new TypeError('fetch failed'))
+        .mockResolvedValueOnce(new Response('error', { status: 500 }))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // ── Integration with callers ──────────────────────────────
+
+  describe('caller integration', () => {
+    it('postPrReview succeeds after transient 502', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('Bad Gateway', { status: 502 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ html_url: 'https://github.com/test/test/pull/1#review-1' }),
+            { status: 200 },
+          ),
+        );
+
+      const response = await fetchWithTimers(
+        'https://api.github.com/repos/test/test/pulls/1/reviews',
+        {
+          method: 'POST',
+          token: 'ghs_test',
+          body: JSON.stringify({ body: 'LGTM', event: 'APPROVE' }),
+        },
+      );
+
+      expect(response.ok).toBe(true);
+      const data = (await response.json()) as { html_url: string };
+      expect(data.html_url).toBe('https://github.com/test/test/pull/1#review-1');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('fetchReviewConfig returns 404 without retry', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('Not Found', { status: 404 }));
+
+      const response = await fetchWithTimers(
+        'https://api.github.com/repos/test/test/contents/.review.yml?ref=main',
+        {
+          token: 'ghs_test',
+          accept: 'application/vnd.github.raw+json',
+        },
+      );
+
+      expect(response.status).toBe(404);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -471,6 +471,37 @@ APPROVE`;
       expect(res.reason).toContain('timed out');
     });
 
+    it('leaves task in current state when GitHub posting fails during timeout', async () => {
+      await store.createTask(
+        makeTask({
+          id: 'task-fail-timeout',
+          timeout_at: Date.now() - 1000, // already expired
+          status: 'pending',
+        }),
+      );
+
+      // Override fetch to fail on installation token request with 401 (not retried)
+      const failingFetch = vi.fn(async (input: string | URL | Request) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+        // Fail on installation token request — simulates auth failure
+        if (url.includes('/access_tokens')) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
+        return new Response('Not Found', { status: 404 });
+      }) as typeof fetch;
+      globalThis.fetch = failingFetch;
+
+      // Trigger timeout check via poll
+      await poll('any-agent');
+
+      // Task should NOT be marked timeout — GitHub posting failed
+      const task = await store.getTask('task-fail-timeout');
+      expect(task?.status).toBe('pending');
+    });
+
     it('completed tasks are not affected by timeout checks', async () => {
       await store.createTask(
         makeTask({

--- a/packages/server/src/github/app.ts
+++ b/packages/server/src/github/app.ts
@@ -1,4 +1,5 @@
 import type { Env } from '../types.js';
+import { githubFetch } from './fetch.js';
 
 /**
  * Generate a JWT for GitHub App authentication.
@@ -58,16 +59,11 @@ function base64url(data: Uint8Array): string {
  */
 export async function getInstallationToken(installationId: number, env: Env): Promise<string> {
   const jwt = await generateAppJwt(env);
-  const response = await fetch(
+  const response = await githubFetch(
     `https://api.github.com/app/installations/${installationId}/access_tokens`,
     {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'OpenCara-Server',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+      token: jwt,
     },
   );
 

--- a/packages/server/src/github/config.ts
+++ b/packages/server/src/github/config.ts
@@ -1,4 +1,5 @@
 import { parseReviewConfig, DEFAULT_REVIEW_CONFIG, type ReviewConfig } from '@opencara/shared';
+import { githubFetch } from './fetch.js';
 import { postPrComment } from './reviews.js';
 
 /**
@@ -11,15 +12,11 @@ export async function fetchReviewConfig(
   ref: string,
   token: string,
 ): Promise<string | null> {
-  const response = await fetch(
+  const response = await githubFetch(
     `https://api.github.com/repos/${owner}/${repo}/contents/.review.yml?ref=${ref}`,
     {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github.raw+json',
-        'User-Agent': 'OpenCara-Server',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+      token,
+      accept: 'application/vnd.github.raw+json',
     },
   );
 
@@ -53,14 +50,10 @@ export async function fetchPrDetails(
   prNumber: number,
   token: string,
 ): Promise<PrDetails | null> {
-  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'OpenCara-Server',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-  });
+  const response = await githubFetch(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+    { token },
+  );
 
   if (!response.ok) {
     console.error(`Failed to fetch PR details: ${response.status} ${response.statusText}`);

--- a/packages/server/src/github/fetch.ts
+++ b/packages/server/src/github/fetch.ts
@@ -1,0 +1,68 @@
+const GITHUB_USER_AGENT = 'OpenCara-Server';
+const GITHUB_API_VERSION = '2022-11-28';
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export interface GitHubFetchOptions extends RequestInit {
+  token?: string;
+  accept?: string;
+}
+
+/**
+ * Centralized GitHub API fetch with retry on transient errors.
+ * Retries on 429 (rate limit) and 5xx (server errors) with exponential backoff.
+ * Does NOT retry 400/401/404 — these are not transient.
+ * Respects the Retry-After header when present.
+ */
+export async function githubFetch(
+  url: string,
+  options: GitHubFetchOptions = {},
+): Promise<Response> {
+  const { token, accept, ...fetchOptions } = options;
+
+  const headers: Record<string, string> = {
+    'User-Agent': GITHUB_USER_AGENT,
+    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    Accept: accept ?? 'application/vnd.github+json',
+    ...(fetchOptions.method === 'POST' ||
+    fetchOptions.method === 'PUT' ||
+    fetchOptions.method === 'PATCH'
+      ? { 'Content-Type': 'application/json' }
+      : {}),
+  };
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, { ...fetchOptions, headers });
+
+      if (response.ok) return response;
+
+      // Retry on transient errors only
+      if (response.status === 429 || response.status >= 500) {
+        if (attempt < MAX_RETRIES) {
+          const retryAfter = response.headers.get('Retry-After');
+          const delay = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : BASE_DELAY_MS * Math.pow(2, attempt);
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+      }
+
+      // Non-retryable error or retries exhausted
+      return response;
+    } catch (err) {
+      // Network errors are transient — retry
+      if (attempt < MAX_RETRIES) {
+        const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  // Unreachable — the loop always returns or throws
+  throw new Error('githubFetch: unreachable');
+}

--- a/packages/server/src/github/reviews.ts
+++ b/packages/server/src/github/reviews.ts
@@ -1,4 +1,5 @@
 import type { ReviewVerdict } from '@opencara/shared';
+import { githubFetch } from './fetch.js';
 
 export type ReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
 
@@ -38,17 +39,11 @@ export async function postPrReview(
     payload.comments = comments;
   }
 
-  const response = await fetch(
+  const response = await githubFetch(
     `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
     {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'OpenCara-Server',
-        'X-GitHub-Api-Version': '2022-11-28',
-        'Content-Type': 'application/json',
-      },
+      token,
       body: JSON.stringify(payload),
     },
   );
@@ -72,17 +67,11 @@ export async function postPrComment(
   body: string,
   token: string,
 ): Promise<string> {
-  const response = await fetch(
+  const response = await githubFetch(
     `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`,
     {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'OpenCara-Server',
-        'X-GitHub-Api-Version': '2022-11-28',
-        'Content-Type': 'application/json',
-      },
+      token,
       body: JSON.stringify({ body }),
     },
   );

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -16,6 +16,7 @@ import type {
 import type { Env } from '../types.js';
 import type { TaskStore } from '../store/interface.js';
 import { getInstallationToken } from '../github/app.js';
+import { githubFetch } from '../github/fetch.js';
 import { postPrReview, postPrComment, verdictToReviewEvent } from '../github/reviews.js';
 import { parseStructuredReview, parseDiffFiles, filterValidComments } from '../review-parser.js';
 import {
@@ -97,11 +98,13 @@ async function checkTimeouts(store: TaskStore, env: Env): Promise<void> {
         `**OpenCara**: Review timed out after ${Math.round((task.timeout_at - task.created_at) / 60000)} minutes.${completedReviews.length > 0 ? ` ${completedReviews.length} partial review(s) posted above.` : ''}`,
         token,
       );
-    } catch (err) {
-      console.error(`Failed to post timeout comment for task ${task.id}:`, err);
-    }
 
-    await store.updateTask(task.id, { status: 'timeout' });
+      // Only mark timeout AFTER posting succeeds — if posting fails,
+      // leave task in current state so next checkTimeouts() retries.
+      await store.updateTask(task.id, { status: 'timeout' });
+    } catch (err) {
+      console.error(`Failed to post timeout for task ${task.id}, will retry on next check:`, err);
+    }
   }
 }
 
@@ -160,24 +163,27 @@ async function postFinalReview(
     let validComments = parsed.comments;
     try {
       // Fetch diff from GitHub for comment path validation
-      const diffResponse = await fetch(
+      const diffResponse = await githubFetch(
         `https://api.github.com/repos/${task.owner}/${task.repo}/pulls/${task.pr_number}`,
         {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'application/vnd.github.diff',
-            'User-Agent': 'OpenCara-Server',
-            'X-GitHub-Api-Version': '2022-11-28',
-          },
+          token,
+          accept: 'application/vnd.github.diff',
         },
       );
       if (diffResponse.ok) {
         const diffContent = await diffResponse.text();
         const diffFiles = parseDiffFiles(diffContent);
         validComments = filterValidComments(parsed.comments, diffFiles);
+      } else {
+        console.warn(
+          `Failed to fetch diff for task ${taskId} (${diffResponse.status}) — skipping comment path validation`,
+        );
       }
-    } catch {
-      // Skip comment filtering if diff fetch fails
+    } catch (err) {
+      console.warn(
+        `Failed to fetch diff for task ${taskId} — skipping comment path validation:`,
+        err,
+      );
     }
 
     await postPrReview(


### PR DESCRIPTION
Closes #174

## Summary
- Created centralized `githubFetch` helper (`packages/server/src/github/fetch.ts`) with exponential backoff retry on 429/5xx, Retry-After header support, and network error retry (max 3 retries)
- Refactored all GitHub API calls in `app.ts`, `reviews.ts`, `config.ts`, and `tasks.ts` to use `githubFetch`, removing duplicated `User-Agent`/`X-GitHub-Api-Version`/header construction
- Fixed timeout handler: `updateTask(status: 'timeout')` now only runs after GitHub posting succeeds — failed posts leave task in current state for retry on next `checkTimeouts()` call
- Added `console.warn` when diff fetch fails in `postFinalReview` (was silently swallowed)
- Does NOT retry 400/401/403/404 — only transient errors

## Test plan
- 24 new unit tests for `githubFetch` covering headers, successful responses, non-retryable errors, retryable errors, network errors, and caller integration
- 1 new integration test verifying timeout handler leaves task in current state when GitHub posting fails
- All 378 existing tests pass
- `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` — all green