### PR TITLE
[server-dev] Add concurrent race condition tests for summary lock (#273)

### DIFF
--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -468,6 +468,10 @@ describe('E2E Scenarios', () => {
       expect(c2.claimed).toBe(false);
     });
 
+    // Note: MemoryTaskStore is synchronous, so Promise.all executes claims
+    // serially in the same microtask turn. These tests validate the locking
+    // logic at the API layer but cannot reproduce true I/O-level races that
+    // occur with Cloudflare KV's eventual consistency.
     it('concurrent summary claims via Promise.all: exactly one wins (#273)', async () => {
       const taskId = await injectPR();
 
@@ -481,6 +485,11 @@ describe('E2E Scenarios', () => {
       // Exactly one agent should win the summary lock
       expect(claimed).toHaveLength(1);
       expect(rejected).toHaveLength(4);
+
+      // All rejected agents should have a reason
+      for (const r of rejected) {
+        expect(r.reason).toBeDefined();
+      }
     });
 
     it('concurrent claims + results: only one GitHub comment posted (#273)', async () => {
@@ -492,7 +501,7 @@ describe('E2E Scenarios', () => {
 
       const winnerIdx = claimResults.findIndex((r) => r.claimed === true);
       expect(winnerIdx).toBeGreaterThanOrEqual(0);
-      const winner = claimAgents[winnerIdx];
+      const winner = claimAgents[winnerIdx]!;
 
       // Count GitHub comment calls before
       const commentsBefore = github.calls.filter(
@@ -510,7 +519,8 @@ describe('E2E Scenarios', () => {
 
       // Task should be in terminal state
       const task = await store.getTask(taskId);
-      expect(['completed', 'failed']).toContain(task?.status);
+      expect(task).toBeDefined();
+      expect(['completed', 'failed']).toContain(task!.status);
     });
   });
 

--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -656,6 +656,11 @@ APPROVE`;
       expect(c4.claimed).toBe(false);
     });
 
+    // Note: MemoryTaskStore is synchronous, so Promise.all executes claims
+    // serially in the same microtask turn. These tests validate the locking
+    // logic at the API layer but cannot reproduce true I/O-level races that
+    // occur with Cloudflare KV's eventual consistency. The lock mechanism
+    // (summary-lock:{taskId} key) is the defense-in-depth for production.
     it('concurrent summary claims: only one agent wins (#273)', async () => {
       await store.createTask(makeTask({ id: 'task-concurrent-summary' }));
 
@@ -682,18 +687,18 @@ APPROVE`;
     it('concurrent summary claims + result: only one GitHub comment posted (#273)', async () => {
       await store.createTask(makeTask({ id: 'task-concurrent-post' }));
 
+      const agentIds = ['synth-a', 'synth-b', 'synth-c'];
+
       // Fire 3 concurrent summary claims
       const claimResults = await Promise.all(
-        ['synth-a', 'synth-b', 'synth-c'].map((agentId) =>
-          claim('task-concurrent-post', agentId, 'summary'),
-        ),
+        agentIds.map((agentId) => claim('task-concurrent-post', agentId, 'summary')),
       );
 
       const winners = claimResults
-        .map((r, i) => ({ result: r, agentId: ['synth-a', 'synth-b', 'synth-c'][i] }))
+        .map((r, i) => ({ result: r, agentId: agentIds[i] }))
         .filter((r) => r.result.claimed === true);
       expect(winners).toHaveLength(1);
-      const winner = winners[0];
+      const winner = winners[0]!;
 
       // Count GitHub comment calls before
       const commentsBefore = githubCalls.filter(


### PR DESCRIPTION
Relates to #273

## Summary
- Add `Promise.all`-based concurrent summary claim tests that fire 5 agents simultaneously
- Verify exactly one agent wins the summary lock, all others rejected
- Test concurrent claims followed by result submission: only one GitHub comment posted
- Tests added to both integration tests and E2E scenarios

## Test plan
- All 733 tests pass (4 new tests)
- Build, lint, format, typecheck all pass