### PR TITLE
[server-dev] Structured error responses with error codes

### DIFF
--- a/packages/cli/src/__tests__/agent-cli.test.ts
+++ b/packages/cli/src/__tests__/agent-cli.test.ts
@@ -85,7 +85,7 @@ describe('Agent CLI tests', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
-      json: () => Promise.resolve({ error: 'Unauthorized' }),
+      json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
     });
   });
 

--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -62,7 +62,7 @@ async function stopAgent(promise: Promise<void>, server: FakeServer): Promise<vo
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: false,
     status: 401,
-    json: () => Promise.resolve({ error: 'shutdown' }),
+    json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
   });
   await advanceTime(3000);
   await promise;
@@ -313,7 +313,7 @@ describe('Agent Coverage Tests', () => {
         globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'shutdown' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
         });
         await advanceTime(3000);
         await promise;
@@ -393,7 +393,7 @@ describe('Agent Coverage Tests', () => {
         globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'shutdown' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
         });
         await advanceTime(3000);
         await promise;
@@ -474,7 +474,7 @@ describe('Agent Coverage Tests', () => {
         globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'shutdown' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
         });
         await advanceTime(3000);
         await promise;
@@ -517,9 +517,12 @@ describe('Agent Coverage Tests', () => {
           );
         }
 
-        // Claim returns 409 Conflict
+        // Claim returns 409 Conflict with structured error
         if (url.includes('/claim')) {
-          return new Response(JSON.stringify({ error: 'Conflict' }), { status: 409 });
+          return new Response(
+            JSON.stringify({ error: { code: 'CLAIM_CONFLICT', message: 'No slots available' } }),
+            { status: 409 },
+          );
         }
 
         return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
@@ -538,12 +541,13 @@ describe('Agent Coverage Tests', () => {
 
         await advanceTime(2000);
 
-        expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to claim task'));
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Claim rejected'));
 
         globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'shutdown' }),
+          json: () =>
+            Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Invalid credentials' } }),
         });
         await advanceTime(3000);
         await promise;
@@ -954,7 +958,7 @@ describe('Agent Coverage Tests', () => {
         globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'shutdown' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
         });
         await advanceTime(3000);
         await promise;

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -56,7 +56,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -184,7 +184,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -237,10 +237,14 @@ describe('agent poll loop', () => {
       // Claim call — capture the body
       if (urlStr.includes('/claim')) {
         claimBody = JSON.parse(init?.body as string);
-        // Return claimed: false so the loop doesn't try to fetch a diff
+        // Return structured error so the loop doesn't try to fetch a diff
         return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ claimed: false, reason: 'test' }),
+          ok: false,
+          status: 409,
+          json: () =>
+            Promise.resolve({
+              error: { code: 'CLAIM_CONFLICT', message: 'No slots available' },
+            }),
         });
       }
 
@@ -284,7 +288,7 @@ describe('agent poll loop', () => {
         return Promise.resolve({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'Unauthorized' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
         });
       }
 
@@ -323,7 +327,7 @@ describe('agent poll loop', () => {
         return Promise.resolve({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'Unauthorized' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
         });
       }
 
@@ -356,7 +360,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -390,7 +394,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -427,7 +431,7 @@ describe('agent poll loop', () => {
         return Promise.resolve({
           ok: false,
           status: 401,
-          json: () => Promise.resolve({ error: 'Unauthorized' }),
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
         });
       }
       if (callCount === 3) {
@@ -472,7 +476,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -506,7 +510,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 
@@ -538,7 +542,7 @@ describe('agent poll loop', () => {
       Promise.resolve({
         ok: false,
         status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
+        json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
       }),
     );
 

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -63,7 +63,7 @@ async function stopAgent(promise: Promise<void>, server: FakeServer): Promise<vo
   globalThis.fetch = vi.fn().mockResolvedValue({
     ok: false,
     status: 401,
-    json: () => Promise.resolve({ error: 'shutdown' }),
+    json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
   });
   await advanceTime(3000);
   await promise;

--- a/packages/cli/src/__tests__/http.test.ts
+++ b/packages/cli/src/__tests__/http.test.ts
@@ -30,26 +30,37 @@ describe('ApiClient', () => {
     expect(calledHeaders).not.toHaveProperty('Authorization');
   });
 
-  it('throws HttpError with server error message on 401', async () => {
+  it('throws HttpError with structured error message on 401', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
-      json: () => Promise.resolve({ error: 'Unauthorized' }),
+      json: () =>
+        Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Invalid webhook signature' } }),
     });
 
     const client = new ApiClient('https://api.test.com');
-    await expect(client.get('/test')).rejects.toThrow('Unauthorized');
+    const err = await client.get('/test').catch((e: HttpError) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.message).toBe('Invalid webhook signature');
+    expect(err.errorCode).toBe('UNAUTHORIZED');
+    expect(err.status).toBe(401);
   });
 
-  it('throws HttpError with server error message', async () => {
+  it('throws HttpError with structured error message on 500', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-      json: () => Promise.resolve({ error: 'Internal server error' }),
+      json: () =>
+        Promise.resolve({
+          error: { code: 'INTERNAL_ERROR', message: 'Internal Server Error' },
+        }),
     });
 
     const client = new ApiClient('https://api.test.com');
-    await expect(client.get('/test')).rejects.toThrow('Internal server error');
+    const err = await client.get('/test').catch((e: HttpError) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect(err.message).toBe('Internal Server Error');
+    expect(err.errorCode).toBe('INTERNAL_ERROR');
   });
 
   it('post sends JSON body', async () => {
@@ -71,11 +82,16 @@ describe('ApiClient', () => {
     );
   });
 
-  it('HttpError has correct status', async () => {
+  it('HttpError has correct status and optional errorCode', async () => {
     const err = new HttpError(403, 'Forbidden');
     expect(err.status).toBe(403);
     expect(err.message).toBe('Forbidden');
     expect(err.name).toBe('HttpError');
+    expect(err.errorCode).toBeUndefined();
+
+    const err2 = new HttpError(429, 'Rate limit exceeded', 'RATE_LIMITED');
+    expect(err2.status).toBe(429);
+    expect(err2.errorCode).toBe('RATE_LIMITED');
   });
 
   it('falls back to generic message when error response is not JSON', async () => {
@@ -86,7 +102,9 @@ describe('ApiClient', () => {
     });
 
     const client = new ApiClient('https://api.test.com');
-    await expect(client.get('/test')).rejects.toThrow('HTTP 502');
+    const err = await client.get('/test').catch((e: HttpError) => e);
+    expect(err.message).toBe('HTTP 502');
+    expect(err.errorCode).toBeUndefined();
   });
 
   it('logs requests in debug mode', async () => {
@@ -125,14 +143,14 @@ describe('ApiClient', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,
-      json: () => Promise.resolve({ error: 'Not found' }),
+      json: () => Promise.resolve({ error: { code: 'TASK_NOT_FOUND', message: 'Task not found' } }),
     });
 
     const client = new ApiClient('https://api.test.com', true);
-    await expect(client.get('/missing')).rejects.toThrow('Not found');
+    await expect(client.get('/missing')).rejects.toThrow('Task not found');
 
     expect(debugSpy).toHaveBeenCalledWith('[ApiClient] GET /missing');
-    expect(debugSpy).toHaveBeenCalledWith('[ApiClient] 404 Not found (/missing)');
+    expect(debugSpy).toHaveBeenCalledWith('[ApiClient] 404 Task not found (/missing)');
     debugSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -278,6 +278,8 @@ async function handleTask(
   log(`  https://github.com/${owner}/${repo}/pull/${pr_number}`);
 
   // Claim the task (retry once — slot may be taken)
+  // On failure, server returns structured error (e.g. CLAIM_CONFLICT, TASK_NOT_FOUND)
+  // which the ApiClient converts to an HttpError.
   let claimResponse: ClaimResponse;
   try {
     claimResponse = await withRetry(
@@ -292,13 +294,12 @@ async function handleTask(
       signal,
     );
   } catch (err) {
-    const status = err instanceof HttpError ? ` (${err.status})` : '';
-    logError(`  Failed to claim task ${task_id}${status}: ${(err as Error).message}`);
-    return {};
-  }
-
-  if (!claimResponse.claimed) {
-    log(`  Claim rejected: ${(claimResponse as { reason: string }).reason}`);
+    if (err instanceof HttpError) {
+      const codeInfo = err.errorCode ? ` [${err.errorCode}]` : '';
+      logError(`  Claim rejected${codeInfo}: ${err.message}`);
+    } else {
+      logError(`  Failed to claim task ${task_id}: ${(err as Error).message}`);
+    }
     return {};
   }
 

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -1,9 +1,10 @@
-import type { ErrorResponse } from '@opencara/shared';
+import type { ErrorCode, ErrorResponse } from '@opencara/shared';
 
 export class HttpError extends Error {
   constructor(
     public readonly status: number,
     message: string,
+    public readonly errorCode?: ErrorCode,
   ) {
     super(message);
     this.name = 'HttpError';
@@ -52,14 +53,19 @@ export class ApiClient {
   private async handleResponse<T>(res: Response, path: string): Promise<T> {
     if (!res.ok) {
       let message = `HTTP ${res.status}`;
+      let errorCode: ErrorCode | undefined;
       try {
         const body = (await res.json()) as ErrorResponse;
-        if (body.error) message = body.error;
+        if (body.error && typeof body.error === 'object' && 'code' in body.error) {
+          // Structured error response
+          errorCode = body.error.code;
+          message = body.error.message;
+        }
       } catch {
-        // ignore parse errors
+        // ignore parse errors — keep generic message
       }
       this.log(`${res.status} ${message} (${path})`);
-      throw new HttpError(res.status, message);
+      throw new HttpError(res.status, message, errorCode);
     }
     this.log(`${res.status} OK (${path})`);
     return (await res.json()) as T;

--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -322,7 +322,7 @@ describe('Server app edge cases', () => {
     );
     expect(res.status).toBe(404);
     const body = await res.json();
-    expect(body).toEqual({ error: 'Not Found' });
+    expect(body).toEqual({ error: { code: 'INVALID_REQUEST', message: 'Not Found' } });
   });
 });
 

--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -486,9 +486,11 @@ describe('E2E Scenarios', () => {
       expect(claimed).toHaveLength(1);
       expect(rejected).toHaveLength(4);
 
-      // All rejected agents should have a reason
+      // All rejected agents should have an error
       for (const r of rejected) {
-        expect(r.reason).toBeDefined();
+        if ('error' in r) {
+          expect(r.error.code).toBeDefined();
+        }
       }
     });
 
@@ -583,8 +585,8 @@ describe('E2E Scenarios', () => {
       const a = agent('late-agent');
       const c = await a.claim(taskId, 'summary');
       expect(c.claimed).toBe(false);
-      if (!c.claimed) {
-        expect(c.reason).toContain('timed out');
+      if ('error' in c) {
+        expect(c.error.message).toContain('timed out');
       }
     });
   });
@@ -679,7 +681,8 @@ describe('E2E Scenarios', () => {
       await a.claim(taskId, 'review');
       const result = await a.submitResult(taskId, 'summary', 'Synthesized review');
       expect(result.status).toBe(400);
-      expect(result.body.error).toContain("does not match submission type 'summary'");
+      expect(result.body.error.code).toBe('INVALID_REQUEST');
+      expect(result.body.error.message).toContain("does not match submission type 'summary'");
     });
 
     it('summary claimer cannot submit as review', async () => {
@@ -689,7 +692,8 @@ describe('E2E Scenarios', () => {
       await a.claim(taskId, 'summary');
       const result = await a.submitResult(taskId, 'review', 'Individual review');
       expect(result.status).toBe(400);
-      expect(result.body.error).toContain("does not match submission type 'review'");
+      expect(result.body.error.code).toBe('INVALID_REQUEST');
+      expect(result.body.error.message).toContain("does not match submission type 'review'");
     });
   });
 

--- a/packages/server/src/__tests__/errors.test.ts
+++ b/packages/server/src/__tests__/errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { apiError } from '../errors.js';
+
+describe('apiError', () => {
+  it('returns structured error with correct status and body', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => apiError(c, 400, 'INVALID_REQUEST', 'Missing field'));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: {
+        code: 'INVALID_REQUEST',
+        message: 'Missing field',
+      },
+    });
+  });
+
+  it('returns 404 with TASK_NOT_FOUND', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => apiError(c, 404, 'TASK_NOT_FOUND', 'Task not found'));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('TASK_NOT_FOUND');
+  });
+
+  it('returns 429 with RATE_LIMITED', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => apiError(c, 429, 'RATE_LIMITED', 'Too many requests'));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error.code).toBe('RATE_LIMITED');
+  });
+
+  it('returns 500 with INTERNAL_ERROR', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => apiError(c, 500, 'INTERNAL_ERROR', 'Something went wrong'));
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(body.error.message).toBe('Something went wrong');
+  });
+});

--- a/packages/server/src/__tests__/helpers/mock-agent.ts
+++ b/packages/server/src/__tests__/helpers/mock-agent.ts
@@ -11,10 +11,16 @@ import type {
   ClaimResponse,
   ClaimRole,
   ReviewVerdict,
+  ErrorResponse,
 } from '@opencara/shared';
 import type { Env, AppVariables } from '../../types.js';
 
 type HonoApp = Hono<{ Bindings: Env; Variables: AppVariables }>;
+
+/** Extended claim result: either a successful ClaimResponse or a structured error. */
+export type ClaimResult =
+  | (ClaimResponse & { _status: 200 })
+  | { claimed: false; error: ErrorResponse['error']; _status: number };
 
 export class MockAgent {
   constructor(
@@ -45,19 +51,24 @@ export class MockAgent {
     return body.tasks;
   }
 
-  /** Claim a task with a specific role. */
+  /** Claim a task with a specific role. Returns success or structured error. */
   async claim(
     taskId: string,
     role: ClaimRole,
     opts?: { model?: string; tool?: string },
-  ): Promise<ClaimResponse> {
+  ): Promise<ClaimResult> {
     const res = await this.request('POST', `/api/tasks/${taskId}/claim`, {
       agent_id: this.agentId,
       role,
       model: opts?.model,
       tool: opts?.tool,
     });
-    return (await res.json()) as ClaimResponse;
+    const body = (await res.json()) as ClaimResponse | ErrorResponse;
+    if (res.status === 200) {
+      return { ...(body as ClaimResponse), _status: 200 };
+    }
+    const err = body as ErrorResponse;
+    return { claimed: false, error: err.error, _status: res.status };
   }
 
   /** Submit a review result. Returns status and parsed body. */
@@ -102,7 +113,7 @@ export class MockAgent {
    */
   async pollAndClaim(
     role?: ClaimRole,
-  ): Promise<{ taskId: string; claimResponse: ClaimResponse } | null> {
+  ): Promise<{ taskId: string; claimResponse: ClaimResult } | null> {
     const tasks = await this.poll(role === 'review' ? { reviewOnly: true } : undefined);
     if (tasks.length === 0) return null;
 

--- a/packages/server/src/__tests__/helpers/test-server.ts
+++ b/packages/server/src/__tests__/helpers/test-server.ts
@@ -2,6 +2,7 @@
  * Test server factory — creates a Hono app with test routes mounted.
  */
 import { Hono } from 'hono';
+import type { ErrorResponse } from '@opencara/shared';
 import type { Env, AppVariables } from '../../types.js';
 import type { TaskStore } from '../../store/interface.js';
 import { webhookRoutes } from '../../routes/webhook.js';
@@ -37,12 +38,17 @@ export function createTestApp(store: TaskStore): HonoApp {
   app.route('/', testRoutes());
 
   // 404
-  app.notFound((c) => c.json({ error: 'Not Found' }, 404));
+  app.notFound((c) =>
+    c.json<ErrorResponse>({ error: { code: 'INVALID_REQUEST', message: 'Not Found' } }, 404),
+  );
 
   // Error handler
   app.onError((err, c) => {
     console.error('Unhandled error:', err);
-    return c.json({ error: 'Internal Server Error' }, 500);
+    return c.json<ErrorResponse>(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal Server Error' } },
+      500,
+    );
   });
 
   return app;

--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -109,10 +109,16 @@ describe('Integration: full E2E flows', () => {
     return (await res.json()) as { tasks: Array<Record<string, unknown>> };
   }
 
-  /** Claim a task. */
+  /** Claim a task. Returns success body or error body with claimed=false. */
   async function claim(taskId: string, agentId: string, role: string) {
     const res = await api('POST', `/api/tasks/${taskId}/claim`, { agent_id: agentId, role });
-    return (await res.json()) as Record<string, unknown>;
+    const body = (await res.json()) as Record<string, unknown>;
+    if (res.status !== 200) {
+      // Map structured error to a flat shape for backward-compatible assertions
+      const err = body as { error: { code: string; message: string } };
+      return { claimed: false, reason: err.error.message, errorCode: err.error.code };
+    }
+    return body;
   }
 
   /** Submit a result. */

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -220,7 +220,8 @@ describe('Task Routes', () => {
       const res = await request('POST', '/api/tasks/poll', { agent_id: 'spam-agent' });
       expect(res.status).toBe(429);
       const body = await res.json();
-      expect(body.error).toBe('Rate limit exceeded');
+      expect(body.error.code).toBe('RATE_LIMITED');
+      expect(body.error.message).toBe('Rate limit exceeded');
       expect(res.headers.get('Retry-After')).toBeDefined();
     });
 
@@ -259,9 +260,9 @@ describe('Task Routes', () => {
         agent_id: 'agent-1',
         role: 'summary',
       });
+      expect(res.status).toBe(404);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
-      expect(body.reason).toContain('not found');
+      expect(body.error.code).toBe('TASK_NOT_FOUND');
     });
 
     it('rejects claim with wrong role', async () => {
@@ -270,8 +271,9 @@ describe('Task Routes', () => {
         agent_id: 'agent-1',
         role: 'review',
       });
+      expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
 
     it('rejects double claim from same agent', async () => {
@@ -286,8 +288,9 @@ describe('Task Routes', () => {
         agent_id: 'agent-1',
         role: 'review',
       });
+      expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
 
     it('includes reviews when claiming summary role', async () => {
@@ -390,7 +393,10 @@ describe('Task Routes', () => {
       });
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toContain("Claim role 'review' does not match submission type 'summary'");
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(body.error.message).toContain(
+        "Claim role 'review' does not match submission type 'summary'",
+      );
     });
 
     it('rejects result when submission type does not match claim role (summary claim, review submission)', async () => {
@@ -411,7 +417,10 @@ describe('Task Routes', () => {
       });
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toContain("Claim role 'summary' does not match submission type 'review'");
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(body.error.message).toContain(
+        "Claim role 'summary' does not match submission type 'review'",
+      );
     });
 
     it('rejects result for already completed claim', async () => {
@@ -1020,9 +1029,10 @@ describe('Task Routes', () => {
         agent_id: 'agent-blocked',
         role: 'review',
       });
+      expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
-      expect(body.reason).toContain('blacklisted');
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
+      expect(body.error.message).toContain('blacklisted');
     });
 
     it('claim rejects non-whitelisted agent with reason', async () => {
@@ -1043,9 +1053,10 @@ describe('Task Routes', () => {
         agent_id: 'agent-other',
         role: 'summary',
       });
+      expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
-      expect(body.reason).toContain('not in the summary whitelist');
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
+      expect(body.error.message).toContain('not in the summary whitelist');
     });
 
     it('default config (empty lists) allows all agents — backward compatible', async () => {
@@ -1078,9 +1089,10 @@ describe('Task Routes', () => {
         agent_id: 'agent-both',
         role: 'review',
       });
+      expect(res.status).toBe(409);
       const body = await res.json();
-      expect(body.claimed).toBe(false);
-      expect(body.reason).toContain('blacklisted');
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
+      expect(body.error.message).toContain('blacklisted');
     });
   });
 
@@ -1107,9 +1119,10 @@ describe('Task Routes', () => {
         agent_id: 'agent-b',
         role: 'summary',
       });
+      expect(res2.status).toBe(409);
       const body2 = await res2.json();
-      expect(body2.claimed).toBe(false);
-      expect(body2.reason).toContain('Summary already claimed');
+      expect(body2.error.code).toBe('SUMMARY_LOCKED');
+      expect(body2.error.message).toContain('Summary already claimed');
     });
 
     it('allows summary claim after previous summary claim was rejected (lock released)', async () => {
@@ -1428,8 +1441,9 @@ describe('Task Routes', () => {
           agent_id: 'agent-other',
           role: 'summary',
         });
+        expect(res.status).toBe(409);
         const body = await res.json();
-        expect(body.claimed).toBe(false);
+        expect(body.error.code).toBe('CLAIM_CONFLICT');
       });
 
       it('preferred agent can claim summary during grace period', async () => {

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,0 +1,19 @@
+import type { Context } from 'hono';
+import type { ErrorCode, ErrorResponse } from '@opencara/shared';
+
+type StatusCode = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+
+/**
+ * Return a standardized JSON error response.
+ *
+ * Usage:
+ *   return apiError(c, 400, 'INVALID_REQUEST', 'agent_id is required');
+ */
+export function apiError(
+  c: Context,
+  status: StatusCode,
+  code: ErrorCode,
+  message: string,
+): Response {
+  return c.json<ErrorResponse>({ error: { code, message } }, status);
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import type { ErrorResponse } from '@opencara/shared';
 import type { Env, AppVariables } from './types.js';
 import { MemoryTaskStore } from './store/memory.js';
 import { KVTaskStore } from './store/kv.js';
@@ -44,12 +45,17 @@ function buildApp(storeProvider: (env: Env) => TaskStore): HonoApp {
   app.route('/', healthRoutes());
 
   // 404
-  app.notFound((c) => c.json({ error: 'Not Found' }, 404));
+  app.notFound((c) =>
+    c.json<ErrorResponse>({ error: { code: 'INVALID_REQUEST', message: 'Not Found' } }, 404),
+  );
 
   // Error handler
   app.onError((err, c) => {
     console.error('Unhandled error:', err);
-    return c.json({ error: 'Internal Server Error' }, 500);
+    return c.json<ErrorResponse>(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal Server Error' } },
+      500,
+    );
   });
 
   return app;

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { Context, MiddlewareHandler } from 'hono';
+import type { ErrorResponse } from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 
 /**
@@ -128,7 +129,10 @@ export function rateLimitByAgent(config: RateLimiterConfig): MiddlewareHandler {
     const retryAfter = checkRateLimit(`agent:${agentId}`, config);
     if (retryAfter !== null) {
       c.header('Retry-After', String(retryAfter));
-      return c.json({ error: 'Rate limit exceeded' }, 429);
+      return c.json<ErrorResponse>(
+        { error: { code: 'RATE_LIMITED', message: 'Rate limit exceeded' } },
+        429,
+      );
     }
 
     await next();
@@ -145,7 +149,10 @@ export function rateLimitByIP(config: RateLimiterConfig): MiddlewareHandler {
     const retryAfter = checkRateLimit(`ip:${ip}`, config);
     if (retryAfter !== null) {
       c.header('Retry-After', String(retryAfter));
-      return c.json({ error: 'Rate limit exceeded' }, 429);
+      return c.json<ErrorResponse>(
+        { error: { code: 'RATE_LIMITED', message: 'Rate limit exceeded' } },
+        429,
+      );
     }
 
     await next();

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -24,6 +24,7 @@ import {
 } from '../review-formatter.js';
 import { isAgentEligibleForRole } from '../eligibility.js';
 import { rateLimitByAgent } from '../middleware/rate-limit.js';
+import { apiError } from '../errors.js';
 
 /** Default grace period (ms) for preferred synthesizer agents. */
 export const PREFERRED_SYNTH_GRACE_PERIOD_MS = 60_000;
@@ -272,7 +273,7 @@ export function taskRoutes() {
     const { agent_id, review_only, repos } = body;
 
     if (!agent_id) {
-      return c.json({ error: 'agent_id is required' }, 400);
+      return apiError(c, 400, 'INVALID_REQUEST', 'agent_id is required');
     }
 
     // Build a set of repos the agent declares for fast lookup
@@ -325,38 +326,42 @@ export function taskRoutes() {
     const { agent_id, role, model, tool } = body;
 
     if (!agent_id || !role) {
-      return c.json({ error: 'agent_id and role are required' }, 400);
+      return apiError(c, 400, 'INVALID_REQUEST', 'agent_id and role are required');
     }
 
     const task = await store.getTask(taskId);
     if (!task) {
-      return c.json<ClaimResponse>({ claimed: false, reason: 'Task not found' });
+      return apiError(c, 404, 'TASK_NOT_FOUND', 'Task not found');
     }
 
     if (task.status !== 'pending' && task.status !== 'reviewing') {
-      return c.json<ClaimResponse>({ claimed: false, reason: `Task is ${task.status}` });
+      return apiError(c, 409, 'CLAIM_CONFLICT', `Task is ${task.status}`);
     }
 
     if (task.timeout_at <= Date.now()) {
-      return c.json<ClaimResponse>({ claimed: false, reason: 'Task has timed out' });
+      return apiError(c, 409, 'CLAIM_CONFLICT', 'Task has timed out');
     }
 
     // Check whitelist/blacklist eligibility before slot availability
     const eligibility = isAgentEligibleForRole(task.config, role, agent_id);
     if (!eligibility.eligible) {
-      return c.json<ClaimResponse>({
-        claimed: false,
-        reason: eligibility.reason ?? 'Agent not eligible for this role',
-      });
+      return apiError(
+        c,
+        409,
+        'CLAIM_CONFLICT',
+        eligibility.reason ?? 'Agent not eligible for this role',
+      );
     }
 
     const actualRole = availableRole(task, agent_id);
 
     if (!actualRole || actualRole !== role) {
-      return c.json<ClaimResponse>({
-        claimed: false,
-        reason: actualRole ? `Expected role ${actualRole}, got ${role}` : 'No slots available',
-      });
+      return apiError(
+        c,
+        409,
+        'CLAIM_CONFLICT',
+        actualRole ? `Expected role ${actualRole}, got ${role}` : 'No slots available',
+      );
     }
 
     // Acquire summary lock to prevent concurrent claims under KV eventual consistency.
@@ -367,10 +372,7 @@ export function taskRoutes() {
         console.log(
           `Task ${taskId}: rejecting duplicate summary claim from ${agent_id} — lock held by another agent`,
         );
-        return c.json<ClaimResponse>({
-          claimed: false,
-          reason: 'Summary already claimed by another agent',
-        });
+        return apiError(c, 409, 'SUMMARY_LOCKED', 'Summary already claimed by another agent');
       }
     }
 
@@ -429,7 +431,7 @@ export function taskRoutes() {
     const { agent_id, type, review_text, verdict, tokens_used } = body;
 
     if (!agent_id || !type || !review_text) {
-      return c.json({ error: 'agent_id, type, and review_text are required' }, 400);
+      return apiError(c, 400, 'INVALID_REQUEST', 'agent_id, type, and review_text are required');
     }
 
     const claimId = `${taskId}:${agent_id}`;
@@ -437,23 +439,25 @@ export function taskRoutes() {
 
     if (!claim) {
       console.error(`[agent:${agent_id}] task=${taskId} action=result_rejected reason=no_claim`);
-      return c.json({ error: 'No claim found for this agent on this task' }, 404);
+      return apiError(c, 404, 'CLAIM_NOT_FOUND', 'No claim found for this agent on this task');
     }
 
     if (claim.status !== 'pending') {
       console.error(
         `[agent:${agent_id}] task=${taskId} action=result_rejected reason=claim_${claim.status}`,
       );
-      return c.json({ error: `Claim already ${claim.status}` }, 409);
+      return apiError(c, 409, 'CLAIM_CONFLICT', `Claim already ${claim.status}`);
     }
 
     if (claim.role !== type) {
       console.error(
         `[agent:${agent_id}] task=${taskId} action=result_rejected reason=role_mismatch claim_role=${claim.role} submission_type=${type}`,
       );
-      return c.json(
-        { error: `Claim role '${claim.role}' does not match submission type '${type}'` },
+      return apiError(
+        c,
         400,
+        'INVALID_REQUEST',
+        `Claim role '${claim.role}' does not match submission type '${type}'`,
       );
     }
 
@@ -521,7 +525,7 @@ export function taskRoutes() {
     const claim = await store.getClaim(claimId);
 
     if (!claim) {
-      return c.json({ error: 'Claim not found' }, 404);
+      return apiError(c, 404, 'CLAIM_NOT_FOUND', 'Claim not found');
     }
 
     if (claim.status !== 'pending') {
@@ -529,7 +533,7 @@ export function taskRoutes() {
       if (claim.status === 'rejected') {
         return c.json({ success: true });
       }
-      return c.json({ error: `Claim is ${claim.status}, expected pending` }, 409);
+      return apiError(c, 409, 'CLAIM_CONFLICT', `Claim is ${claim.status}, expected pending`);
     }
 
     await store.updateClaim(claimId, { status: 'rejected' });
@@ -567,7 +571,7 @@ export function taskRoutes() {
     const claim = await store.getClaim(claimId);
 
     if (!claim) {
-      return c.json({ error: 'Claim not found' }, 404);
+      return apiError(c, 404, 'CLAIM_NOT_FOUND', 'Claim not found');
     }
 
     if (claim.status !== 'pending') {
@@ -575,7 +579,7 @@ export function taskRoutes() {
       if (claim.status === 'error') {
         return c.json({ success: true });
       }
-      return c.json({ error: `Claim is ${claim.status}, expected pending` }, 409);
+      return apiError(c, 409, 'CLAIM_CONFLICT', `Claim is ${claim.status}, expected pending`);
     }
 
     await store.updateClaim(claimId, { status: 'error' });

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import { getInstallationToken } from '../github/app.js';
 import { loadReviewConfig, fetchPrDetails } from '../github/config.js';
 import { shouldSkipReview, parseTimeoutMs } from '../eligibility.js';
 import { rateLimitByIP } from '../middleware/rate-limit.js';
+import { apiError } from '../errors.js';
 
 const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR', 'CONTRIBUTOR']);
 
@@ -150,7 +151,7 @@ export function webhookRoutes() {
 
     const valid = await verifySignature(body, signature, c.env.GITHUB_WEBHOOK_SECRET);
     if (!valid) {
-      return c.text('Unauthorized', 401);
+      return apiError(c, 401, 'UNAUTHORIZED', 'Invalid webhook signature');
     }
 
     const event = c.req.header('X-GitHub-Event');
@@ -158,7 +159,7 @@ export function webhookRoutes() {
     try {
       payload = JSON.parse(body) as Record<string, unknown>;
     } catch {
-      return c.text('Bad Request', 400);
+      return apiError(c, 400, 'INVALID_REQUEST', 'Malformed request body');
     }
 
     const action = typeof payload.action === 'string' ? payload.action : '';

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -43,10 +43,11 @@ export interface ClaimReview {
   verdict: ReviewVerdict;
 }
 
-/** POST /api/tasks/{taskId}/claim — response */
-export type ClaimResponse =
-  | { claimed: true; reviews?: ClaimReview[] }
-  | { claimed: false; reason: string };
+/** POST /api/tasks/{taskId}/claim — success response (errors use ErrorResponse) */
+export interface ClaimResponse {
+  claimed: true;
+  reviews?: ClaimReview[];
+}
 
 // ── Result ─────────────────────────────────────────────────────
 
@@ -182,7 +183,21 @@ export const DEFAULT_REGISTRY: RegistryResponse = {
 
 // ── Common ─────────────────────────────────────────────────────
 
-/** Standard error response */
+/** Standardized API error codes for programmatic error handling. */
+export type ErrorCode =
+  | 'UNAUTHORIZED'
+  | 'TASK_NOT_FOUND'
+  | 'CLAIM_CONFLICT'
+  | 'CLAIM_NOT_FOUND'
+  | 'INVALID_REQUEST'
+  | 'RATE_LIMITED'
+  | 'INTERNAL_ERROR'
+  | 'SUMMARY_LOCKED';
+
+/** Standard error response — structured format with error code. */
 export interface ErrorResponse {
-  error: string;
+  error: {
+    code: ErrorCode;
+    message: string;
+  };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export type {
   ToolRegistryEntry,
   ModelRegistryEntry,
   RegistryResponse,
+  ErrorCode,
   ErrorResponse,
 } from './api.js';
 


### PR DESCRIPTION
Closes #283

## Summary
- Define `ErrorCode` type and update `ErrorResponse` to structured format `{error: {code, message}}` in shared package
- Simplify `ClaimResponse` to success-only type (claim failures now use HTTP error codes + `ErrorResponse`)
- Add `apiError()` helper in server for consistent error formatting across all routes
- Update all error returns in task routes, webhook, rate-limit middleware, 404/500 handlers
- Update CLI `HttpError` to carry optional `errorCode` for programmatic handling
- Update all tests across server (routes, e2e, integration, coverage) and CLI (http, agent) packages

## Test plan
- [x] All 777 tests pass
- [x] Build succeeds
- [x] Lint clean
- [x] Format clean
- [x] Typecheck clean