### PR TITLE
feat: add CLI E2E test suite with fake server and mocked tool executor

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,9 @@
   },
   "devDependencies": {
     "@opencara/shared": "workspace:*",
+    "@opencara/server": "workspace:*",
+    "@cloudflare/workers-types": "^4.20250214.0",
+    "hono": "^4.7.0",
     "@types/node": "^22.0.0",
     "tsup": "^8.5.1",
     "tsx": "^4.0.0"

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -1,0 +1,373 @@
+/**
+ * E2E tests for the CLI agent — runs startAgent() against a real Hono server
+ * (in-memory) with a mocked tool executor.
+ *
+ * Fake Server: real Hono app + MemoryTaskStore, accessed via fetch interception
+ * Fake Tool: vi.mock() on tool-executor.js returns canned review output
+ *
+ * Note: tests that submit summary results trigger server-side postFinalReview
+ * which uses crypto.subtle (doesn't resolve with fake timers). These tests
+ * verify claim status only, not task final status.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
+import type { ReviewExecutorDeps } from '../review.js';
+import { createSessionTracker } from '../consumption.js';
+import { FakeServer, FAKE_SERVER_URL } from './helpers/fake-server.js';
+import { executeTool } from '../tool-executor.js';
+
+// ── Mock tool executor ───────────────────────────────────────
+
+vi.mock('../tool-executor.js', () => ({
+  executeTool: vi.fn(async () => ({
+    stdout:
+      '## Summary\nLooks good. No issues found.\n\n## Findings\nNo issues found.\n\n## Verdict\nAPPROVE',
+    stderr: '',
+    exitCode: 0,
+    tokensUsed: 500,
+    tokensParsed: true,
+  })),
+  estimateTokens: (text: string) => Math.ceil(text.length / 4),
+  validateCommandBinary: () => true,
+  parseCommandTemplate: (cmd: string) => cmd.split(' '),
+}));
+
+const mockedExecuteTool = vi.mocked(executeTool);
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeDeps(agentId = 'test-agent'): {
+  reviewDeps: ReviewExecutorDeps;
+  consumptionDeps: ConsumptionDeps;
+} {
+  const session = createSessionTracker();
+  return {
+    reviewDeps: { commandTemplate: 'echo test', maxDiffSizeKb: 500 },
+    consumptionDeps: { agentId, limits: null, session },
+  };
+}
+
+async function advanceTime(totalMs: number, stepMs = 100): Promise<void> {
+  const steps = Math.ceil(totalMs / stepMs);
+  for (let i = 0; i < steps; i++) {
+    await vi.advanceTimersByTimeAsync(stepMs);
+  }
+}
+
+async function stopAgent(promise: Promise<void>, server: FakeServer): Promise<void> {
+  server.uninstallFetch();
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    json: () => Promise.resolve({ error: 'shutdown' }),
+  });
+  await advanceTime(3000);
+  await promise;
+}
+
+// ── Test Suite ───────────────────────────────────────────────
+
+describe('E2E Agent Scenarios', () => {
+  let server: FakeServer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process, 'on').mockImplementation(() => process);
+
+    server = new FakeServer();
+    server.install();
+
+    mockedExecuteTool.mockResolvedValue({
+      stdout:
+        '## Summary\nLooks good. No issues found.\n\n## Findings\nNo issues found.\n\n## Verdict\nAPPROVE',
+      stderr: '',
+      exitCode: 0,
+      tokensUsed: 500,
+      tokensParsed: true,
+    });
+  });
+
+  afterEach(() => {
+    server.restore();
+    vi.useRealTimers();
+  });
+
+  function startTestAgent(
+    agentId: string,
+    opts?: { reviewOnly?: boolean; maxDiffSizeKb?: number },
+  ): Promise<void> {
+    const deps = makeDeps(agentId);
+    const reviewDeps = opts?.maxDiffSizeKb
+      ? { ...deps.reviewDeps, maxDiffSizeKb: opts.maxDiffSizeKb }
+      : deps.reviewDeps;
+
+    return startAgent(
+      agentId,
+      FAKE_SERVER_URL,
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      deps.consumptionDeps,
+      { pollIntervalMs: 100, reviewOnly: opts?.reviewOnly },
+    );
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  // A. Single-Agent Review (review role, no postFinalReview)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('A. Single-agent review lifecycle', () => {
+    it('poll → claim review → tool runs → submit → claim completed', async () => {
+      // Use review_count=2 so the agent gets a 'review' role (not summary).
+      // Review submissions don't trigger postFinalReview (no crypto.subtle).
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      const agentPromise = startTestAgent('agent-1');
+      await advanceTime(500);
+
+      // Verify claim was created and completed
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].agent_id).toBe('agent-1');
+      expect(claims[0].role).toBe('review');
+      expect(claims[0].status).toBe('completed');
+      expect(claims[0].review_text).toBeDefined();
+      expect(claims[0].model).toBe('test-model');
+      expect(claims[0].tool).toBe('test-tool');
+
+      // Tool was called
+      expect(mockedExecuteTool).toHaveBeenCalled();
+
+      // Task should have completed_reviews incremented
+      const task = await server.getTask(taskId);
+      expect(task?.completed_reviews).toBe(1);
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // B. Multi-Agent Review Flow
+  // ═══════════════════════════════════════════════════════════
+
+  describe('B. Multi-agent review flow', () => {
+    it('two agents claim review slots → both submit successfully', async () => {
+      const taskId = await server.injectTask({ reviewCount: 3 });
+
+      // First agent claims and completes review
+      const agent1Promise = startTestAgent('reviewer-1');
+      await advanceTime(500);
+
+      let claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].role).toBe('review');
+      expect(claims[0].status).toBe('completed');
+
+      await stopAgent(agent1Promise, server);
+      server.install();
+
+      // Second agent claims and completes review
+      const agent2Promise = startTestAgent('reviewer-2');
+      await advanceTime(500);
+
+      claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(2);
+      const r2 = claims.find((c) => c.agent_id === 'reviewer-2');
+      expect(r2).toBeDefined();
+      expect(r2!.role).toBe('review');
+      expect(r2!.status).toBe('completed');
+
+      // Task should have both reviews counted
+      const task = await server.getTask(taskId);
+      expect(task?.completed_reviews).toBe(2);
+
+      // Summary should now be available for the next agent
+      // (we don't test summary submission here to avoid crypto.subtle issues)
+
+      await stopAgent(agent2Promise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // C. Diff Fetch Failure → Rejection
+  // ═══════════════════════════════════════════════════════════
+
+  describe('C. Diff fetch failure → rejection', () => {
+    it('diff URL returns 500 → agent rejects task on server', async () => {
+      await server.injectTask();
+      server.diffFetchError = true;
+
+      const agentPromise = startTestAgent('agent-diff-fail');
+      await advanceTime(3000);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to fetch diff'));
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // D. Tool Execution Failure → Error
+  // ═══════════════════════════════════════════════════════════
+
+  describe('D. Tool execution failure → error', () => {
+    it('tool throws → agent reports error to server', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 }); // review role
+      mockedExecuteTool.mockRejectedValue(new Error('Tool crashed with SIGSEGV'));
+
+      const agentPromise = startTestAgent('agent-crash');
+      await advanceTime(3000);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error on task'));
+
+      // Mark task completed to stop re-claim loop
+      await server.store.updateTask(taskId, { status: 'completed' });
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // E. Claim Rejected → Agent Skips
+  // ═══════════════════════════════════════════════════════════
+
+  describe('E. Claim rejected → skip', () => {
+    it('no available slots → agent keeps polling without claiming', async () => {
+      const taskId = await server.injectTask();
+
+      await server.store.updateTask(taskId, {
+        claimed_agents: ['other-agent'],
+        summary_claimed: true,
+        status: 'reviewing',
+      });
+      await server.store.createClaim({
+        id: `${taskId}:other-agent`,
+        task_id: taskId,
+        agent_id: 'other-agent',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      const agentPromise = startTestAgent('late-agent');
+      await advanceTime(500);
+
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // F. review_only Filtering
+  // ═══════════════════════════════════════════════════════════
+
+  describe('F. review_only filtering', () => {
+    it('agent with reviewOnly skips summary-only tasks', async () => {
+      await server.injectTask({ reviewCount: 1 });
+
+      const agentPromise = startTestAgent('review-only-agent', { reviewOnly: true });
+      await advanceTime(500);
+
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+
+    it('agent with reviewOnly picks up review tasks', async () => {
+      const taskId = await server.injectTask({ reviewCount: 3 });
+
+      const agentPromise = startTestAgent('review-only-agent', { reviewOnly: true });
+      await advanceTime(500);
+
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].role).toBe('review');
+      expect(claims[0].status).toBe('completed');
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // G. Diff Too Large → Rejection
+  // ═══════════════════════════════════════════════════════════
+
+  describe('G. Diff too large → rejection', () => {
+    it('diff exceeds maxDiffSizeKb → agent rejects task', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 }); // review role
+      server.diffContent = 'x'.repeat(2 * 1024); // 2KB
+
+      const agentPromise = startTestAgent('agent-big-diff', { maxDiffSizeKb: 1 });
+      await advanceTime(3000);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Diff too large'));
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await server.store.updateTask(taskId, { status: 'completed' });
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // H. Graceful Shutdown
+  // ═══════════════════════════════════════════════════════════
+
+  describe('H. Graceful shutdown via auth failure', () => {
+    it('agent stops after 3 consecutive auth failures', async () => {
+      server.uninstallFetch();
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Unauthorized' }),
+      });
+
+      const deps = makeDeps('graceful-agent');
+      const agentPromise = startAgent(
+        'graceful-agent',
+        FAKE_SERVER_URL,
+        { model: 'test-model', tool: 'test-tool' },
+        deps.reviewDeps,
+        deps.consumptionDeps,
+        { pollIntervalMs: 100 },
+      );
+
+      await advanceTime(2000);
+      await agentPromise;
+
+      expect(console.error).toHaveBeenCalledWith('Authentication failed repeatedly. Exiting.');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // I. Summary Type Mismatch Bug (documents known issue)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('I. Summary type mismatch bug (single-agent mode)', () => {
+    it('single-agent: summary claim with empty reviews → type mismatch error', async () => {
+      // In single-agent mode (review_count=1), the agent claims 'summary'.
+      // Server returns empty reviews. executeSummaryTask falls back to
+      // executeReviewTask, which submits type: 'review'. But the claim role
+      // is 'summary' — server rejects with 400 (type mismatch).
+      const taskId = await server.injectTask({ reviewCount: 1 });
+
+      const agentPromise = startTestAgent('single-agent');
+      await advanceTime(3000);
+
+      // Tool was called (review execution happened)
+      expect(mockedExecuteTool).toHaveBeenCalled();
+
+      // The type mismatch error was logged
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("does not match submission type 'review'"),
+      );
+
+      await server.store.updateTask(taskId, { status: 'completed' });
+      await stopAgent(agentPromise, server);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/helpers/fake-server.ts
+++ b/packages/cli/src/__tests__/helpers/fake-server.ts
@@ -1,0 +1,235 @@
+/**
+ * FakeServer — wraps the real Hono server with MemoryTaskStore,
+ * intercepting globalThis.fetch to route CLI API calls through app.request().
+ *
+ * Handles three categories of fetch:
+ * 1. CLI API calls (http://fake-server/api/*) → routed to Hono app
+ * 2. GitHub diff URLs (*.diff) → return canned diff content
+ * 3. Server GitHub API calls (api.github.com/*) → mock responses
+ */
+import { generateKeyPairSync } from 'node:crypto';
+import { vi } from 'vitest';
+import type { ReviewConfig, ReviewTask, TaskClaim } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import { MemoryTaskStore } from '../../../../server/src/store/memory.js';
+import { createTestApp } from '../../../../server/src/__tests__/helpers/test-server.js';
+import { resetTimeoutThrottle } from '../../../../server/src/routes/tasks.js';
+import type { Env } from '../../../../server/src/types.js';
+
+export const FAKE_SERVER_URL = 'http://fake-server';
+
+const CANNED_DIFF = `diff --git a/src/index.ts b/src/index.ts
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,3 +1,5 @@
+ import { foo } from './foo';
++import { bar } from './bar';
+
+-export function main() {}
++export function main() {
++  bar();
++}
+`;
+
+// Generate RSA key once for JWT signing in server's getInstallationToken
+let testPem: string;
+function getTestPem(): string {
+  if (!testPem) {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    testPem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+  }
+  return testPem;
+}
+
+export class FakeServer {
+  store: MemoryTaskStore;
+  env: Env;
+  app: ReturnType<typeof createTestApp>;
+  private originalFetch: typeof globalThis.fetch;
+  /** Optionally make diff fetch fail */
+  diffFetchError: boolean = false;
+  /** Canned diff content (can be overridden per test) */
+  diffContent: string = CANNED_DIFF;
+
+  constructor() {
+    this.store = new MemoryTaskStore();
+    this.env = {
+      GITHUB_WEBHOOK_SECRET: 'test-secret',
+      GITHUB_APP_ID: '12345',
+      GITHUB_APP_PRIVATE_KEY: getTestPem(),
+      TASK_STORE: {} as KVNamespace,
+      WEB_URL: 'https://test.opencara.com',
+    };
+    this.app = createTestApp(this.store);
+    this.originalFetch = globalThis.fetch;
+  }
+
+  /** Replace globalThis.fetch with interceptor. */
+  install(): void {
+    const { app, env, diffContent: _dc, diffFetchError: _de } = this;
+    // Use closures to reference mutable properties
+    const getDiffError = () => this.diffFetchError;
+    const getDiffContent = () => this.diffContent;
+
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? 'GET';
+      const headers = init?.headers as Record<string, string> | undefined;
+
+      // 1. CLI API calls → route to Hono app
+      if (url.startsWith(FAKE_SERVER_URL)) {
+        const path = url.slice(FAKE_SERVER_URL.length);
+        const response = await app.request(
+          path,
+          {
+            method,
+            headers: { 'Content-Type': 'application/json', ...headers },
+            body: init?.body as string | undefined,
+          },
+          env,
+        );
+
+        // Convert Hono Response to standard Response for ApiClient
+        const body = await response.text();
+        return new Response(body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: Object.fromEntries(response.headers.entries()),
+        });
+      }
+
+      // 2. Diff URL fetches (GitHub .diff URLs)
+      if (url.includes('.diff') || url.includes('/pull/')) {
+        if (getDiffError()) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        return new Response(getDiffContent(), { status: 200 });
+      }
+
+      // 3. Server GitHub API calls (installation tokens, review posting, etc.)
+      if (url.includes('api.github.com') || url.includes('/access_tokens')) {
+        // Installation token
+        if (url.includes('/access_tokens')) {
+          return new Response(JSON.stringify({ token: 'ghs_mock_token' }), { status: 200 });
+        }
+
+        // Fetch .review.yml
+        if (url.includes('/contents/.review.yml')) {
+          return new Response('Not Found', { status: 404 });
+        }
+
+        // Post PR review
+        if (url.includes('/pulls/') && url.includes('/reviews') && method === 'POST') {
+          return new Response(
+            JSON.stringify({ html_url: 'https://github.com/test/repo/pull/1#review-123' }),
+            { status: 200 },
+          );
+        }
+
+        // Post PR comment
+        if (url.includes('/issues/') && url.includes('/comments') && method === 'POST') {
+          return new Response(
+            JSON.stringify({ html_url: 'https://github.com/test/repo/pull/1#comment-456' }),
+            { status: 200 },
+          );
+        }
+
+        // Fetch PR diff (for comment validation)
+        if (
+          url.includes('/pulls/') &&
+          !url.includes('/reviews') &&
+          !url.includes('/comments') &&
+          headers?.Accept === 'application/vnd.github.diff'
+        ) {
+          return new Response(getDiffContent(), { status: 200 });
+        }
+
+        // Fetch PR details
+        if (url.includes('/pulls/') && !url.includes('/reviews') && method === 'GET') {
+          return new Response(
+            JSON.stringify({
+              number: 1,
+              html_url: 'https://github.com/test/repo/pull/1',
+              diff_url: 'https://github.com/test/repo/pull/1.diff',
+              base: { ref: 'main' },
+              head: { ref: 'feat/test' },
+              draft: false,
+              labels: [],
+            }),
+            { status: 200 },
+          );
+        }
+      }
+
+      // Default 404
+      return new Response('Not Found', { status: 404 });
+    }) as typeof fetch;
+  }
+
+  /** Restore original fetch only (does not restore other mocks). */
+  uninstallFetch(): void {
+    globalThis.fetch = this.originalFetch;
+  }
+
+  /** Full cleanup: restore fetch + all mocks. Use in afterEach. */
+  restore(): void {
+    globalThis.fetch = this.originalFetch;
+    vi.restoreAllMocks();
+  }
+
+  /** Reset store and timeout throttle. */
+  reset(): void {
+    this.store.reset();
+    resetTimeoutThrottle();
+    this.diffFetchError = false;
+    this.diffContent = CANNED_DIFF;
+  }
+
+  /** Inject a task via test routes. Returns the task ID. */
+  async injectTask(opts?: {
+    owner?: string;
+    repo?: string;
+    prNumber?: number;
+    reviewCount?: number;
+    timeout?: string;
+  }): Promise<string> {
+    const config: ReviewConfig = {
+      ...DEFAULT_REVIEW_CONFIG,
+      agents: {
+        ...DEFAULT_REVIEW_CONFIG.agents,
+        reviewCount: opts?.reviewCount ?? 1,
+      },
+      ...(opts?.timeout ? { timeout: opts.timeout } : {}),
+    };
+
+    const res = await this.app.request(
+      '/test/events/pr',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          owner: opts?.owner ?? 'test-org',
+          repo: opts?.repo ?? 'test-repo',
+          pr_number: opts?.prNumber ?? 1,
+          config,
+        }),
+      },
+      this.env,
+    );
+    const body = (await res.json()) as { created: boolean; task_id?: string };
+    if (!body.created || !body.task_id) {
+      throw new Error(`Failed to inject task: ${JSON.stringify(body)}`);
+    }
+    return body.task_id;
+  }
+
+  /** Get a task from the store. */
+  async getTask(id: string): Promise<ReviewTask | null> {
+    return this.store.getTask(id);
+  }
+
+  /** Get claims for a task. */
+  async getClaims(taskId: string): Promise<TaskClaim[]> {
+    return this.store.getClaims(taskId);
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,6 +8,6 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"],
+  "exclude": ["src/**/*.test.ts", "src/__tests__"],
   "references": [{ "path": "../shared" }]
 }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@opencara/shared': resolve(__dirname, '../shared/src/index.ts'),
+      '@opencara/server': resolve(__dirname, '../server/src/index.ts'),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,12 +51,21 @@ importers:
         specifier: ^2.7.0
         version: 2.8.2
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250214.0
+        version: 4.20260317.1
+      '@opencara/server':
+        specifier: workspace:*
+        version: link:../server
       '@opencara/shared':
         specifier: workspace:*
         version: link:../shared
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.8
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## Summary
- Add E2E integration tests for CLI agent using real Hono server (in-memory) as fake API server
- Mock tool executor via `vi.mock()` to return canned review output (no subprocess spawning)
- FakeServer class intercepts `globalThis.fetch` to route CLI API calls, diff fetches, and server-side GitHub API calls
- 10 tests across 9 scenarios: review lifecycle, multi-agent flow, diff failure, tool error, claim rejection, review_only filtering, diff too large, graceful shutdown, type mismatch bug detection
- Test I documents a known CLI bug: single-agent mode submits `type: 'review'` for a `summary` claim (server rejects 400)

## Test plan
- [x] All 450 tests pass (10 new CLI E2E + 440 existing)
- [x] Build, lint, typecheck, format all pass
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)