### PR TITLE
[qa] Fix verdict case mismatch causing invisible PR reviews

### DIFF
--- a/packages/server/src/github/reviews.ts
+++ b/packages/server/src/github/reviews.ts
@@ -49,7 +49,10 @@ export async function postPrReview(
   );
 
   if (!response.ok) {
-    throw new Error(`Failed to post PR review: ${response.status} ${response.statusText}`);
+    const errorBody = await response.text();
+    throw new Error(
+      `Failed to post PR review: ${response.status} ${response.statusText} — ${errorBody.slice(0, 200)}`,
+    );
   }
 
   const data = (await response.json()) as { html_url: string };

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -183,8 +183,12 @@ async function postFinalReview(
     }
 
     // Determine verdict and inline comments
-    const verdict =
+    // Normalize to lowercase — agents may submit uppercase verdicts (e.g. "APPROVE")
+    const rawVerdict =
       parsed.verdict ?? (summaryClaim.verdict as ReviewVerdict | undefined) ?? 'comment';
+    const verdict = (
+      typeof rawVerdict === 'string' ? rawVerdict.toLowerCase() : rawVerdict
+    ) as ReviewVerdict;
 
     // Try to fetch diff for comment validation (best effort)
     let validComments = parsed.comments;


### PR DESCRIPTION
## Summary

- Normalize verdict string to lowercase in `postFinalReview()` before passing to `verdictToReviewEvent()` — agents submit uppercase verdicts (e.g. `"APPROVE"`) but the lookup map only has lowercase keys, returning `undefined` and causing GitHub to create invisible PENDING (draft) reviews
- Include response body in `postPrReview()` error messages for easier debugging

## Root Cause

`verdictToReviewEvent()` maps `"approve"` → `"APPROVE"`, `"comment"` → `"COMMENT"`, etc. When the CLI submits `"APPROVE"` (uppercase), the lookup returns `undefined`. GitHub's Create Review API accepts `event: undefined` and creates the review in PENDING state — a draft review visible only to the bot, never published. The API returns 200 success, so the server logs "review posted to GitHub" with no error.

## Test Plan

- [x] All 445 tests pass
- [x] Lint, typecheck, format all clean
- [x] Verified on live dev worker: PR #20 on `opencara-dev-test` now shows a visible APPROVED review from `opencara-dev[bot]`
- [x] Tested with uppercase `"APPROVE"` verdict — review now correctly posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)