### PR TITLE
[server-dev] Improve review-parser and eligibility robustness

### DIFF
--- a/packages/server/src/__tests__/eligibility.test.ts
+++ b/packages/server/src/__tests__/eligibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
 import { shouldSkipReview, parseTimeoutMs, isRepoAllowed } from '../eligibility.js';
 
@@ -40,6 +40,34 @@ describe('shouldSkipReview', () => {
       trigger: { ...DEFAULT_REVIEW_CONFIG.trigger, skip: ['branch:release/*'] },
     };
     expect(shouldSkipReview(config, { headRef: 'feature/new-thing' })).toBeNull();
+  });
+
+  it('logs warning and does not skip for invalid glob pattern', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Force RegExp constructor to throw for the glob-derived pattern
+    const OrigRegExp = globalThis.RegExp;
+    globalThis.RegExp = class extends OrigRegExp {
+      constructor(pattern: string, flags?: string) {
+        if (typeof pattern === 'string' && pattern.startsWith('^')) {
+          throw new SyntaxError('Invalid regular expression');
+        }
+        super(pattern, flags);
+      }
+    } as typeof RegExp;
+
+    try {
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        trigger: { ...DEFAULT_REVIEW_CONFIG.trigger, skip: ['branch:test-*'] },
+      };
+      expect(shouldSkipReview(config, { headRef: 'test-branch' })).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid glob pattern in skip config'),
+      );
+    } finally {
+      globalThis.RegExp = OrigRegExp;
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/server/src/__tests__/review-parser.test.ts
+++ b/packages/server/src/__tests__/review-parser.test.ts
@@ -38,6 +38,66 @@ REQUEST_CHANGES`;
     expect(result.verdict).toBe('request_changes');
   });
 
+  it('skips findings with line number 0', () => {
+    const text = `## Summary
+Zero line.
+
+## Findings
+- **[minor]** \`src/index.ts:0\` — invalid line
+
+## Verdict
+APPROVE`;
+
+    const result = parseStructuredReview(text);
+    expect(result.comments).toHaveLength(0);
+  });
+
+  it('skips findings with negative line numbers', () => {
+    const text = `## Summary
+Negative line.
+
+## Findings
+- **[minor]** \`src/index.ts:-5\` — negative line
+
+## Verdict
+APPROVE`;
+
+    const result = parseStructuredReview(text);
+    expect(result.comments).toHaveLength(0);
+  });
+
+  it('skips synthesizer findings with line number 0', () => {
+    const text = `## Summary
+Zero line heading.
+
+## Findings
+
+### [major] \`app.ts:0\` — Invalid line
+Should be skipped.
+
+## Verdict
+COMMENT`;
+
+    const result = parseStructuredReview(text);
+    expect(result.comments).toHaveLength(0);
+  });
+
+  it('skips synthesizer findings with negative line numbers', () => {
+    const text = `## Summary
+Negative line heading.
+
+## Findings
+
+### [major] \`app.ts:-3\` — Negative line
+Should be skipped.
+
+## Verdict
+COMMENT`;
+
+    const result = parseStructuredReview(text);
+    expect(result.comments).toHaveLength(0);
+  });
+
   it('parses synthesizer format (### headings)', () => {
     const text = `## Summary
 Overview here.

--- a/packages/server/src/eligibility.ts
+++ b/packages/server/src/eligibility.ts
@@ -35,6 +35,7 @@ function matchGlob(pattern: string, text: string): boolean {
     const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
     return new RegExp('^' + escaped + '$').test(text);
   } catch {
+    console.warn(`Invalid glob pattern in skip config: "${pattern}"`);
     return false;
   }
 }

--- a/packages/server/src/review-parser.ts
+++ b/packages/server/src/review-parser.ts
@@ -55,7 +55,7 @@ export function parseStructuredReview(text: string): ParsedReview {
       const path = match[2];
       const line = parseInt(match[3], 10);
       const description = match[4].trim();
-      if (isNaN(line)) continue;
+      if (isNaN(line) || line <= 0) continue;
       comments.push({
         path,
         line,
@@ -87,7 +87,7 @@ export function parseStructuredReview(text: string): ParsedReview {
     }
     for (let i = 0; i < headings.length; i++) {
       const h = headings[i];
-      if (isNaN(h.line)) continue;
+      if (isNaN(h.line) || h.line <= 0) continue;
       if (comments.some((c) => c.path === h.path && c.line === h.line)) continue;
       const nextStart = i + 1 < headings.length ? headings[i + 1].startIdx : findingsBlock.length;
       const bodyAfterTitle = findingsBlock.slice(h.endIdx, nextStart).trim();


### PR DESCRIPTION
Closes #179

## Summary
- Validate line numbers in `parseStructuredReview()` — reject `<= 0` for both list and heading formats
- Add `console.warn` in `matchGlob()` when a glob pattern produces an invalid regex
- Added 5 new unit tests covering line number 0, negative line numbers, and invalid glob warning

## Test plan
- [x] Unit test: parseStructuredReview skips findings with line number 0 (list format)
- [x] Unit test: parseStructuredReview skips findings with negative line numbers (list format)
- [x] Unit test: parseStructuredReview skips findings with line number 0 (heading format)
- [x] Unit test: parseStructuredReview skips findings with negative line numbers (heading format)
- [x] Unit test: matchGlob logs warning and returns false for invalid patterns
- [x] All 460 existing tests pass
- [x] Build, lint, format, typecheck all pass