### PR TITLE
fix: add clickable PR URL to agent task log output

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -181,6 +181,7 @@ async function handleTask(
   const { task_id, owner, repo, pr_number, diff_url, timeout_seconds, prompt, role } = task;
 
   console.log(`\nTask ${task_id}: PR #${pr_number} on ${owner}/${repo} (role: ${role})`);
+  console.log(`  ${diff_url}`);
 
   // Claim the task (retry once — slot may be taken)
   let claimResponse: ClaimResponse;


### PR DESCRIPTION
Closes #130

## Summary
- Adds the PR URL (from `diff_url`) as a second log line when a task is found, making it clickable in terminals that support hyperlinks

Before:
```
Task abc123: PR #42 on org/repo (role: review)
```

After:
```
Task abc123: PR #42 on org/repo (role: review)
  https://github.com/org/repo/pull/42
```

## Test plan
- [x] All 463 tests pass
- [ ] Manual verification: run `opencara agent start` and confirm URL appears in task log