### PR TITLE
[server-dev] Fix duplicate summary claims via defense-in-depth (#221)

### DIFF
--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -387,6 +387,72 @@ describe('E2E Scenarios', () => {
       expect(c4.claimed).toBe(false);
     });
 
+    it('duplicate summary claim rejected even with stale task-level flag (#221)', async () => {
+      const taskId = await injectPR();
+      const a1 = agent('synth-1');
+      const a2 = agent('synth-2');
+
+      // Agent 1 claims summary
+      const c1 = await a1.claim(taskId, 'summary');
+      expect(c1.claimed).toBe(true);
+
+      // Simulate KV stale read: reset task-level summary_claimed flag
+      // (mimics what happens when a concurrent read returns stale data)
+      await store.updateTask(taskId, { summary_claimed: false, claimed_agents: [] });
+
+      // Agent 2 tries to claim — claim-level dedup should catch it
+      const c2 = await a2.claim(taskId, 'summary');
+      expect(c2.claimed).toBe(false);
+    });
+
+    it('second summary result does not post duplicate GitHub comment (#221)', async () => {
+      const taskId = await injectPR();
+
+      // Manually create two summary claims (simulating the race condition)
+      await store.createClaim({
+        id: `${taskId}:synth-a`,
+        task_id: taskId,
+        agent_id: 'synth-a',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.createClaim({
+        id: `${taskId}:synth-b`,
+        task_id: taskId,
+        agent_id: 'synth-b',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.updateTask(taskId, {
+        summary_claimed: true,
+        claimed_agents: ['synth-a', 'synth-b'],
+        status: 'reviewing',
+      });
+
+      const synthA = agent('synth-a');
+      const synthB = agent('synth-b');
+
+      // Count GitHub comment calls before
+      const commentsBefore = github.calls.filter(
+        (c) => c.url.includes('/issues/') && c.url.includes('/comments') && c.method === 'POST',
+      ).length;
+
+      // Agent A submits summary — should post
+      await synthA.submitResult(taskId, 'summary', '## Summary\nFirst.', 'approve');
+
+      // Agent B submits summary — postFinalReview should skip (task already completed)
+      await synthB.submitResult(taskId, 'summary', '## Summary\nDuplicate.', 'approve');
+
+      // Only 1 new comment should have been posted (not 2)
+      const commentsAfter = github.calls.filter(
+        (c) => c.url.includes('/issues/') && c.url.includes('/comments') && c.method === 'POST',
+      ).length;
+      const newComments = commentsAfter - commentsBefore;
+      expect(newComments).toBe(1);
+    });
+
     it('same agent cannot double-claim', async () => {
       const taskId = await injectPR({ reviewCount: 3 });
       const a = agent('greedy');

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -981,6 +981,123 @@ describe('Task Routes', () => {
     });
   });
 
+  // ── Duplicate summary claim prevention (#221) ──────────
+
+  describe('duplicate summary claim prevention (#221)', () => {
+    it('rejects summary claim when another pending summary claim exists', async () => {
+      await store.createTask(makeTask());
+
+      // Agent A claims summary
+      const res1 = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-a',
+        role: 'summary',
+      });
+      const body1 = await res1.json();
+      expect(body1.claimed).toBe(true);
+
+      // Simulate KV stale read: task still shows summary_claimed=false
+      // by manually resetting it (mimics KV eventual consistency)
+      await store.updateTask('task-1', { summary_claimed: false, claimed_agents: [] });
+
+      // Agent B tries to claim summary — task-level flag says available,
+      // but claim-level check should catch the existing pending claim
+      const res2 = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-b',
+        role: 'summary',
+      });
+      const body2 = await res2.json();
+      expect(body2.claimed).toBe(false);
+      expect(body2.reason).toContain('Summary already claimed');
+    });
+
+    it('allows summary claim after previous summary claim was rejected', async () => {
+      await store.createTask(makeTask());
+
+      // Agent A claims and rejects summary
+      await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-a',
+        role: 'summary',
+      });
+      await request('POST', '/api/tasks/task-1/reject', {
+        agent_id: 'agent-a',
+        reason: 'test',
+      });
+
+      // Agent B should be able to claim summary
+      const res = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-b',
+        role: 'summary',
+      });
+      const body = await res.json();
+      expect(body.claimed).toBe(true);
+    });
+
+    it('allows summary claim after previous summary claim errored', async () => {
+      await store.createTask(makeTask());
+
+      // Agent A claims and errors summary
+      await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-a',
+        role: 'summary',
+      });
+      await request('POST', '/api/tasks/task-1/error', {
+        agent_id: 'agent-a',
+        error: 'OOM',
+      });
+
+      // Agent B should be able to claim summary
+      const res = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-b',
+        role: 'summary',
+      });
+      const body = await res.json();
+      expect(body.claimed).toBe(true);
+    });
+
+    it('postFinalReview skips duplicate post when task is already completed', async () => {
+      await store.createTask(makeTask({ status: 'reviewing', summary_claimed: true }));
+
+      // Create two summary claims (simulating the race that slipped past claim-time dedup)
+      await store.createClaim({
+        id: 'task-1:agent-a',
+        task_id: 'task-1',
+        agent_id: 'agent-a',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.createClaim({
+        id: 'task-1:agent-b',
+        task_id: 'task-1',
+        agent_id: 'agent-b',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // Agent A submits — should post and complete task
+      const res1 = await request('POST', '/api/tasks/task-1/result', {
+        agent_id: 'agent-a',
+        type: 'summary',
+        review_text: '## Summary\nFirst review.',
+      });
+      expect(res1.status).toBe(200);
+
+      // Task should be in terminal state (completed or failed depending on GitHub mock)
+      const taskAfterFirst = await store.getTask('task-1');
+      expect(['completed', 'failed']).toContain(taskAfterFirst?.status);
+
+      // Agent B submits — postFinalReview should skip (task already completed)
+      const res2 = await request('POST', '/api/tasks/task-1/result', {
+        agent_id: 'agent-b',
+        type: 'summary',
+        review_text: '## Summary\nDuplicate review.',
+      });
+      // Result endpoint returns 200 (claim was updated), but postFinalReview skips posting
+      expect(res2.status).toBe(200);
+    });
+  });
+
   // ── Multi-agent flow ─────────────────────────────────────
 
   describe('multi-agent review flow', () => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -149,6 +149,15 @@ async function postFinalReview(
   const task = await store.getTask(taskId);
   if (!task) return;
 
+  // Defense-in-depth: if task is already completed, another agent already posted.
+  // This prevents duplicate GitHub comments even if duplicate summary claims slip through.
+  if (task.status === 'completed') {
+    console.log(
+      `Task ${taskId}: skipping duplicate post from ${summaryAgentId} — task already completed`,
+    );
+    return;
+  }
+
   // Use direct getClaim (KV get) instead of getClaims (KV list) to avoid
   // eventual consistency issues — the claim was just updated moments ago.
   const summaryClaim = await store.getClaim(`${taskId}:${summaryAgentId}`);
@@ -280,6 +289,25 @@ export function taskRoutes() {
         claimed: false,
         reason: actualRole ? `Expected role ${actualRole}, got ${role}` : 'No slots available',
       });
+    }
+
+    // Defense-in-depth: check existing claims before creating a summary claim.
+    // The task-level `summary_claimed` flag can be stale due to KV eventual consistency,
+    // so we also check individual claim entries which have a narrower consistency window.
+    if (role === 'summary') {
+      const existingClaims = await store.getClaims(taskId);
+      const existingSummaryClaim = existingClaims.find(
+        (c) => c.role === 'summary' && c.status === 'pending',
+      );
+      if (existingSummaryClaim) {
+        console.log(
+          `Task ${taskId}: rejecting duplicate summary claim from ${agent_id} — already claimed by ${existingSummaryClaim.agent_id}`,
+        );
+        return c.json<ClaimResponse>({
+          claimed: false,
+          reason: 'Summary already claimed by another agent',
+        });
+      }
     }
 
     // Create the claim


### PR DESCRIPTION
Closes #221

## Summary
- Add **claim-time dedup**: before creating a summary claim, check existing claims for any pending summary claim (narrower KV consistency window than the task-level `summary_claimed` flag)
- Add **post-time dedup**: in `postFinalReview`, check `task.status === 'completed'` before posting to GitHub — prevents duplicate comments even if duplicate claims slip through
- Add 6 new tests covering the race condition scenarios (4 in routes-tasks, 2 in e2e-scenarios)

## Test plan
- [x] Existing 553 tests pass
- [x] New test: duplicate summary claim rejected when stale task-level flag allows it
- [x] New test: summary claim allowed after previous claim was rejected/errored
- [x] New test: second summary result skips GitHub post when task already completed
- [x] New e2e test: duplicate summary claim rejected with stale flag
- [x] New e2e test: only 1 GitHub comment posted when 2 summary agents submit
- [x] Build, lint, format, typecheck all pass