### PR TITLE
[server-dev] Private repo task isolation — filter private tasks in poll

### DIFF
--- a/packages/cli/src/__tests__/helpers/fake-server.ts
+++ b/packages/cli/src/__tests__/helpers/fake-server.ts
@@ -197,6 +197,7 @@ export class FakeServer {
     prNumber?: number;
     reviewCount?: number;
     timeout?: string;
+    private?: boolean;
   }): Promise<string> {
     const config: ReviewConfig = {
       ...DEFAULT_REVIEW_CONFIG,
@@ -216,6 +217,7 @@ export class FakeServer {
           owner: opts?.owner ?? 'test-org',
           repo: opts?.repo ?? 'test-repo',
           pr_number: opts?.prNumber ?? 1,
+          ...(opts?.private !== undefined ? { private: opts.private } : {}),
           config,
         }),
       },

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -163,9 +163,12 @@ async function pollLoop(
 
   while (!signal?.aborted) {
     try {
-      // Poll for tasks
+      // Poll for tasks — include whitelist repos so server can return matching private tasks
       const pollBody: Record<string, unknown> = { agent_id: agentId };
       if (reviewOnly) pollBody.review_only = true;
+      if (repoConfig?.mode === 'whitelist' && repoConfig.list?.length) {
+        pollBody.repos = repoConfig.list;
+      }
       const pollResponse = await client.post<PollResponse>('/api/tasks/poll', pollBody);
 
       consecutiveAuthErrors = 0;

--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -52,6 +52,7 @@ function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
     timeout_at: Date.now() + 600_000,
     status: 'pending',
     github_installation_id: 999,
+    private: false,
     config: DEFAULT_REVIEW_CONFIG,
     created_at: Date.now(),
     ...overrides,

--- a/packages/server/src/__tests__/routes-health.test.ts
+++ b/packages/server/src/__tests__/routes-health.test.ts
@@ -27,6 +27,7 @@ function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
     timeout_at: Date.now() + 600_000,
     status: 'pending',
     github_installation_id: 999,
+    private: false,
     config: DEFAULT_REVIEW_CONFIG,
     created_at: Date.now(),
     ...overrides,

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -24,6 +24,7 @@ function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
     timeout_at: Date.now() + 600_000,
     status: 'pending',
     github_installation_id: 123,
+    private: false,
     config: DEFAULT_REVIEW_CONFIG,
     created_at: Date.now(),
     ...overrides,
@@ -149,6 +150,60 @@ describe('Task Routes', () => {
       const body = await res.json();
       expect(body.tasks).toHaveLength(1);
       expect(body.tasks[0].role).toBe('summary');
+    });
+
+    // ── Private repo filtering ────────────────────────────
+
+    it('hides private repo tasks from agents without matching repos', async () => {
+      await store.createTask(makeTask({ private: true }));
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('returns private repo tasks to agents with matching repos', async () => {
+      await store.createTask(makeTask({ private: true }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        repos: ['test-org/test-repo'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('task-1');
+    });
+
+    it('hides private repo tasks when agent repos do not match', async () => {
+      await store.createTask(makeTask({ private: true }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        repos: ['other-org/other-repo'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('returns public tasks to all agents regardless of repos', async () => {
+      await store.createTask(makeTask({ private: false }));
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+    });
+
+    it('returns public tasks plus matching private tasks', async () => {
+      await store.createTask(makeTask({ id: 'public-task', private: false }));
+      await store.createTask(
+        makeTask({ id: 'private-match', private: true, owner: 'priv-org', repo: 'priv-repo' }),
+      );
+      await store.createTask(
+        makeTask({ id: 'private-no-match', private: true, owner: 'secret-org', repo: 'secret' }),
+      );
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        repos: ['priv-org/priv-repo'],
+      });
+      const body = await res.json();
+      const ids = body.tasks.map((t: { task_id: string }) => t.task_id).sort();
+      expect(ids).toEqual(['private-match', 'public-task']);
     });
   });
 

--- a/packages/server/src/__tests__/store-kv.test.ts
+++ b/packages/server/src/__tests__/store-kv.test.ts
@@ -66,6 +66,7 @@ function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
     timeout_at: Date.now() + 600_000,
     status: 'pending',
     github_installation_id: 123,
+    private: false,
     config: DEFAULT_REVIEW_CONFIG,
     created_at: Date.now(),
     ...overrides,

--- a/packages/server/src/__tests__/store-memory.test.ts
+++ b/packages/server/src/__tests__/store-memory.test.ts
@@ -18,6 +18,7 @@ function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
     timeout_at: Date.now() + 600_000,
     status: 'pending',
     github_installation_id: 123,
+    private: false,
     config: DEFAULT_REVIEW_CONFIG,
     created_at: Date.now(),
     ...overrides,

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -269,11 +269,14 @@ export function taskRoutes() {
   app.post('/api/tasks/poll', rateLimitByAgent(POLL_RATE_LIMIT), async (c) => {
     const store = c.get('store');
     const body = await c.req.json<PollRequest>();
-    const { agent_id, review_only } = body;
+    const { agent_id, review_only, repos } = body;
 
     if (!agent_id) {
       return c.json({ error: 'agent_id is required' }, 400);
     }
+
+    // Build a set of repos the agent declares for fast lookup
+    const agentRepos = repos && repos.length > 0 ? new Set(repos) : null;
 
     // Update last-seen
     await store.setAgentLastSeen(agent_id, Date.now());
@@ -286,6 +289,11 @@ export function taskRoutes() {
     const available: PollTask[] = [];
 
     for (const task of tasks) {
+      // Private repo tasks: only return to agents declaring matching repos
+      if (task.private && (!agentRepos || !agentRepos.has(`${task.owner}/${task.repo}`))) {
+        continue;
+      }
+
       const role = availableRole(task, agent_id);
       if (!role) continue;
       if (review_only && role === 'summary') continue;

--- a/packages/server/src/routes/test.ts
+++ b/packages/server/src/routes/test.ts
@@ -30,6 +30,7 @@ export function testRoutes() {
       head_ref?: string;
       draft?: boolean;
       labels?: string[];
+      private?: boolean;
       config?: Partial<ReviewConfig>;
     }>();
 
@@ -56,6 +57,7 @@ export function testRoutes() {
       baseRef,
       headRef,
       config,
+      body.private ?? false,
     );
 
     if (!taskId) {

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -12,7 +12,7 @@ const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRI
 interface PullRequestPayload {
   action: string;
   installation?: { id: number };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private?: boolean };
   pull_request: {
     number: number;
     html_url: string;
@@ -27,7 +27,7 @@ interface PullRequestPayload {
 interface IssueCommentPayload {
   action: string;
   installation?: { id: number };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private?: boolean };
   issue: {
     number: number;
     pull_request?: { url: string };
@@ -100,6 +100,7 @@ export async function createTaskForPR(
   baseRef: string,
   headRef: string,
   config: ReviewConfig,
+  isPrivate: boolean,
 ): Promise<string | null> {
   // Check for existing active task on this PR (dedup guard)
   const activeTasks = await store.listTasks({ status: ['pending', 'reviewing'] });
@@ -130,6 +131,7 @@ export async function createTaskForPR(
     timeout_at: Date.now() + timeoutMs,
     status: 'pending',
     github_installation_id: installationId,
+    private: isPrivate,
     config,
     created_at: Date.now(),
   });
@@ -244,6 +246,7 @@ async function handlePullRequest(
     pull_request.base.ref,
     headRef,
     config,
+    repository.private ?? false,
   );
 
   return new Response('OK', { status: 200 });
@@ -312,6 +315,7 @@ async function handleIssueComment(
     pr.base.ref,
     pr.head.ref,
     config,
+    repository.private ?? false,
   );
 
   return new Response('OK', { status: 200 });

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -6,6 +6,7 @@ import type { ClaimRole, ReviewVerdict } from './types.js';
 export interface PollRequest {
   agent_id: string;
   review_only?: boolean;
+  repos?: string[]; // "owner/repo" entries — used to include matching private repo tasks
 }
 
 /** A task returned in the poll response */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -34,6 +34,7 @@ export interface ReviewTask {
   timeout_at: number; // unix ms
   status: TaskStatus;
   github_installation_id: number;
+  private: boolean; // true if the source repo is private
   config: import('./review-config.js').ReviewConfig; // parsed .review.yml
   created_at: number;
   // Claim counters — updated atomically on task to avoid KV list() consistency issues


### PR DESCRIPTION
Closes #282

## Summary
- Add `private` boolean flag to `ReviewTask`, set from `repository.private` in webhook payload
- Add optional `repos` field to `PollRequest` — list of `owner/repo` strings the agent is willing to review
- Poll endpoint filters: public tasks returned to all agents; private tasks only to agents with matching `repos`
- CLI automatically sends whitelist repos in poll requests when agent has `repos.mode: whitelist`
- 5 new tests covering all private repo filtering scenarios

## Test plan
- [x] Private repo tasks hidden from agents without matching repos
- [x] Private repo tasks returned to agents with matching repos
- [x] Private repo tasks hidden when agent repos don't match
- [x] Public tasks returned to all agents regardless of repos
- [x] Mixed public + private: only matching private tasks returned
- [x] All 746 existing tests pass
- [x] `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` all pass