### PR TITLE
[server-dev] Fix: read .review.yml from base branch instead of head

### DIFF
--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -864,6 +864,46 @@ APPROVE`;
       expect(pollResult.tasks[0].role).toBe('summary'); // review_count=1 (default)
     });
 
+    it('fetches .review.yml from base branch, not head branch', async () => {
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: { owner: { login: 'acme' }, name: 'widget' },
+        pull_request: {
+          number: 78,
+          html_url: 'https://github.com/acme/widget/pull/78',
+          diff_url: 'https://github.com/acme/widget/pull/78.diff',
+          base: { ref: 'main' },
+          head: { ref: 'feat/malicious-config' },
+          draft: false,
+          labels: [],
+        },
+      };
+
+      const body = JSON.stringify(payload);
+      const signature = await signPayload(body, WEBHOOK_SECRET);
+
+      await app.request(
+        '/webhook/github',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Hub-Signature-256': signature,
+            'X-GitHub-Event': 'pull_request',
+          },
+          body,
+        },
+        mockEnv,
+      );
+
+      // The .review.yml fetch should use base ref (main), not head ref (feat/malicious-config)
+      const configFetch = githubCalls.find((c) => c.url.includes('/contents/.review.yml'));
+      expect(configFetch).toBeDefined();
+      expect(configFetch!.url).toContain('ref=main');
+      expect(configFetch!.url).not.toContain('ref=feat/malicious-config');
+    });
+
     it('invalid signature is rejected with 401', async () => {
       const body = JSON.stringify({ action: 'opened' });
 
@@ -1137,6 +1177,18 @@ APPROVE`;
       const tasks = await store.listTasks();
       expect(tasks).toHaveLength(1);
       expect(tasks[0].pr_number).toBe(81);
+    });
+
+    it('/opencara review comment fetches .review.yml from base branch', async () => {
+      githubCalls.length = 0;
+      await sendCommentWebhook(83, '/opencara review');
+
+      // The mock returns PR details with base: { ref: 'main' } and head: { ref: 'feat/test' }
+      // .review.yml should be fetched using base ref (main), not head ref
+      const configFetch = githubCalls.find((c) => c.url.includes('/contents/.review.yml'));
+      expect(configFetch).toBeDefined();
+      expect(configFetch!.url).toContain('ref=main');
+      expect(configFetch!.url).not.toContain('ref=feat/test');
     });
 
     it('/opencara review comment creates task after previous task completed', async () => {

--- a/packages/server/src/github/config.ts
+++ b/packages/server/src/github/config.ts
@@ -70,13 +70,13 @@ export async function fetchPrDetails(
 export async function loadReviewConfig(
   owner: string,
   repo: string,
-  headRef: string,
+  baseRef: string,
   prNumber: number,
   token: string,
 ): Promise<{ config: ReviewConfig; parseError: boolean }> {
   let configYaml: string | null;
   try {
-    configYaml = await fetchReviewConfig(owner, repo, headRef, token);
+    configYaml = await fetchReviewConfig(owner, repo, baseRef, token);
   } catch (err) {
     console.error('Failed to fetch .review.yml:', err);
     return { config: DEFAULT_REVIEW_CONFIG, parseError: false };

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -207,7 +207,8 @@ async function handlePullRequest(
     return new Response('OK', { status: 200 });
   }
 
-  const { config, parseError } = await loadReviewConfig(owner, repo, headRef, prNumber, token);
+  const baseRef = pull_request.base.ref;
+  const { config, parseError } = await loadReviewConfig(owner, repo, baseRef, prNumber, token);
 
   if (parseError) {
     console.log(`PR #${prNumber}: aborting due to .review.yml parse error`);
@@ -281,7 +282,7 @@ async function handleIssueComment(
     return new Response('OK', { status: 200 });
   }
 
-  const { config } = await loadReviewConfig(owner, repo, pr.head.ref, prNumber, token);
+  const { config } = await loadReviewConfig(owner, repo, pr.base.ref, prNumber, token);
 
   const triggerCommand = config.trigger.comment;
   if (!comment.body.trim().toLowerCase().startsWith(triggerCommand.toLowerCase())) {


### PR DESCRIPTION
Closes #228

## Summary
- Changed `loadReviewConfig()` to read `.review.yml` from the PR's **base branch** instead of the head branch
- Prevents PR authors from manipulating review config (prompts, whitelist, review count, skip conditions)
- Fixed both `handlePullRequest` and `handleIssueComment` webhook handlers
- Added integration tests verifying the base ref is used for config fetches

## Test plan
- [x] Integration test: PR webhook fetches `.review.yml` using base ref (`main`), not head ref
- [x] Integration test: issue_comment webhook fetches `.review.yml` using base ref
- [x] All 576 existing tests pass