### PR TITLE
[cli-dev] Fix Docker build: copy root tsconfig.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:20-slim AS builder
 WORKDIR /app
 RUN corepack enable
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY tsconfig.json ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/cli/package.json packages/cli/
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Closes #225

## Summary
- Add `COPY tsconfig.json ./` to the Dockerfile before the build step
- The root `tsconfig.json` is required because `packages/shared/tsconfig.json` extends it (`../../tsconfig.json`)
- Without it, the TypeScript build fails with `TS5083: Cannot read file '/app/tsconfig.json'`

## Test plan
- [x] `podman build -t opencara-test .` succeeds (verified locally)
- [x] `pnpm build && pnpm test` passes (574/574 tests)