### PR TITLE
[cli-dev] Add review_only config to exclude agent from synthesis

### DIFF
--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -249,6 +249,84 @@ describe('agent poll loop', () => {
     });
   });
 
+  it('sends review_only in poll request when option is set', async () => {
+    let pollBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : String(url);
+
+      if (urlStr.includes('/api/tasks/poll')) {
+        pollBody = JSON.parse(init?.body as string);
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Unauthorized' }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      { pollIntervalMs: 100, reviewOnly: true },
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(pollBody).not.toBeNull();
+    expect(pollBody!.review_only).toBe(true);
+  });
+
+  it('does not send review_only when option is not set', async () => {
+    let pollBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : String(url);
+
+      if (urlStr.includes('/api/tasks/poll')) {
+        pollBody = JSON.parse(init?.body as string);
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Unauthorized' }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      { pollIntervalMs: 100 },
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(pollBody).not.toBeNull();
+    expect(pollBody!.review_only).toBeUndefined();
+  });
+
   it('resets auth counter on successful poll', async () => {
     let callCount = 0;
     globalThis.fetch = vi.fn().mockImplementation(() => {

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -589,6 +589,36 @@ anonymous_agents:
     });
   });
 
+  describe('agent review_only config', () => {
+    it('parses review_only: true from agent entries', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: gpt-5-codex
+    tool: codex
+    review_only: true
+  - model: claude-sonnet-4-6
+    tool: claude-code
+`);
+      const config = loadConfig();
+      expect(config.agents).toHaveLength(2);
+      expect(config.agents![0].review_only).toBe(true);
+      expect(config.agents![1].review_only).toBeUndefined();
+    });
+
+    it('ignores review_only: false', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-sonnet-4-6
+    tool: claude-code
+    review_only: false
+`);
+      const config = loadConfig();
+      expect(config.agents![0].review_only).toBeUndefined();
+    });
+  });
+
   describe('agent router config', () => {
     it('parses router: true from agent entries', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -70,10 +70,11 @@ async function pollLoop(
   options: {
     pollIntervalMs: number;
     routerRelay?: RouterRelay;
+    reviewOnly?: boolean;
     signal?: AbortSignal;
   },
 ): Promise<void> {
-  const { pollIntervalMs, routerRelay, signal } = options;
+  const { pollIntervalMs, routerRelay, reviewOnly, signal } = options;
 
   console.log(`Agent ${agentId} polling every ${pollIntervalMs / 1000}s...`);
 
@@ -83,9 +84,9 @@ async function pollLoop(
   while (!signal?.aborted) {
     try {
       // Poll for tasks
-      const pollResponse = await client.post<PollResponse>('/api/tasks/poll', {
-        agent_id: agentId,
-      });
+      const pollBody: Record<string, unknown> = { agent_id: agentId };
+      if (reviewOnly) pollBody.review_only = true;
+      const pollResponse = await client.post<PollResponse>('/api/tasks/poll', pollBody);
 
       consecutiveAuthErrors = 0;
       consecutiveErrors = 0;
@@ -488,7 +489,7 @@ export async function startAgent(
   agentInfo: { model: string; tool: string },
   reviewDeps?: ReviewExecutorDeps,
   consumptionDeps?: ConsumptionDeps,
-  options?: { pollIntervalMs?: number; routerRelay?: RouterRelay },
+  options?: { pollIntervalMs?: number; routerRelay?: RouterRelay; reviewOnly?: boolean },
 ): Promise<void> {
   const client = new ApiClient(platformUrl);
   const session = consumptionDeps?.session ?? createSessionTracker();
@@ -517,6 +518,7 @@ export async function startAgent(
   await pollLoop(client, agentId, reviewDeps, deps, agentInfo, {
     pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
     routerRelay: options?.routerRelay,
+    reviewOnly: options?.reviewOnly,
     signal: abortController.signal,
   });
 
@@ -570,6 +572,7 @@ export async function startAgentRouter(): Promise<void> {
     },
     {
       routerRelay: router,
+      reviewOnly: agentConfig?.review_only,
     },
   );
 
@@ -648,6 +651,7 @@ agentCommand
         {
           pollIntervalMs,
           routerRelay,
+          reviewOnly: agentConfig?.review_only,
         },
       );
     } finally {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -16,6 +16,7 @@ export interface LocalAgentConfig {
   name?: string;
   command?: string;
   router?: boolean;
+  review_only?: boolean;
   limits?: ConsumptionLimits;
   repos?: RepoConfig;
 }
@@ -182,6 +183,7 @@ function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
     if (typeof obj.name === 'string') agent.name = obj.name;
     if (typeof obj.command === 'string') agent.command = obj.command;
     if (obj.router === true) agent.router = true;
+    if (obj.review_only === true) agent.review_only = true;
     const agentLimits = parseLimits(obj);
     if (agentLimits) agent.limits = agentLimits;
     const repoConfig = parseRepoConfig(obj, i);

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -100,6 +100,50 @@ describe('Task Routes', () => {
       const res = await request('POST', '/api/tasks/poll', {});
       expect(res.status).toBe(400);
     });
+
+    it('skips summary tasks when review_only is true', async () => {
+      // review_count=1 → only summary role available
+      await store.createTask(makeTask());
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        review_only: true,
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('returns review tasks when review_only is true', async () => {
+      // review_count=3 → review role available
+      await store.createTask(makeTask({ review_count: 3 }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        review_only: true,
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('review');
+    });
+
+    it('returns both review and summary when review_only is not set', async () => {
+      await store.createTask(makeTask({ id: 'task-review', review_count: 3 }));
+      await store.createTask(makeTask({ id: 'task-summary', review_count: 1 }));
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+      const roles = body.tasks.map((t: { role: string }) => t.role).sort();
+      expect(roles).toEqual(['review', 'summary']);
+    });
+
+    it('returns summary tasks when review_only is false', async () => {
+      await store.createTask(makeTask());
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        review_only: false,
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('summary');
+    });
   });
 
   // ── Claim ────────────────────────────────────────────────

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -232,7 +232,7 @@ export function taskRoutes() {
   app.post('/api/tasks/poll', async (c) => {
     const store = c.get('store');
     const body = await c.req.json<PollRequest>();
-    const { agent_id } = body;
+    const { agent_id, review_only } = body;
 
     if (!agent_id) {
       return c.json({ error: 'agent_id is required' }, 400);
@@ -251,6 +251,7 @@ export function taskRoutes() {
     for (const task of tasks) {
       const role = availableRole(task, agent_id);
       if (!role) continue;
+      if (review_only && role === 'summary') continue;
 
       const remainingMs = task.timeout_at - Date.now();
       if (remainingMs <= 0) continue;

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -5,6 +5,7 @@ import type { ClaimRole, ReviewVerdict } from './types.js';
 /** POST /api/tasks/poll — request */
 export interface PollRequest {
   agent_id: string;
+  review_only?: boolean;
 }
 
 /** A task returned in the poll response */


### PR DESCRIPTION
Closes #165

## Summary
- Add `review_only?: boolean` to `PollRequest` in shared types
- Server poll endpoint skips summary-role tasks when `review_only: true`
- CLI config parses `review_only` from YAML agent entries
- CLI agent loop sends `review_only` flag in poll request body
- Tests cover all paths: server filtering, config parsing, agent poll body

## Test plan
- [x] Server: poll with `review_only: true` skips tasks where only summary role is available
- [x] Server: poll with `review_only: true` still returns tasks where review role is available
- [x] Server: poll without `review_only` returns both review and summary tasks
- [x] Server: poll with `review_only: false` returns summary tasks (explicit false)
- [x] CLI: `review_only: true` parsed from YAML config
- [x] CLI: `review_only: false` ignored (defaults to undefined)
- [x] CLI: `review_only` sent in poll request body when set
- [x] CLI: `review_only` not sent in poll request when not set
- [x] Build, lint, format, typecheck all pass
- [x] All 408 tests pass