### PR TITLE
[server-dev] Fix KV store race conditions: eliminate shared task index

### DIFF
--- a/packages/server/src/__tests__/store-kv.test.ts
+++ b/packages/server/src/__tests__/store-kv.test.ts
@@ -5,31 +5,39 @@ import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
 
 // ── Mock KVNamespace ───────────────────────────────────────────────
 
-type PutOptions = { expirationTtl?: number };
+type PutOptions = { expirationTtl?: number; metadata?: unknown };
+
+interface StoredEntry {
+  value: string;
+  metadata?: unknown;
+}
 
 class MockKV {
-  private data = new Map<string, string>();
+  private data = new Map<string, StoredEntry>();
   /** Track put calls with their options for TTL assertions */
   putCalls: Array<{ key: string; value: string; options?: PutOptions }> = [];
 
   async get(key: string): Promise<string | null> {
-    return this.data.get(key) ?? null;
+    const entry = this.data.get(key);
+    return entry?.value ?? null;
   }
 
   async put(key: string, value: string, options?: PutOptions): Promise<void> {
     this.putCalls.push({ key, value, options });
-    this.data.set(key, value);
+    this.data.set(key, { value, metadata: options?.metadata });
   }
 
   async delete(key: string): Promise<void> {
     this.data.delete(key);
   }
 
-  async list(opts: { prefix: string }): Promise<{ keys: Array<{ name: string }> }> {
-    const keys: Array<{ name: string }> = [];
-    for (const k of this.data.keys()) {
+  async list(opts: {
+    prefix: string;
+  }): Promise<{ keys: Array<{ name: string; metadata?: unknown }> }> {
+    const keys: Array<{ name: string; metadata?: unknown }> = [];
+    for (const [k, entry] of this.data.entries()) {
       if (k.startsWith(opts.prefix)) {
-        keys.push({ name: k });
+        keys.push({ name: k, metadata: entry.metadata });
       }
     }
     return { keys };
@@ -37,7 +45,7 @@ class MockKV {
 
   /** Inject raw string at a key (for corruption tests) */
   _setRaw(key: string, value: string): void {
-    this.data.set(key, value);
+    this.data.set(key, { value });
   }
 }
 
@@ -127,6 +135,91 @@ describe('KVTaskStore', () => {
     });
   });
 
+  // ── createTask: metadata ──────────────────────────────────────
+
+  describe('createTask — metadata', () => {
+    it('stores task status and timeout_at in KV metadata', async () => {
+      const task = makeTask();
+      await store.createTask(task);
+
+      const putCall = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(putCall).toBeDefined();
+      expect(putCall!.options?.metadata).toEqual({
+        status: 'pending',
+        timeout_at: task.timeout_at,
+      });
+    });
+  });
+
+  // ── listTasks: uses kv.list() instead of index ────────────────
+
+  describe('listTasks — uses kv.list() prefix scan', () => {
+    it('lists all tasks via prefix scan', async () => {
+      await store.createTask(makeTask({ id: 'a' }));
+      await store.createTask(makeTask({ id: 'b' }));
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+      expect(tasks.map((t) => t.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('filters by status using metadata', async () => {
+      await store.createTask(makeTask({ id: 'a', status: 'pending' }));
+      await store.createTask(makeTask({ id: 'b', status: 'reviewing' }));
+      await store.createTask(makeTask({ id: 'c', status: 'completed' }));
+
+      const pending = await store.listTasks({ status: ['pending'] });
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe('a');
+
+      const active = await store.listTasks({ status: ['pending', 'reviewing'] });
+      expect(active).toHaveLength(2);
+    });
+
+    it('filters by timeout_before using metadata', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ id: 'expired', timeout_at: now - 1000 }));
+      await store.createTask(makeTask({ id: 'active', timeout_at: now + 60_000 }));
+
+      const expired = await store.listTasks({ timeout_before: now });
+      expect(expired).toHaveLength(1);
+      expect(expired[0].id).toBe('expired');
+    });
+
+    it('handles entries without metadata (backwards compatibility)', async () => {
+      // Simulate a task stored without metadata (pre-migration)
+      kv._setRaw('task:legacy', JSON.stringify(makeTask({ id: 'legacy', status: 'pending' })));
+
+      const tasks = await store.listTasks({ status: ['pending'] });
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('legacy');
+    });
+
+    it('skips corrupted task entries', async () => {
+      await store.createTask(makeTask({ id: 'good' }));
+      kv._setRaw('task:bad', '{corrupt');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('good');
+      warnSpy.mockRestore();
+    });
+
+    it('no race condition: concurrent creates are independent KV keys', async () => {
+      // With the index-based approach, concurrent creates could lose entries.
+      // With prefix scan, each task is an independent key — no shared state.
+      await Promise.all([
+        store.createTask(makeTask({ id: 'concurrent-1' })),
+        store.createTask(makeTask({ id: 'concurrent-2' })),
+        store.createTask(makeTask({ id: 'concurrent-3' })),
+      ]);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(3);
+    });
+  });
+
   // ── getClaim: corrupted JSON ─────────────────────────────────
 
   describe('getClaim — corrupted JSON', () => {
@@ -166,16 +259,6 @@ describe('KVTaskStore', () => {
     });
   });
 
-  // ── getTaskIndex: corrupted JSON ─────────────────────────────
-
-  describe('getTaskIndex — corrupted JSON', () => {
-    it('returns empty array when task_index is corrupted', async () => {
-      kv._setRaw('task_index', '{not-an-array');
-      const tasks = await store.listTasks();
-      expect(tasks).toEqual([]);
-    });
-  });
-
   // ── updateClaim: corrupted JSON ──────────────────────────────
 
   describe('updateClaim — corrupted JSON', () => {
@@ -206,7 +289,7 @@ describe('KVTaskStore', () => {
 
       const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
       expect(taskPut).toBeDefined();
-      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+      expect(taskPut!.options?.expirationTtl).toBe(SEVEN_DAYS);
     });
 
     it('sets expirationTtl when status transitions to timeout', async () => {
@@ -216,7 +299,7 @@ describe('KVTaskStore', () => {
       await store.updateTask('task-1', { status: 'timeout' });
 
       const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
-      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+      expect(taskPut!.options?.expirationTtl).toBe(SEVEN_DAYS);
     });
 
     it('sets expirationTtl when status transitions to failed', async () => {
@@ -226,7 +309,7 @@ describe('KVTaskStore', () => {
       await store.updateTask('task-1', { status: 'failed' });
 
       const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
-      expect(taskPut!.options).toEqual({ expirationTtl: SEVEN_DAYS });
+      expect(taskPut!.options?.expirationTtl).toBe(SEVEN_DAYS);
     });
 
     it('does NOT set expirationTtl for non-terminal status', async () => {
@@ -237,7 +320,7 @@ describe('KVTaskStore', () => {
 
       const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
       expect(taskPut).toBeDefined();
-      expect(taskPut!.options).toBeUndefined();
+      expect(taskPut!.options?.expirationTtl).toBeUndefined();
     });
 
     it('does NOT set expirationTtl when updating non-status fields', async () => {
@@ -248,7 +331,17 @@ describe('KVTaskStore', () => {
 
       const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
       expect(taskPut).toBeDefined();
-      expect(taskPut!.options).toBeUndefined();
+      expect(taskPut!.options?.expirationTtl).toBeUndefined();
+    });
+
+    it('updates metadata on every task update', async () => {
+      await store.createTask(makeTask());
+      kv.putCalls = [];
+
+      await store.updateTask('task-1', { status: 'reviewing' });
+
+      const taskPut = kv.putCalls.find((c) => c.key === 'task:task-1');
+      expect(taskPut!.options?.metadata).toEqual(expect.objectContaining({ status: 'reviewing' }));
     });
   });
 
@@ -295,6 +388,32 @@ describe('KVTaskStore', () => {
       const claimPut = kv.putCalls.find((c) => c.key === 'claim:task-1:agent-1');
       expect(claimPut).toBeDefined();
       expect(claimPut!.options).toBeUndefined();
+    });
+  });
+
+  // ── deleteTask: cleanup ────────────────────────────────────────
+
+  describe('deleteTask', () => {
+    it('removes task and associated claims', async () => {
+      await store.createTask(makeTask());
+      await store.createClaim(makeClaim({ task_id: 'task-1', agent_id: 'a1' }));
+
+      await store.deleteTask('task-1');
+
+      expect(await store.getTask('task-1')).toBeNull();
+      const claims = await store.getClaims('task-1');
+      expect(claims).toEqual([]);
+    });
+
+    it('task no longer appears in listTasks after deletion', async () => {
+      await store.createTask(makeTask({ id: 'a' }));
+      await store.createTask(makeTask({ id: 'b' }));
+
+      await store.deleteTask('a');
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe('b');
     });
   });
 });

--- a/packages/server/src/store/kv.ts
+++ b/packages/server/src/store/kv.ts
@@ -1,17 +1,22 @@
-import type { ReviewTask, TaskClaim } from '@opencara/shared';
+import type { ReviewTask, TaskClaim, TaskStatus } from '@opencara/shared';
 import type { TaskFilter } from '../types.js';
 import type { TaskStore } from './interface.js';
 
 const TASK_PREFIX = 'task:';
 const CLAIM_PREFIX = 'claim:';
 const AGENT_PREFIX = 'agent:';
-const TASK_INDEX_KEY = 'task_index';
 
 /** TTL for terminal KV entries: 7 days in seconds */
 const TERMINAL_TTL = 7 * 24 * 60 * 60;
 
 const TERMINAL_TASK_STATES = ['completed', 'timeout', 'failed'];
 const TERMINAL_CLAIM_STATUSES = ['completed', 'rejected', 'error'];
+
+/** Metadata stored on task KV entries for fast filtering via list(). */
+interface TaskMetadata {
+  status: TaskStatus;
+  timeout_at: number;
+}
 
 /** Safely parse JSON, returning fallback on malformed input. */
 export function safeParseJson<T>(raw: string, fallback: T | null = null): T | null {
@@ -27,10 +32,13 @@ export function safeParseJson<T>(raw: string, fallback: T | null = null): T | nu
  * Cloudflare Workers KV-backed TaskStore.
  *
  * Key layout:
- *   task:{id}              → ReviewTask JSON
- *   claim:{taskId}:{agentId} → TaskClaim JSON
- *   agent:{agentId}        → last-seen timestamp (string)
- *   task_index             → JSON array of task IDs (for listing)
+ *   task:{id}                 → ReviewTask JSON (with metadata: { status, timeout_at })
+ *   claim:{taskId}:{agentId}  → TaskClaim JSON
+ *   agent:{agentId}           → last-seen timestamp (string)
+ *
+ * Task enumeration uses kv.list({ prefix: "task:" }) instead of a shared index,
+ * eliminating the race condition where concurrent creates/deletes could lose entries
+ * in a shared JSON array.
  */
 export class KVTaskStore implements TaskStore {
   constructor(private readonly kv: KVNamespace) {}
@@ -38,11 +46,11 @@ export class KVTaskStore implements TaskStore {
   // ── Tasks ──────────────────────────────────────────────────────
 
   async createTask(task: ReviewTask): Promise<void> {
-    await this.kv.put(`${TASK_PREFIX}${task.id}`, JSON.stringify(task));
-    // Add to index
-    const index = await this.getTaskIndex();
-    index.push(task.id);
-    await this.kv.put(TASK_INDEX_KEY, JSON.stringify(index));
+    const metadata: TaskMetadata = {
+      status: task.status,
+      timeout_at: task.timeout_at,
+    };
+    await this.kv.put(`${TASK_PREFIX}${task.id}`, JSON.stringify(task), { metadata });
   }
 
   async getTask(id: string): Promise<ReviewTask | null> {
@@ -52,18 +60,37 @@ export class KVTaskStore implements TaskStore {
   }
 
   async listTasks(filter?: TaskFilter): Promise<ReviewTask[]> {
-    const index = await this.getTaskIndex();
+    // Use kv.list() to enumerate all task keys, using metadata for fast filtering
+    const listResult = await this.kv.list({ prefix: TASK_PREFIX });
     const tasks: ReviewTask[] = [];
 
-    for (const id of index) {
-      const task = await this.getTask(id);
+    for (const key of listResult.keys) {
+      const meta = key.metadata as TaskMetadata | undefined;
+
+      // Fast-path filtering using metadata (avoids full JSON fetch)
+      if (meta) {
+        if (filter?.status && filter.status.length > 0 && !filter.status.includes(meta.status)) {
+          continue;
+        }
+        if (filter?.timeout_before && meta.timeout_at > filter.timeout_before) {
+          continue;
+        }
+      }
+
+      // Fetch full task JSON
+      const raw = await this.kv.get(key.name);
+      if (!raw) continue;
+      const task = safeParseJson<ReviewTask>(raw);
       if (!task) continue;
 
-      if (filter?.status && filter.status.length > 0 && !filter.status.includes(task.status)) {
-        continue;
-      }
-      if (filter?.timeout_before && task.timeout_at > filter.timeout_before) {
-        continue;
+      // Double-check filter for tasks without metadata (backwards compatibility)
+      if (!meta) {
+        if (filter?.status && filter.status.length > 0 && !filter.status.includes(task.status)) {
+          continue;
+        }
+        if (filter?.timeout_before && task.timeout_at > filter.timeout_before) {
+          continue;
+        }
       }
 
       tasks.push(task);
@@ -77,27 +104,22 @@ export class KVTaskStore implements TaskStore {
     if (!task) return false;
     const updated = { ...task, ...updates };
 
-    const options = TERMINAL_TASK_STATES.includes(updated.status)
-      ? { expirationTtl: TERMINAL_TTL }
-      : undefined;
-    await this.kv.put(`${TASK_PREFIX}${id}`, JSON.stringify(updated), options);
+    const metadata: TaskMetadata = {
+      status: updated.status,
+      timeout_at: updated.timeout_at,
+    };
 
-    // Remove from index when reaching terminal state to prevent unbounded growth
-    if (updates.status && TERMINAL_TASK_STATES.includes(updates.status)) {
-      const index = await this.getTaskIndex();
-      const filtered = index.filter((tid) => tid !== id);
-      await this.kv.put(TASK_INDEX_KEY, JSON.stringify(filtered));
+    const options: { expirationTtl?: number; metadata: TaskMetadata } = { metadata };
+    if (TERMINAL_TASK_STATES.includes(updated.status)) {
+      options.expirationTtl = TERMINAL_TTL;
     }
 
+    await this.kv.put(`${TASK_PREFIX}${id}`, JSON.stringify(updated), options);
     return true;
   }
 
   async deleteTask(id: string): Promise<void> {
     await this.kv.delete(`${TASK_PREFIX}${id}`);
-    // Remove from index
-    const index = await this.getTaskIndex();
-    const filtered = index.filter((tid) => tid !== id);
-    await this.kv.put(TASK_INDEX_KEY, JSON.stringify(filtered));
 
     // Delete claims (best effort — list by prefix)
     const claimList = await this.kv.list({ prefix: `${CLAIM_PREFIX}${id}:` });
@@ -165,13 +187,5 @@ export class KVTaskStore implements TaskStore {
     const raw = await this.kv.get(`${AGENT_PREFIX}${agentId}`);
     if (!raw) return null;
     return parseInt(raw, 10);
-  }
-
-  // ── Helpers ────────────────────────────────────────────────────
-
-  private async getTaskIndex(): Promise<string[]> {
-    const raw = await this.kv.get(TASK_INDEX_KEY);
-    if (!raw) return [];
-    return safeParseJson<string[]>(raw, []) ?? [];
   }
 }


### PR DESCRIPTION
Closes #229

## Summary
- **Eliminated the shared `task_index` JSON array** — the root cause of index race conditions where concurrent creates/deletes could lose entries (last-write-wins on a shared JSON array)
- Replaced with `kv.list({ prefix: "task:" })` prefix scan — each task is an independent KV key, no shared mutable state
- **Task metadata** (status, timeout_at) stored on KV entries for fast filtering without fetching full JSON
- **Backwards compatible** — tasks written without metadata are filtered by reading the full JSON value
- `createTask()` is now a single `kv.put()` — no read-modify-write on a shared index
- `updateTask()` always writes fresh metadata alongside the task data
- `deleteTask()` is just `kv.delete()` — no index update needed

## What this fixes
1. **Concurrent creates losing entries**: Two webhook events creating tasks simultaneously would both read the index, append, and write — one write would lose the other's entry. Now each task is an independent key.
2. **Orphan tasks**: If a worker crashed between writing the task and updating the index, the task would be invisible to `listTasks()`. Now there's no separate index — if the task key exists, it's visible.
3. **Concurrent deletes**: Same last-write-wins issue as creates, now eliminated.

## What this doesn't fix (documented limitations)
- **updateTask read-modify-write**: Two concurrent `updateTask()` calls on the same task can still clobber each other. The existing `summary_claimed` flag pattern (from PR #222) mitigates the worst case. True CAS requires Durable Objects or D1.

## Test plan
- [x] `listTasks()` returns all tasks via prefix scan
- [x] Status filtering works via metadata
- [x] Timeout filtering works via metadata  
- [x] Backwards compatibility: tasks without metadata are still filtered correctly
- [x] Corrupted entries are skipped
- [x] Concurrent creates don't lose entries (independent keys)
- [x] Task deletion removes task from future `listTasks()` results
- [x] TTL on terminal states still works
- [x] Metadata updated on every task update
- [x] All 592 tests pass