### PR TITLE
[server-dev] Auto-shutdown agent after too many consecutive errors

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -105,6 +105,11 @@ agents:
 # Default: 100
 # max_diff_size_kb: 100
 
+# Maximum consecutive poll errors before the agent shuts down.
+# Prevents infinite loops when the platform is unreachable.
+# Default: 10
+# max_consecutive_errors: 10
+
 # Codebase context: clone repos locally for context-aware reviews.
 # When set, the CLI shallow-clones repos and runs tool commands from within
 # the local checkout. The tool command's cwd is set automatically.

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -46,6 +46,7 @@ describe('agent poll loop', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    process.exitCode = undefined;
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -635,5 +636,84 @@ describe('agent poll loop', () => {
     expect(diffFetchInit).toBeDefined();
     expect(diffFetchInit!.signal).toBeInstanceOf(AbortSignal);
     expect(diffFetchInit!.signal!.aborted).toBe(false);
+  });
+
+  it('exits after maxConsecutiveErrors threshold', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        maxConsecutiveErrors: 3,
+      },
+    );
+
+    // Advance through 3 consecutive errors with backoff
+    // poll 1: error (consecutive=1), no extra backoff, sleep 100
+    await vi.advanceTimersByTimeAsync(100);
+    // poll 2: error (consecutive=2), backoff=200, extra 100, sleep 100
+    await vi.advanceTimersByTimeAsync(300);
+    // poll 3: error (consecutive=3) → exits
+    await vi.advanceTimersByTimeAsync(100);
+
+    await promise;
+
+    expect(console.error).toHaveBeenCalledWith('Too many consecutive errors (3/3). Shutting down.');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('resets consecutive error count on successful poll', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      // Fail first 2, then succeed, then fail 2 more, then succeed forever
+      if (callCount <= 2 || (callCount >= 4 && callCount <= 5)) {
+        return Promise.reject(new Error('Network error'));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    void startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        maxConsecutiveErrors: 3,
+      },
+    );
+
+    // Advance enough for 6 polls (errors reset on success, never hits 3 consecutive)
+    // poll 1: error (1), sleep 100
+    await vi.advanceTimersByTimeAsync(100);
+    // poll 2: error (2), backoff extra 100, sleep 100
+    await vi.advanceTimersByTimeAsync(300);
+    // poll 3: success (reset to 0), sleep 100
+    await vi.advanceTimersByTimeAsync(100);
+    // poll 4: error (1), sleep 100
+    await vi.advanceTimersByTimeAsync(100);
+    // poll 5: error (2), backoff extra 100, sleep 100
+    await vi.advanceTimersByTimeAsync(300);
+    // poll 6: success (reset to 0), sleep 100
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should still be running — never hit 3 consecutive
+    expect(console.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('Too many consecutive errors'),
+    );
   });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -23,6 +23,7 @@ import {
   CONFIG_FILE,
   DEFAULT_PLATFORM_URL,
   DEFAULT_MAX_DIFF_SIZE_KB,
+  DEFAULT_MAX_CONSECUTIVE_ERRORS,
 } from '../config.js';
 
 describe('config', () => {
@@ -57,6 +58,7 @@ describe('config', () => {
 
       expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
       expect(config.maxDiffSizeKb).toBe(DEFAULT_MAX_DIFF_SIZE_KB);
+      expect(config.maxConsecutiveErrors).toBe(DEFAULT_MAX_CONSECUTIVE_ERRORS);
       expect(config.githubToken).toBeNull();
       expect(config.codebaseDir).toBeNull();
       expect(config.agentCommand).toBeNull();
@@ -78,6 +80,23 @@ describe('config', () => {
       const config = loadConfig();
 
       expect(config.maxDiffSizeKb).toBe(200);
+    });
+
+    it('parses max_consecutive_errors config field', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('max_consecutive_errors: 5\n');
+
+      const config = loadConfig();
+
+      expect(config.maxConsecutiveErrors).toBe(5);
+    });
+
+    it('returns default for non-number max_consecutive_errors', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('max_consecutive_errors: many\n');
+
+      const config = loadConfig();
+      expect(config.maxConsecutiveErrors).toBe(DEFAULT_MAX_CONSECUTIVE_ERRORS);
     });
 
     it('returns defaults for non-number max_diff_size_kb', () => {
@@ -170,6 +189,7 @@ describe('config', () => {
     const baseConfig = {
       platformUrl: 'https://api.dev',
       maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+      maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
       githubToken: null as string | null,
       codebaseDir: null as string | null,
 
@@ -209,6 +229,20 @@ describe('config', () => {
 
       const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
       expect(content).not.toContain('max_diff_size_kb');
+    });
+
+    it('saves max_consecutive_errors when non-default', () => {
+      saveConfig({ ...baseConfig, maxConsecutiveErrors: 5 });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('max_consecutive_errors: 5');
+    });
+
+    it('does not save max_consecutive_errors when default', () => {
+      saveConfig(baseConfig);
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).not.toContain('max_consecutive_errors');
     });
 
     it('saves agent_command when present', () => {
@@ -282,6 +316,7 @@ describe('config', () => {
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,
@@ -297,6 +332,7 @@ describe('config', () => {
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,
@@ -329,6 +365,7 @@ agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,
@@ -603,6 +640,7 @@ agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,
@@ -651,6 +689,7 @@ agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: 'ghp_xyz789',
         codebaseDir: null,
         agentCommand: null,
@@ -665,6 +704,7 @@ agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,
@@ -757,6 +797,7 @@ anonymous_agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: '~/.opencara/repos',
         agentCommand: null,
@@ -771,6 +812,7 @@ anonymous_agents:
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
         codebaseDir: null,
         agentCommand: null,

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -14,6 +14,7 @@ import {
   loadConfig,
   resolveCodebaseDir,
   resolveGithubToken as resolveConfigToken,
+  DEFAULT_MAX_CONSECUTIVE_ERRORS,
   type LocalAgentConfig,
 } from '../config.js';
 import { cloneOrUpdate } from '../codebase.js';
@@ -138,13 +139,15 @@ async function pollLoop(
   logger: Logger,
   options: {
     pollIntervalMs: number;
+    maxConsecutiveErrors: number;
     routerRelay?: RouterRelay;
     reviewOnly?: boolean;
     repoConfig?: RepoConfig;
     signal?: AbortSignal;
   },
 ): Promise<void> {
-  const { pollIntervalMs, routerRelay, reviewOnly, repoConfig, signal } = options;
+  const { pollIntervalMs, maxConsecutiveErrors, routerRelay, reviewOnly, repoConfig, signal } =
+    options;
   const { log, logError, logWarn } = logger;
 
   log(`Agent ${agentId} polling every ${pollIntervalMs / 1000}s...`);
@@ -209,6 +212,15 @@ async function pollLoop(
         consecutiveAuthErrors = 0;
         consecutiveErrors++;
         logError(`Poll error: ${(err as Error).message}`);
+      }
+
+      // Exit after too many consecutive errors
+      if (consecutiveErrors >= maxConsecutiveErrors) {
+        logError(
+          `Too many consecutive errors (${consecutiveErrors}/${maxConsecutiveErrors}). Shutting down.`,
+        );
+        process.exitCode = 1;
+        break;
       }
 
       // Exponential backoff on consecutive failures
@@ -666,6 +678,7 @@ export async function startAgent(
   consumptionDeps?: ConsumptionDeps,
   options?: {
     pollIntervalMs?: number;
+    maxConsecutiveErrors?: number;
     routerRelay?: RouterRelay;
     reviewOnly?: boolean;
     repoConfig?: RepoConfig;
@@ -712,6 +725,7 @@ export async function startAgent(
 
   await pollLoop(client, agentId, reviewDeps, deps, agentInfo, logger, {
     pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    maxConsecutiveErrors: options?.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
     routerRelay: options?.routerRelay,
     reviewOnly: options?.reviewOnly,
     repoConfig: options?.repoConfig,
@@ -772,6 +786,7 @@ export async function startAgentRouter(): Promise<void> {
       session,
     },
     {
+      maxConsecutiveErrors: config.maxConsecutiveErrors,
       routerRelay: router,
       reviewOnly: agentConfig?.review_only,
       repoConfig: agentConfig?.repos,
@@ -863,6 +878,7 @@ function startAgentByIndex(
     { agentId, session },
     {
       pollIntervalMs,
+      maxConsecutiveErrors: config.maxConsecutiveErrors,
       routerRelay,
       reviewOnly: agentConfig?.review_only,
       repoConfig: agentConfig?.repos,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -19,6 +19,7 @@ export interface LocalAgentConfig {
 export interface CliConfig {
   platformUrl: string;
   maxDiffSizeKb: number;
+  maxConsecutiveErrors: number;
   githubToken: string | null;
   codebaseDir: string | null;
   agentCommand: string | null;
@@ -38,6 +39,7 @@ export function ensureConfigDir(): void {
 }
 
 export const DEFAULT_MAX_DIFF_SIZE_KB = 100;
+export const DEFAULT_MAX_CONSECUTIVE_ERRORS = 10;
 
 const VALID_REPO_MODES: RepoFilterMode[] = ['all', 'own', 'whitelist', 'blacklist'];
 const REPO_PATTERN = /^[^/]+\/[^/]+$/;
@@ -125,6 +127,7 @@ export function loadConfig(): CliConfig {
   const defaults: CliConfig = {
     platformUrl: DEFAULT_PLATFORM_URL,
     maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+    maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
     githubToken: null,
     codebaseDir: null,
     agentCommand: null,
@@ -146,6 +149,10 @@ export function loadConfig(): CliConfig {
     platformUrl: typeof data.platform_url === 'string' ? data.platform_url : DEFAULT_PLATFORM_URL,
     maxDiffSizeKb:
       typeof data.max_diff_size_kb === 'number' ? data.max_diff_size_kb : DEFAULT_MAX_DIFF_SIZE_KB,
+    maxConsecutiveErrors:
+      typeof data.max_consecutive_errors === 'number'
+        ? data.max_consecutive_errors
+        : DEFAULT_MAX_CONSECUTIVE_ERRORS,
     githubToken: typeof data.github_token === 'string' ? data.github_token : null,
     codebaseDir: typeof data.codebase_dir === 'string' ? data.codebase_dir : null,
     agentCommand: typeof data.agent_command === 'string' ? data.agent_command : null,
@@ -166,6 +173,9 @@ export function saveConfig(config: CliConfig): void {
   }
   if (config.maxDiffSizeKb !== DEFAULT_MAX_DIFF_SIZE_KB) {
     data.max_diff_size_kb = config.maxDiffSizeKb;
+  }
+  if (config.maxConsecutiveErrors !== DEFAULT_MAX_CONSECUTIVE_ERRORS) {
+    data.max_consecutive_errors = config.maxConsecutiveErrors;
   }
   if (config.agentCommand) {
     data.agent_command = config.agentCommand;


### PR DESCRIPTION
Closes #245

## Summary
- Add `max_consecutive_errors` config field (default 10) to `CliConfig`
- Agent exits with `process.exitCode = 1` when consecutive general errors exceed the threshold
- Auth errors keep existing 3-attempt limit (unchanged)
- Threshold configurable via `max_consecutive_errors` in config.yml
- Updated config template with documentation

## Test plan
- [x] All 584 tests pass (6 new tests added)
- [x] Test: agent exits after maxConsecutiveErrors threshold
- [x] Test: consecutive error count resets on successful poll
- [x] Test: config parses max_consecutive_errors
- [x] Test: config defaults for non-number max_consecutive_errors
- [x] Test: saveConfig writes/omits max_consecutive_errors
- [x] Build, lint, format, typecheck all pass