### PR TITLE
feat: add comprehensive E2E test suite with test infrastructure

### DIFF
--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -1,0 +1,726 @@
+/**
+ * E2E scenario tests — simulate real agent behavior against the server.
+ *
+ * Uses test routes to inject PR events (no webhook signatures needed)
+ * and MockAgent to simulate agent HTTP interactions.
+ *
+ * Mocks only the external boundary (GitHub API via global fetch).
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import { MemoryTaskStore } from '../store/memory.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+import type { Env } from '../types.js';
+import { createTestApp } from './helpers/test-server.js';
+import { createGitHubMock } from './helpers/github-mock.js';
+import { MockAgent } from './helpers/mock-agent.js';
+
+// ── Setup ────────────────────────────────────────────────────
+
+let TEST_PEM: string;
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  TEST_PEM = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+function getMockEnv(): Env {
+  return {
+    GITHUB_WEBHOOK_SECRET: 'test-secret',
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: TEST_PEM,
+    TASK_STORE: {} as KVNamespace,
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+describe('E2E Scenarios', () => {
+  let store: MemoryTaskStore;
+  let app: ReturnType<typeof createTestApp>;
+  let env: Env;
+  let github: ReturnType<typeof createGitHubMock>;
+
+  /** Helper: inject a PR event via test routes. */
+  async function injectPR(opts?: {
+    owner?: string;
+    repo?: string;
+    prNumber?: number;
+    reviewCount?: number;
+    timeout?: string;
+  }): Promise<string> {
+    const config = {
+      ...DEFAULT_REVIEW_CONFIG,
+      agents: {
+        ...DEFAULT_REVIEW_CONFIG.agents,
+        reviewCount: opts?.reviewCount ?? 1,
+      },
+      ...(opts?.timeout ? { timeout: opts.timeout } : {}),
+    };
+
+    const res = await app.request(
+      '/test/events/pr',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          owner: opts?.owner ?? 'test-org',
+          repo: opts?.repo ?? 'test-repo',
+          pr_number: opts?.prNumber ?? 1,
+          config,
+        }),
+      },
+      env,
+    );
+    const body = (await res.json()) as { created: boolean; task_id?: string };
+    expect(body.created).toBe(true);
+    return body.task_id!;
+  }
+
+  /** Create a MockAgent bound to the test app. */
+  function agent(id: string): MockAgent {
+    return new MockAgent(id, app, env);
+  }
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    store = new MemoryTaskStore();
+    app = createTestApp(store);
+    env = getMockEnv();
+    github = createGitHubMock();
+    github.install();
+  });
+
+  afterEach(() => {
+    github.restore();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // A. Single-Agent Lifecycle
+  // ═══════════════════════════════════════════════════════════
+
+  describe('A. Single-Agent Lifecycle', () => {
+    it('PR event → poll → claim summary → submit → GitHub review posted', async () => {
+      const taskId = await injectPR();
+      const a = agent('solo-agent');
+
+      // Poll — sees task with summary role
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].task_id).toBe(taskId);
+      expect(tasks[0].role).toBe('summary');
+
+      // Claim
+      const claimRes = await a.claim(taskId, 'summary');
+      expect(claimRes.claimed).toBe(true);
+      if (claimRes.claimed) {
+        expect(claimRes.reviews).toEqual([]); // No prior reviews in single-agent
+      }
+
+      // Verify task is now reviewing
+      const task = await store.getTask(taskId);
+      expect(task?.status).toBe('reviewing');
+
+      // Submit result
+      const result = await a.submitResult(
+        taskId,
+        'summary',
+        '## Summary\nLooks good.\n\n## Verdict\nAPPROVE',
+        'approve',
+        1000,
+      );
+      expect(result.status).toBe(200);
+      expect(result.body.success).toBe(true);
+
+      // Task completed
+      const finalTask = await store.getTask(taskId);
+      expect(['completed', 'failed']).toContain(finalTask?.status);
+
+      // GitHub review was posted
+      const reviewPost = github.calls.find(
+        (c) => c.url.includes('/reviews') && c.method === 'POST',
+      );
+      expect(reviewPost).toBeDefined();
+
+      // No more tasks for polling
+      const empty = await a.poll();
+      expect(empty).toHaveLength(0);
+    });
+
+    it('second agent sees nothing after task is claimed', async () => {
+      const taskId = await injectPR();
+      const a1 = agent('agent-1');
+      const a2 = agent('agent-2');
+
+      await a1.claim(taskId, 'summary');
+      const tasks = await a2.poll();
+      expect(tasks).toHaveLength(0);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // B. Multi-Agent Lifecycle
+  // ═══════════════════════════════════════════════════════════
+
+  describe('B. Multi-Agent Lifecycle', () => {
+    it('2 reviewers → submit → synthesizer claims with reviews → submits → posted', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const r1 = agent('reviewer-1');
+      const r2 = agent('reviewer-2');
+      const synth = agent('synthesizer');
+
+      // Both reviewers poll — see review role
+      const r1Tasks = await r1.poll();
+      expect(r1Tasks[0].role).toBe('review');
+      const r2Tasks = await r2.poll();
+      expect(r2Tasks[0].role).toBe('review');
+
+      // Both claim review
+      const c1 = await r1.claim(taskId, 'review');
+      expect(c1.claimed).toBe(true);
+      const c2 = await r2.claim(taskId, 'review');
+      expect(c2.claimed).toBe(true);
+
+      // Synthesizer polls — nothing yet (reviews not complete)
+      let synthTasks = await synth.poll();
+      expect(synthTasks).toHaveLength(0);
+
+      // Reviewer 1 submits
+      await r1.submitResult(taskId, 'review', 'Review 1: LGTM', 'approve', 500);
+
+      // Still no summary (only 1 of 2 reviews done)
+      synthTasks = await synth.poll();
+      expect(synthTasks).toHaveLength(0);
+
+      // Reviewer 2 submits
+      await r2.submitResult(taskId, 'review', 'Review 2: Needs work', 'request_changes', 600);
+
+      // Summary now available
+      synthTasks = await synth.poll();
+      expect(synthTasks).toHaveLength(1);
+      expect(synthTasks[0].role).toBe('summary');
+
+      // Synthesizer claims — receives prior reviews
+      const synthClaim = await synth.claim(taskId, 'summary');
+      expect(synthClaim.claimed).toBe(true);
+      if (synthClaim.claimed) {
+        expect(synthClaim.reviews).toHaveLength(2);
+        const agents = synthClaim.reviews!.map((r) => r.agent_id).sort();
+        expect(agents).toEqual(['reviewer-1', 'reviewer-2']);
+      }
+
+      // Synthesizer submits
+      const result = await synth.submitResult(
+        taskId,
+        'summary',
+        '## Summary\nSynthesized.\n\n## Verdict\nCOMMENT',
+        undefined,
+        900,
+      );
+      expect(result.status).toBe(200);
+
+      // All claims completed
+      const claims = await store.getClaims(taskId);
+      expect(claims).toHaveLength(3);
+      expect(claims.filter((c) => c.status === 'completed')).toHaveLength(3);
+    });
+
+    it('third agent cannot claim review when all slots taken', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a1 = agent('a1');
+      const a2 = agent('a2');
+      const a3 = agent('a3');
+
+      await a1.claim(taskId, 'review');
+      await a2.claim(taskId, 'review');
+
+      const c3 = await a3.claim(taskId, 'review');
+      expect(c3.claimed).toBe(false);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // C. Rejection & Reclaim
+  // ═══════════════════════════════════════════════════════════
+
+  describe('C. Rejection & Reclaim', () => {
+    it('claim → reject → slot freed → new agent claims → completes', async () => {
+      const taskId = await injectPR();
+      const a1 = agent('agent-1');
+      const a2 = agent('agent-2');
+
+      // Agent 1 claims and rejects
+      await a1.claim(taskId, 'summary');
+      const rejectRes = await a1.reject(taskId, 'Cannot access diff');
+      expect(rejectRes.status).toBe(200);
+
+      // Slot freed — agent 2 can claim
+      const tasks = await a2.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].role).toBe('summary');
+
+      const c2 = await a2.claim(taskId, 'summary');
+      expect(c2.claimed).toBe(true);
+
+      // Agent 2 completes
+      const result = await a2.submitResult(taskId, 'summary', 'Done.', 'approve');
+      expect(result.status).toBe(200);
+    });
+
+    it('review reject in multi-agent flow → new agent takes freed slot', async () => {
+      const taskId = await injectPR({ reviewCount: 2 });
+      const a1 = agent('reviewer-1');
+      const a2 = agent('reviewer-2');
+
+      // Agent 1 claims review, then rejects
+      await a1.claim(taskId, 'review');
+      await a1.reject(taskId, 'Diff too large');
+
+      // Agent 2 claims the freed review slot
+      const tasks = await a2.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].role).toBe('review');
+
+      const c2 = await a2.claim(taskId, 'review');
+      expect(c2.claimed).toBe(true);
+    });
+
+    it('same agent can re-claim after rejection', async () => {
+      const taskId = await injectPR();
+      const a = agent('retry-agent');
+
+      await a.claim(taskId, 'summary');
+      await a.reject(taskId, 'Transient error');
+
+      // Same agent polls again and re-claims
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(1);
+
+      const c = await a.claim(taskId, 'summary');
+      expect(c.claimed).toBe(true);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // D. Error Recovery
+  // ═══════════════════════════════════════════════════════════
+
+  describe('D. Error Recovery', () => {
+    it('claim → error → slot freed → new agent claims → completes', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const crasher = agent('crasher');
+      const replacement = agent('replacement');
+
+      // Agent crashes
+      await crasher.claim(taskId, 'review');
+      const errRes = await crasher.reportError(taskId, 'SIGSEGV');
+      expect(errRes.status).toBe(200);
+
+      // Slot freed
+      const task = await store.getTask(taskId);
+      expect(task?.review_claims).toBe(0);
+      expect(task?.claimed_agents).toEqual([]);
+
+      // Replacement agent claims
+      const tasks = await replacement.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].role).toBe('review');
+
+      const c = await replacement.claim(taskId, 'review');
+      expect(c.claimed).toBe(true);
+    });
+
+    it('summary error frees summary slot', async () => {
+      const taskId = await injectPR();
+      const a1 = agent('err-agent');
+      const a2 = agent('recovery-agent');
+
+      await a1.claim(taskId, 'summary');
+      await a1.reportError(taskId, 'OOM');
+
+      const task = await store.getTask(taskId);
+      expect(task?.summary_claimed).toBe(false);
+
+      const tasks = await a2.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].role).toBe('summary');
+
+      const c = await a2.claim(taskId, 'summary');
+      expect(c.claimed).toBe(true);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // E. Concurrent Claims
+  // ═══════════════════════════════════════════════════════════
+
+  describe('E. Concurrent Claims', () => {
+    it('multiple agents claim same summary slot → only first succeeds', async () => {
+      const taskId = await injectPR();
+      const agents = [agent('fast'), agent('medium'), agent('slow')];
+
+      const results = [];
+      for (const a of agents) {
+        results.push(await a.claim(taskId, 'summary'));
+      }
+
+      const claimed = results.filter((r) => r.claimed);
+      const rejected = results.filter((r) => !r.claimed);
+      expect(claimed).toHaveLength(1);
+      expect(rejected).toHaveLength(2);
+    });
+
+    it('multiple agents can claim different review slots', async () => {
+      const taskId = await injectPR({ reviewCount: 4 });
+      const agents = [agent('a1'), agent('a2'), agent('a3')];
+
+      const results = [];
+      for (const a of agents) {
+        results.push(await a.claim(taskId, 'review'));
+      }
+
+      // All 3 should succeed (3 review slots for review_count=4)
+      expect(results.every((r) => r.claimed)).toBe(true);
+
+      // Fourth agent rejected
+      const a4 = agent('a4');
+      const c4 = await a4.claim(taskId, 'review');
+      expect(c4.claimed).toBe(false);
+    });
+
+    it('same agent cannot double-claim', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a = agent('greedy');
+
+      const c1 = await a.claim(taskId, 'review');
+      expect(c1.claimed).toBe(true);
+
+      const c2 = await a.claim(taskId, 'review');
+      expect(c2.claimed).toBe(false);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // F. Timeout with Partial Results
+  // ═══════════════════════════════════════════════════════════
+
+  describe('F. Timeout with Partial Results', () => {
+    it('some reviewers complete, timeout fires → partial results posted', async () => {
+      // Create task that's already expired
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        agents: { ...DEFAULT_REVIEW_CONFIG.agents, reviewCount: 3 },
+      };
+
+      const res = await app.request(
+        '/test/events/pr',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            owner: 'test-org',
+            repo: 'test-repo',
+            pr_number: 100,
+            config,
+          }),
+        },
+        env,
+      );
+      const { task_id: taskId } = (await res.json()) as { task_id: string };
+
+      // Simulate: one reviewer completed, then task expires
+      const r1 = agent('reviewer-1');
+      await r1.claim(taskId, 'review');
+      await r1.submitResult(taskId, 'review', 'Partial review content', 'comment', 300);
+
+      // Manually expire the task
+      await store.updateTask(taskId, { timeout_at: Date.now() - 1000 });
+
+      // Any agent polling triggers timeout check
+      const poller = agent('poller');
+      await poller.poll();
+
+      // Task should be timed out
+      const task = await store.getTask(taskId);
+      expect(task?.status).toBe('timeout');
+
+      // Partial review should have been posted
+      const reviewPosts = github.calls.filter(
+        (c) => c.url.includes('/reviews') && c.method === 'POST',
+      );
+      expect(reviewPosts.length).toBeGreaterThanOrEqual(1);
+
+      // Timeout comment should have been posted
+      const commentPosts = github.calls.filter(
+        (c) => c.url.includes('/issues/') && c.url.includes('/comments') && c.method === 'POST',
+      );
+      expect(commentPosts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('claim rejected for expired task', async () => {
+      const taskId = await injectPR();
+      await store.updateTask(taskId, { timeout_at: Date.now() - 1000 });
+
+      const a = agent('late-agent');
+      const c = await a.claim(taskId, 'summary');
+      expect(c.claimed).toBe(false);
+      if (!c.claimed) {
+        expect(c.reason).toContain('timed out');
+      }
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // G. Webhook Idempotency (via test routes)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('G. Webhook Idempotency', () => {
+    it('same PR event twice → only one task', async () => {
+      await injectPR({ prNumber: 42 });
+
+      // Second injection — should not create duplicate
+      const res = await app.request(
+        '/test/events/pr',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pr_number: 42 }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { created: boolean };
+      expect(body.created).toBe(false);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+
+    it('different PRs create separate tasks', async () => {
+      await injectPR({ prNumber: 10 });
+      await injectPR({ prNumber: 11 });
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+    });
+
+    it('new task allowed after previous reached terminal state', async () => {
+      const taskId = await injectPR({ prNumber: 50 });
+      await store.updateTask(taskId, { status: 'completed' });
+
+      // New event for same PR — should create new task
+      const newTaskId = await injectPR({ prNumber: 50 });
+      expect(newTaskId).not.toBe(taskId);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // H. Eligibility Filtering
+  // ═══════════════════════════════════════════════════════════
+
+  describe('H. Eligibility Filtering', () => {
+    it('task with review_count=1 only offers summary role', async () => {
+      const taskId = await injectPR({ reviewCount: 1 });
+      const a = agent('agent');
+
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].role).toBe('summary');
+
+      // Trying to claim review should fail
+      const c = await a.claim(taskId, 'review');
+      expect(c.claimed).toBe(false);
+    });
+
+    it('completed/timed-out/failed tasks excluded from poll', async () => {
+      const t1 = await injectPR({ prNumber: 1 });
+      const t2 = await injectPR({ prNumber: 2 });
+      const t3 = await injectPR({ prNumber: 3 });
+      await injectPR({ prNumber: 4 }); // stays active
+
+      await store.updateTask(t1, { status: 'completed' });
+      await store.updateTask(t2, { status: 'timeout' });
+      await store.updateTask(t3, { status: 'failed' });
+
+      const a = agent('filter-agent');
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].pr_number).toBe(4);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // I. Role Validation
+  // ═══════════════════════════════════════════════════════════
+
+  describe('I. Role Validation', () => {
+    it('review claimer cannot submit as summary', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a = agent('confused-agent');
+
+      await a.claim(taskId, 'review');
+      const result = await a.submitResult(taskId, 'summary', 'Synthesized review');
+      expect(result.status).toBe(400);
+      expect(result.body.error).toContain("does not match submission type 'summary'");
+    });
+
+    it('summary claimer cannot submit as review', async () => {
+      const taskId = await injectPR({ reviewCount: 1 });
+      const a = agent('confused-agent');
+
+      await a.claim(taskId, 'summary');
+      const result = await a.submitResult(taskId, 'review', 'Individual review');
+      expect(result.status).toBe(400);
+      expect(result.body.error).toContain("does not match submission type 'review'");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // J. review_only Flag
+  // ═══════════════════════════════════════════════════════════
+
+  describe('J. review_only Flag', () => {
+    it('agent with review_only sees only review tasks, not summary', async () => {
+      // review_count=1 → only summary role
+      await injectPR({ prNumber: 1, reviewCount: 1 });
+      // review_count=3 → review role
+      await injectPR({ prNumber: 2, reviewCount: 3 });
+
+      const a = agent('review-only-agent');
+
+      // With review_only: should only see the review task
+      const reviewTasks = await a.poll({ reviewOnly: true });
+      expect(reviewTasks).toHaveLength(1);
+      expect(reviewTasks[0].pr_number).toBe(2);
+      expect(reviewTasks[0].role).toBe('review');
+    });
+
+    it('agent without review_only sees both review and summary tasks', async () => {
+      await injectPR({ prNumber: 1, reviewCount: 1 }); // summary only
+      await injectPR({ prNumber: 2, reviewCount: 3 }); // review
+
+      const a = agent('any-agent');
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(2);
+
+      const roles = tasks.map((t) => t.role).sort();
+      expect(roles).toEqual(['review', 'summary']);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // K. State Machine
+  // ═══════════════════════════════════════════════════════════
+
+  describe('K. State Machine', () => {
+    it('cannot reject a completed claim', async () => {
+      const taskId = await injectPR();
+      const a = agent('agent');
+
+      await a.claim(taskId, 'summary');
+      await a.submitResult(taskId, 'summary', 'Done.', 'approve');
+
+      const rejectRes = await a.reject(taskId, 'Too late');
+      expect(rejectRes.status).toBe(409);
+    });
+
+    it('cannot error a completed claim', async () => {
+      const taskId = await injectPR();
+      const a = agent('agent');
+
+      await a.claim(taskId, 'summary');
+      await a.submitResult(taskId, 'summary', 'Done.', 'approve');
+
+      const errRes = await a.reportError(taskId, 'Crash');
+      expect(errRes.status).toBe(409);
+    });
+
+    it('idempotent reject — double reject returns 200', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a = agent('agent');
+
+      await a.claim(taskId, 'review');
+      const r1 = await a.reject(taskId, 'First');
+      expect(r1.status).toBe(200);
+
+      const r2 = await a.reject(taskId, 'Second');
+      expect(r2.status).toBe(200);
+    });
+
+    it('idempotent error — double error returns 200', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a = agent('agent');
+
+      await a.claim(taskId, 'review');
+      const e1 = await a.reportError(taskId, 'Crash 1');
+      expect(e1.status).toBe(200);
+
+      const e2 = await a.reportError(taskId, 'Crash 2');
+      expect(e2.status).toBe(200);
+    });
+
+    it('cannot submit result twice on same claim', async () => {
+      const taskId = await injectPR();
+      const a = agent('agent');
+
+      await a.claim(taskId, 'summary');
+      const r1 = await a.submitResult(taskId, 'summary', 'First');
+      expect(r1.status).toBe(200);
+
+      const r2 = await a.submitResult(taskId, 'summary', 'Second');
+      expect(r2.status).toBe(409);
+    });
+
+    it('claim on completed task is rejected', async () => {
+      const taskId = await injectPR();
+      const a1 = agent('agent-1');
+      const a2 = agent('agent-2');
+
+      await a1.claim(taskId, 'summary');
+      await a1.submitResult(taskId, 'summary', 'Done', 'approve');
+
+      const c = await a2.claim(taskId, 'summary');
+      expect(c.claimed).toBe(false);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Test Routes Verification
+  // ═══════════════════════════════════════════════════════════
+
+  describe('Test Routes', () => {
+    it('POST /test/reset clears all data', async () => {
+      await injectPR({ prNumber: 1 });
+      await injectPR({ prNumber: 2 });
+
+      let tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+
+      await app.request(
+        '/test/reset',
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
+        env,
+      );
+
+      tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('GET /test/tasks returns all tasks', async () => {
+      await injectPR({ prNumber: 1 });
+      await injectPR({ prNumber: 2 });
+
+      const res = await app.request('/test/tasks', { method: 'GET' }, env);
+      const body = (await res.json()) as { tasks: unknown[] };
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('GET /test/claims/:taskId returns claims for a task', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const a = agent('agent');
+      await a.claim(taskId, 'review');
+
+      const res = await app.request(`/test/claims/${taskId}`, { method: 'GET' }, env);
+      const body = (await res.json()) as { claims: unknown[] };
+      expect(body.claims).toHaveLength(1);
+    });
+  });
+});

--- a/packages/server/src/__tests__/helpers/github-mock.ts
+++ b/packages/server/src/__tests__/helpers/github-mock.ts
@@ -1,0 +1,128 @@
+/**
+ * Reusable GitHub API fetch mock for tests.
+ *
+ * Intercepts globalThis.fetch and routes GitHub API calls to stub responses.
+ * Tracks all calls for assertion.
+ */
+import { vi } from 'vitest';
+
+export interface GitHubCall {
+  url: string;
+  method: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export interface GitHubMock {
+  /** All intercepted GitHub API calls, in order. */
+  calls: GitHubCall[];
+  /** Install the mock (replace globalThis.fetch). Call in beforeEach. */
+  install(): void;
+  /** Restore original fetch. Call in afterEach. */
+  restore(): void;
+}
+
+/**
+ * Create a GitHub API fetch mock.
+ *
+ * Handles:
+ * - Installation access tokens
+ * - .review.yml fetch (returns 404 → defaults)
+ * - PR review posting
+ * - PR comment posting
+ * - PR diff fetching
+ * - PR details fetching
+ */
+export function createGitHubMock(): GitHubMock {
+  const originalFetch = globalThis.fetch;
+  const calls: GitHubCall[] = [];
+
+  function install(): void {
+    calls.length = 0;
+
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      const headers = init?.headers as Record<string, string> | undefined;
+
+      const call: GitHubCall = { url, method };
+      if (init?.body) {
+        try {
+          call.body = JSON.parse(init.body as string);
+        } catch {
+          call.body = init.body;
+        }
+      }
+      if (headers) call.headers = headers;
+      calls.push(call);
+
+      // Installation token
+      if (url.includes('/access_tokens')) {
+        return new Response(JSON.stringify({ token: 'ghs_mock_token' }), { status: 200 });
+      }
+
+      // Fetch .review.yml — return 404 (use defaults)
+      if (url.includes('/contents/.review.yml')) {
+        return new Response('Not Found', { status: 404 });
+      }
+
+      // Post PR review
+      if (url.includes('/pulls/') && url.includes('/reviews') && method === 'POST') {
+        return new Response(
+          JSON.stringify({ html_url: 'https://github.com/test/repo/pull/1#review-123' }),
+          { status: 200 },
+        );
+      }
+
+      // Post PR comment (issue comment)
+      if (url.includes('/issues/') && url.includes('/comments') && method === 'POST') {
+        return new Response(
+          JSON.stringify({ html_url: 'https://github.com/test/repo/pull/1#comment-456' }),
+          { status: 200 },
+        );
+      }
+
+      // Fetch PR diff (for comment validation in postFinalReview)
+      if (
+        url.includes('/pulls/') &&
+        !url.includes('/reviews') &&
+        !url.includes('/comments') &&
+        headers?.Accept === 'application/vnd.github.diff'
+      ) {
+        return new Response(
+          'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts',
+          { status: 200 },
+        );
+      }
+
+      // Fetch PR details (for issue_comment trigger)
+      if (url.includes('/pulls/') && !url.includes('/reviews') && method === 'GET') {
+        // Extract PR number from URL
+        const prMatch = url.match(/\/pulls\/(\d+)/);
+        const prNumber = prMatch ? parseInt(prMatch[1], 10) : 1;
+        return new Response(
+          JSON.stringify({
+            number: prNumber,
+            html_url: `https://github.com/test/repo/pull/${prNumber}`,
+            diff_url: `https://github.com/test/repo/pull/${prNumber}.diff`,
+            base: { ref: 'main' },
+            head: { ref: 'feat/test' },
+            draft: false,
+            labels: [],
+          }),
+          { status: 200 },
+        );
+      }
+
+      // Default 404
+      return new Response('Not Found', { status: 404 });
+    }) as typeof fetch;
+  }
+
+  function restore(): void {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  }
+
+  return { calls, install, restore };
+}

--- a/packages/server/src/__tests__/helpers/mock-agent.ts
+++ b/packages/server/src/__tests__/helpers/mock-agent.ts
@@ -1,0 +1,147 @@
+/**
+ * MockAgent — simulates a CLI agent's HTTP interactions with the server.
+ *
+ * Wraps Hono's app.request() calls into agent-like methods:
+ * poll, claim, submitResult, reject, reportError, pollAndClaim.
+ */
+import type { Hono } from 'hono';
+import type {
+  PollResponse,
+  PollTask,
+  ClaimResponse,
+  ClaimRole,
+  ReviewVerdict,
+} from '@opencara/shared';
+import type { Env, AppVariables } from '../../types.js';
+
+type HonoApp = Hono<{ Bindings: Env; Variables: AppVariables }>;
+
+export class MockAgent {
+  constructor(
+    public readonly agentId: string,
+    private app: HonoApp,
+    private env: Env,
+  ) {}
+
+  private request(method: string, path: string, body?: unknown) {
+    return this.app.request(
+      path,
+      {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      },
+      this.env,
+    );
+  }
+
+  /** Poll for available tasks. */
+  async poll(opts?: { reviewOnly?: boolean }): Promise<PollTask[]> {
+    const res = await this.request('POST', '/api/tasks/poll', {
+      agent_id: this.agentId,
+      review_only: opts?.reviewOnly,
+    });
+    const body = (await res.json()) as PollResponse;
+    return body.tasks;
+  }
+
+  /** Claim a task with a specific role. */
+  async claim(
+    taskId: string,
+    role: ClaimRole,
+    opts?: { model?: string; tool?: string },
+  ): Promise<ClaimResponse> {
+    const res = await this.request('POST', `/api/tasks/${taskId}/claim`, {
+      agent_id: this.agentId,
+      role,
+      model: opts?.model,
+      tool: opts?.tool,
+    });
+    return (await res.json()) as ClaimResponse;
+  }
+
+  /** Submit a review result. Returns status and parsed body. */
+  async submitResult(
+    taskId: string,
+    type: ClaimRole,
+    reviewText: string,
+    verdict?: ReviewVerdict,
+    tokensUsed?: number,
+  ): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await this.request('POST', `/api/tasks/${taskId}/result`, {
+      agent_id: this.agentId,
+      type,
+      review_text: reviewText,
+      verdict,
+      tokens_used: tokensUsed,
+    });
+    return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+  }
+
+  /** Reject a claimed task. */
+  async reject(taskId: string, reason: string): Promise<{ status: number }> {
+    const res = await this.request('POST', `/api/tasks/${taskId}/reject`, {
+      agent_id: this.agentId,
+      reason,
+    });
+    return { status: res.status };
+  }
+
+  /** Report an error on a claimed task. */
+  async reportError(taskId: string, error: string): Promise<{ status: number }> {
+    const res = await this.request('POST', `/api/tasks/${taskId}/error`, {
+      agent_id: this.agentId,
+      error,
+    });
+    return { status: res.status };
+  }
+
+  /**
+   * Convenience: poll and claim the first available task.
+   * Returns null if no tasks are available.
+   */
+  async pollAndClaim(
+    role?: ClaimRole,
+  ): Promise<{ taskId: string; claimResponse: ClaimResponse } | null> {
+    const tasks = await this.poll(role === 'review' ? { reviewOnly: true } : undefined);
+    if (tasks.length === 0) return null;
+
+    const task = tasks[0];
+    const taskRole = role ?? (task.role as ClaimRole);
+    const claimResponse = await this.claim(task.task_id, taskRole);
+    return { taskId: task.task_id, claimResponse };
+  }
+
+  /** Inject a PR event via test routes (bypasses webhook signature). */
+  async injectPR(opts?: {
+    owner?: string;
+    repo?: string;
+    prNumber?: number;
+    reviewCount?: number;
+    timeout?: string;
+  }): Promise<{ created: boolean; taskId?: string }> {
+    const config =
+      opts?.reviewCount || opts?.timeout
+        ? {
+            agents: {
+              ...{
+                reviewCount: opts.reviewCount ?? 1,
+                preferredModels: [],
+                preferredTools: [],
+                minReputation: 0,
+              },
+            },
+            ...(opts.timeout ? { timeout: opts.timeout } : {}),
+          }
+        : undefined;
+
+    const res = await this.request('POST', '/test/events/pr', {
+      owner: opts?.owner ?? 'test-org',
+      repo: opts?.repo ?? 'test-repo',
+      pr_number: opts?.prNumber ?? 1,
+      config,
+    });
+    const body = (await res.json()) as { created: boolean; task_id?: string };
+    return { created: body.created, taskId: body.task_id };
+  }
+}

--- a/packages/server/src/__tests__/helpers/test-server.ts
+++ b/packages/server/src/__tests__/helpers/test-server.ts
@@ -1,0 +1,49 @@
+/**
+ * Test server factory — creates a Hono app with test routes mounted.
+ */
+import { Hono } from 'hono';
+import type { Env, AppVariables } from '../../types.js';
+import type { TaskStore } from '../../store/interface.js';
+import { webhookRoutes } from '../../routes/webhook.js';
+import { taskRoutes } from '../../routes/tasks.js';
+import { registryRoutes } from '../../routes/registry.js';
+import { testRoutes } from '../../routes/test.js';
+
+type HonoApp = Hono<{ Bindings: Env; Variables: AppVariables }>;
+
+/**
+ * Create a Hono app with test routes mounted.
+ * Unlike `createApp()` from index.ts, this also mounts `/test/*` endpoints
+ * that bypass webhook signature verification.
+ */
+export function createTestApp(store: TaskStore): HonoApp {
+  const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+  // Inject store
+  app.use('*', async (c, next) => {
+    c.set('store', store);
+    await next();
+  });
+
+  // Health check
+  app.get('/', (c) => c.json({ status: 'ok', service: 'opencara-server' }));
+
+  // Production routes
+  app.route('/', webhookRoutes());
+  app.route('/', taskRoutes());
+  app.route('/', registryRoutes());
+
+  // Test-only routes
+  app.route('/', testRoutes());
+
+  // 404
+  app.notFound((c) => c.json({ error: 'Not Found' }, 404));
+
+  // Error handler
+  app.onError((err, c) => {
+    console.error('Unhandled error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  });
+
+  return app;
+}

--- a/packages/server/src/routes/test.ts
+++ b/packages/server/src/routes/test.ts
@@ -1,0 +1,99 @@
+/**
+ * Test-only API routes — bypass webhook signature verification.
+ * Only mounted by createTestApp(), never in production.
+ */
+import { Hono } from 'hono';
+import type { ReviewConfig } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import type { Env, AppVariables } from '../types.js';
+import { MemoryTaskStore } from '../store/memory.js';
+import { createTaskForPR } from './webhook.js';
+import { resetTimeoutThrottle } from './tasks.js';
+
+export function testRoutes() {
+  const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+
+  /**
+   * POST /test/events/pr — Inject a PR event without webhook signature.
+   * Accepts optional `config` to override review config (merged with defaults).
+   */
+  app.post('/test/events/pr', async (c) => {
+    const store = c.get('store');
+    const body = await c.req.json<{
+      owner?: string;
+      repo?: string;
+      pr_number?: number;
+      action?: string;
+      installation_id?: number;
+      base_ref?: string;
+      head_ref?: string;
+      draft?: boolean;
+      labels?: string[];
+      config?: Partial<ReviewConfig>;
+    }>();
+
+    const owner = body.owner ?? 'test-org';
+    const repo = body.repo ?? 'test-repo';
+    const prNumber = body.pr_number ?? 1;
+    const installationId = body.installation_id ?? 999;
+    const baseRef = body.base_ref ?? 'main';
+    const headRef = body.head_ref ?? 'feat/test';
+
+    // Merge config with defaults
+    const config: ReviewConfig = body.config
+      ? { ...DEFAULT_REVIEW_CONFIG, ...body.config }
+      : DEFAULT_REVIEW_CONFIG;
+
+    const taskId = await createTaskForPR(
+      store,
+      installationId,
+      owner,
+      repo,
+      prNumber,
+      `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+      `https://github.com/${owner}/${repo}/pull/${prNumber}.diff`,
+      baseRef,
+      headRef,
+      config,
+    );
+
+    if (!taskId) {
+      return c.json({ created: false, reason: 'Active task already exists for this PR' }, 200);
+    }
+
+    return c.json({ created: true, task_id: taskId }, 201);
+  });
+
+  /**
+   * POST /test/reset — Clear all tasks, claims, and agents. Reset throttle.
+   */
+  app.post('/test/reset', async (c) => {
+    const store = c.get('store');
+    if (store instanceof MemoryTaskStore) {
+      store.reset();
+    }
+    resetTimeoutThrottle();
+    return c.json({ success: true });
+  });
+
+  /**
+   * GET /test/tasks — List all tasks (debug view).
+   */
+  app.get('/test/tasks', async (c) => {
+    const store = c.get('store');
+    const tasks = await store.listTasks();
+    return c.json({ tasks });
+  });
+
+  /**
+   * GET /test/claims/:taskId — List all claims for a task.
+   */
+  app.get('/test/claims/:taskId', async (c) => {
+    const store = c.get('store');
+    const taskId = c.req.param('taskId');
+    const claims = await store.getClaims(taskId);
+    return c.json({ claims });
+  });
+
+  return app;
+}

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -88,7 +88,7 @@ function hexToBytes(hex: string): Uint8Array | null {
  * Returns null if an active (pending/reviewing) task already exists for this PR
  * (idempotency guard against webhook redeliveries and rapid PR events).
  */
-async function createTaskForPR(
+export async function createTaskForPR(
   store: TaskStore,
   installationId: number,
   owner: string,

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -83,4 +83,11 @@ export class MemoryTaskStore implements TaskStore {
   async getAgentLastSeen(agentId: string): Promise<number | null> {
     return this.agentLastSeen.get(agentId) ?? null;
   }
+
+  /** Clear all data. Test-only — not on the TaskStore interface. */
+  reset(): void {
+    this.tasks.clear();
+    this.claims.clear();
+    this.agentLastSeen.clear();
+  }
 }


### PR DESCRIPTION
## Summary
- Add scenario-based E2E tests (32 tests, 11 groups) simulating real agent behavior against the server
- Create reusable test helpers: MockAgent class, GitHub fetch mock, test server factory
- Add test-only API routes (`/test/events/pr`, `/test/reset`, `/test/tasks`, `/test/claims/:taskId`) for injecting events without webhook signatures
- Export `createTaskForPR()` from webhook.ts and add `reset()` to MemoryTaskStore for test use

## Test plan
- [x] All 440 tests pass (32 new + 408 existing)
- [x] Build, lint, typecheck, format all pass
- [x] No production code behavior changed — only test infrastructure added

🤖 Generated with [Claude Code](https://claude.com/claude-code)