### PR TITLE
[server-dev] Remove dead api_key config field

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -17,10 +17,6 @@
 # Set automatically by `opencara login`.
 platform_url: https://opencara-server.opencara.workers.dev
 
-# Your API key — set automatically by `opencara login`.
-# This authenticates your CLI with the platform. Never share this key.
-# api_key: cr_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
 # ---------------------------------------------------------------------------
 # GITHUB TOKEN (optional)
 # ---------------------------------------------------------------------------

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -56,7 +56,6 @@ describe('config', () => {
 
       const config = loadConfig();
 
-      expect(config.apiKey).toBeNull();
       expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
       expect(config.maxDiffSizeKb).toBe(DEFAULT_MAX_DIFF_SIZE_KB);
       expect(config.githubToken).toBeNull();
@@ -67,13 +66,10 @@ describe('config', () => {
 
     it('parses valid config file', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(
-        'api_key: cr_test123\nplatform_url: https://custom.dev\n',
-      );
+      vi.mocked(fs.readFileSync).mockReturnValue('platform_url: https://custom.dev\n');
 
       const config = loadConfig();
 
-      expect(config.apiKey).toBe('cr_test123');
       expect(config.platformUrl).toBe('https://custom.dev');
     });
 
@@ -94,7 +90,7 @@ describe('config', () => {
       expect(config.maxDiffSizeKb).toBe(DEFAULT_MAX_DIFF_SIZE_KB);
     });
 
-    it('silently ignores old anthropic_api_key and review_model fields', () => {
+    it('silently ignores old anthropic_api_key, review_model, and api_key fields', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
         'anthropic_api_key: sk-ant-test\nreview_model: claude-opus-4-6\napi_key: cr_test\n',
@@ -103,9 +99,9 @@ describe('config', () => {
       const config = loadConfig();
 
       // Old fields are ignored, no errors thrown
-      expect(config.apiKey).toBe('cr_test');
       expect(config).not.toHaveProperty('anthropicApiKey');
       expect(config).not.toHaveProperty('reviewModel');
+      expect(config).not.toHaveProperty('apiKey');
     });
 
     it('returns defaults for empty config file', () => {
@@ -114,7 +110,6 @@ describe('config', () => {
 
       const config = loadConfig();
 
-      expect(config.apiKey).toBeNull();
       expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
     });
 
@@ -124,7 +119,6 @@ describe('config', () => {
 
       const config = loadConfig();
 
-      expect(config.apiKey).toBeNull();
       expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
     });
 
@@ -134,17 +128,7 @@ describe('config', () => {
 
       const config = loadConfig();
 
-      expect(config.apiKey).toBeNull();
       expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
-    });
-
-    it('handles config with non-string api_key', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue('api_key: 123\n');
-
-      const config = loadConfig();
-
-      expect(config.apiKey).toBeNull();
     });
 
     it('handles config with non-string platform_url', () => {
@@ -250,7 +234,6 @@ describe('config', () => {
 
   describe('saveConfig', () => {
     const baseConfig = {
-      apiKey: null as string | null,
       platformUrl: 'https://api.dev',
       maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
       githubToken: null as string | null,
@@ -260,15 +243,10 @@ describe('config', () => {
       agents: null as import('../config.js').LocalAgentConfig[] | null,
     };
 
-    it('saves config with API key', () => {
-      saveConfig({ ...baseConfig, apiKey: 'cr_test' });
+    it('saves config with platform_url', () => {
+      saveConfig(baseConfig);
 
       expect(fs.mkdirSync).toHaveBeenCalledWith(CONFIG_DIR, { recursive: true });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        CONFIG_FILE,
-        expect.stringContaining('api_key: cr_test'),
-        { encoding: 'utf-8', mode: 0o600 },
-      );
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         CONFIG_FILE,
         expect.stringContaining('platform_url: https://api.dev'),
@@ -276,19 +254,11 @@ describe('config', () => {
       );
     });
 
-    it('saves config without API key when null', () => {
+    it('does not save api_key, anthropic_api_key or review_model', () => {
       saveConfig(baseConfig);
 
-      expect(fs.writeFileSync).toHaveBeenCalled();
       const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
       expect(content).not.toContain('api_key');
-      expect(content).toContain('platform_url');
-    });
-
-    it('does not save anthropic_api_key or review_model', () => {
-      saveConfig(baseConfig);
-
-      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
       expect(content).not.toContain('anthropic_api_key');
       expect(content).not.toContain('review_model');
     });
@@ -395,7 +365,6 @@ describe('config', () => {
 
     it('saveConfig writes agents when not null', () => {
       saveConfig({
-        apiKey: 'cr_test',
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -412,7 +381,6 @@ describe('config', () => {
 
     it('saveConfig omits agents when null', () => {
       saveConfig({
-        apiKey: 'cr_test',
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -481,7 +449,6 @@ agents:
 
     it('round-trips name through save and load', () => {
       saveConfig({
-        apiKey: 'cr_test',
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -780,7 +747,6 @@ agents:
 
     it('saveConfig persists repos field on agents', () => {
       saveConfig({
-        apiKey: 'cr_test',
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -830,7 +796,6 @@ agents:
 
     it('saveConfig writes github_token when present', () => {
       saveConfig({
-        apiKey: null,
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: 'ghp_xyz789',
@@ -846,7 +811,6 @@ agents:
 
     it('saveConfig omits github_token when null', () => {
       saveConfig({
-        apiKey: null,
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -940,7 +904,6 @@ anonymous_agents:
 
     it('saveConfig writes codebase_dir when present', () => {
       saveConfig({
-        apiKey: null,
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,
@@ -956,7 +919,6 @@ anonymous_agents:
 
     it('saveConfig omits codebase_dir when null', () => {
       saveConfig({
-        apiKey: null,
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         githubToken: null,

--- a/packages/cli/src/__tests__/http.test.ts
+++ b/packages/cli/src/__tests__/http.test.ts
@@ -9,35 +9,23 @@ describe('ApiClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('adds Authorization header when apiKey is provided', async () => {
+  it('sends Content-Type header', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ data: 'test' }),
     });
 
-    const client = new ApiClient('https://api.test.com', 'cr_mykey');
+    const client = new ApiClient('https://api.test.com');
     await client.get('/test');
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://api.test.com/test',
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'Bearer cr_mykey',
           'Content-Type': 'application/json',
         }),
       }),
     );
-  });
-
-  it('omits Authorization header when no apiKey', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({}),
-    });
-
-    const client = new ApiClient('https://api.test.com');
-    await client.get('/test');
-
     const calledHeaders = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
     expect(calledHeaders).not.toHaveProperty('Authorization');
   });
@@ -49,7 +37,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({ error: 'Unauthorized' }),
     });
 
-    const client = new ApiClient('https://api.test.com', 'cr_bad');
+    const client = new ApiClient('https://api.test.com');
     await expect(client.get('/test')).rejects.toThrow('Unauthorized');
   });
 
@@ -60,7 +48,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({ error: 'Internal server error' }),
     });
 
-    const client = new ApiClient('https://api.test.com', 'cr_key');
+    const client = new ApiClient('https://api.test.com');
     await expect(client.get('/test')).rejects.toThrow('Internal server error');
   });
 
@@ -70,7 +58,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({ id: '123' }),
     });
 
-    const client = new ApiClient('https://api.test.com', 'cr_key');
+    const client = new ApiClient('https://api.test.com');
     const result = await client.post('/agents', { model: 'gpt-4' });
 
     expect(result).toEqual({ id: '123' });
@@ -97,7 +85,7 @@ describe('ApiClient', () => {
       json: () => Promise.reject(new Error('not json')),
     });
 
-    const client = new ApiClient('https://api.test.com', 'cr_key');
+    const client = new ApiClient('https://api.test.com');
     await expect(client.get('/test')).rejects.toThrow('HTTP 502');
   });
 
@@ -109,7 +97,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({ data: 'test' }),
     });
 
-    const client = new ApiClient('https://api.test.com', null, true);
+    const client = new ApiClient('https://api.test.com', true);
     await client.post('/tasks/poll', { agent_id: 'a1' });
 
     expect(debugSpy).toHaveBeenCalledWith('[ApiClient] POST /tasks/poll');
@@ -125,7 +113,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({}),
     });
 
-    const client = new ApiClient('https://api.test.com', null, false);
+    const client = new ApiClient('https://api.test.com', false);
     await client.get('/test');
 
     expect(debugSpy).not.toHaveBeenCalled();
@@ -140,7 +128,7 @@ describe('ApiClient', () => {
       json: () => Promise.resolve({ error: 'Not found' }),
     });
 
-    const client = new ApiClient('https://api.test.com', null, true);
+    const client = new ApiClient('https://api.test.com', true);
     await expect(client.get('/missing')).rejects.toThrow('Not found');
 
     expect(debugSpy).toHaveBeenCalledWith('[ApiClient] GET /missing');

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -24,7 +24,6 @@ export interface LocalAgentConfig {
 }
 
 export interface CliConfig {
-  apiKey: string | null;
   platformUrl: string;
   maxDiffSizeKb: number;
   githubToken: string | null;
@@ -146,7 +145,6 @@ function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
 
 export function loadConfig(): CliConfig {
   const defaults: CliConfig = {
-    apiKey: null,
     platformUrl: DEFAULT_PLATFORM_URL,
     maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
     githubToken: null,
@@ -168,7 +166,6 @@ export function loadConfig(): CliConfig {
   }
 
   return {
-    apiKey: typeof data.api_key === 'string' ? data.api_key : null,
     platformUrl: typeof data.platform_url === 'string' ? data.platform_url : DEFAULT_PLATFORM_URL,
     maxDiffSizeKb:
       typeof data.max_diff_size_kb === 'number' ? data.max_diff_size_kb : DEFAULT_MAX_DIFF_SIZE_KB,
@@ -185,9 +182,6 @@ export function saveConfig(config: CliConfig): void {
   const data: Record<string, unknown> = {
     platform_url: config.platformUrl,
   };
-  if (config.apiKey) {
-    data.api_key = config.apiKey;
-  }
   if (config.githubToken) {
     data.github_token = config.githubToken;
   }

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -15,7 +15,6 @@ export class ApiClient {
 
   constructor(
     private readonly baseUrl: string,
-    private readonly apiKey: string | null = null,
     debug?: boolean,
   ) {
     this.debug = debug ?? process.env.OPENCARA_DEBUG === '1';
@@ -26,13 +25,9 @@ export class ApiClient {
   }
 
   private headers(): Record<string, string> {
-    const h: Record<string, string> = {
+    return {
       'Content-Type': 'application/json',
     };
-    if (this.apiKey) {
-      h['Authorization'] = `Bearer ${this.apiKey}`;
-    }
-    return h;
   }
 
   async get<T>(path: string): Promise<T> {


### PR DESCRIPTION
Closes #236

## Summary
- Remove `apiKey` from `CliConfig` interface — field was parsed but never used
- Remove `apiKey` parameter from `ApiClient` constructor — no platform auth exists
- Remove `api_key` section from config template
- Update tests to reflect removal

## Test plan
- [x] All 592 tests pass
- [x] Lint, format, typecheck clean
- [x] Config still correctly ignores old `api_key` fields in existing config files