### PR TITLE
[cli-dev] Improve agent logging: show command and PR URL

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -951,4 +951,194 @@ describe('Agent Coverage Tests', () => {
       }
     });
   });
+
+  // ═══════════════════════════════════════════════════════════
+  // PR URL logging (#278) and command logging (#277)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('Logging improvements', () => {
+    it('logs PR URL instead of diff URL when handling a task', async () => {
+      const taskId = await server.injectTask({
+        owner: 'my-org',
+        repo: 'my-repo',
+        prNumber: 42,
+        reviewCount: 2,
+      });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('pr-url-agent');
+        await advanceTime(2000);
+
+        // Should log PR URL, not diff URL
+        expect(console.log).toHaveBeenCalledWith('  https://github.com/my-org/my-repo/pull/42');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('logs review command before executing review task', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('review-cmd-agent');
+        await advanceTime(2000);
+
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.type).toBe('review');
+        expect(console.log).toHaveBeenCalledWith('  Executing review command: echo test');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('logs summary command before executing summary task', async () => {
+      const taskId = await server.injectTask({ reviewCount: 1 });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('summary-cmd-agent');
+        await advanceTime(2000);
+
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.type).toBe('summary');
+        expect(console.log).toHaveBeenCalledWith('  Executing summary command: echo test');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('sanitizes tokens in logged command', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        // Use a command template with a GitHub token embedded
+        const deps = makeDeps('sanitize-agent');
+        const reviewDeps: ReviewExecutorDeps = {
+          ...deps.reviewDeps,
+          commandTemplate: 'claude --token ghp_secrettoken123abc --print',
+        };
+
+        const agentPromise = startAgent(
+          'sanitize-agent',
+          FAKE_SERVER_URL,
+          { model: 'test', tool: 'test' },
+          reviewDeps,
+          deps.consumptionDeps,
+          { pollIntervalMs: 100 },
+        );
+
+        await advanceTime(2000);
+
+        // The command should be logged with the token sanitized
+        expect(console.log).toHaveBeenCalledWith(
+          '  Executing review command: claude --token *** --print',
+        );
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('logs router mode for review command in router relay', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+      const mockRelay = {
+        start: vi.fn(),
+        stop: vi.fn(),
+        buildReviewPrompt: vi.fn(() => 'router review prompt'),
+        buildSummaryPrompt: vi.fn(() => 'router summary prompt'),
+        sendPrompt: vi.fn(async () => '## Summary\nRouter OK\n\n## Verdict\nAPPROVE'),
+        parseReviewResponse: vi.fn(() => ({ review: 'Router OK', verdict: 'approve' })),
+      };
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const deps = makeDeps('router-log-agent');
+        const promise = startAgent(
+          'router-log-agent',
+          FAKE_SERVER_URL,
+          { model: 'test', tool: 'test' },
+          deps.reviewDeps,
+          deps.consumptionDeps,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { pollIntervalMs: 100, routerRelay: mockRelay as any },
+        );
+
+        await advanceTime(2000);
+
+        expect(console.log).toHaveBeenCalledWith('  Executing review command: [router mode]');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(promise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -268,7 +268,7 @@ async function handleTask(
   const { log, logError, logWarn } = logger;
 
   log(`\nTask ${task_id}: PR #${pr_number} on ${owner}/${repo} (role: ${role})`);
-  log(`  ${diff_url}`);
+  log(`  https://github.com/${owner}/${repo}/pull/${pr_number}`);
 
   // Claim the task (retry once — slot may be taken)
   let claimResponse: ClaimResponse;
@@ -468,6 +468,7 @@ async function executeReviewTask(
 
   if (routerRelay) {
     // Router mode: relay to external agent
+    logger.log(`  Executing review command: [router mode]`);
     const fullPrompt = routerRelay.buildReviewPrompt({
       owner,
       repo,
@@ -487,6 +488,7 @@ async function executeReviewTask(
     tokensUsed = estimateTokens(fullPrompt) + estimateTokens(response);
   } else {
     // Direct mode: execute tool locally
+    logger.log(`  Executing review command: ${reviewDeps.commandTemplate}`);
     const result = await executeReview(
       {
         taskId,
@@ -552,6 +554,7 @@ async function executeSummaryTask(
     let tokensUsed: number;
 
     if (routerRelay) {
+      logger.log(`  Executing summary command: [router mode]`);
       const fullPrompt = routerRelay.buildReviewPrompt({
         owner,
         repo,
@@ -570,6 +573,7 @@ async function executeSummaryTask(
       verdict = parsed.verdict as ReviewVerdict;
       tokensUsed = estimateTokens(fullPrompt) + estimateTokens(response);
     } else {
+      logger.log(`  Executing summary command: ${reviewDeps.commandTemplate}`);
       const result = await executeReview(
         {
           taskId,
@@ -621,6 +625,7 @@ async function executeSummaryTask(
   let tokensUsed: number;
 
   if (routerRelay) {
+    logger.log(`  Executing summary command: [router mode]`);
     const fullPrompt = routerRelay.buildSummaryPrompt({
       owner,
       repo,
@@ -637,6 +642,7 @@ async function executeSummaryTask(
     summaryText = response;
     tokensUsed = estimateTokens(fullPrompt) + estimateTokens(response);
   } else {
+    logger.log(`  Executing summary command: ${reviewDeps.commandTemplate}`);
     const result = await executeSummary(
       {
         taskId,


### PR DESCRIPTION
Closes #277
Closes #278

## Summary
- Log PR URL (`https://github.com/owner/repo/pull/N`) instead of diff URL when a task is picked up (#278)
- Log the executed command template before running review and summary tasks (#277)
- Token sanitization is automatic via `createLogger` which wraps all output through `sanitizeTokens`
- Router mode logs `[router mode]` instead of a command template

## Test plan
- [x] PR URL logged instead of diff URL (verified via test)
- [x] Review command logged before execution (verified via test)
- [x] Summary command logged before execution (verified via test)
- [x] Tokens sanitized in logged command (verified via test with embedded `ghp_` token)
- [x] Router mode shows `[router mode]` (verified via test)
- [x] All 738 existing tests pass
- [x] `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` all pass