### PR TITLE
[cli-dev] npm publish readiness: package.json, README, and bin entry

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,126 @@
+# opencara
+
+Distributed AI code review agent for GitHub pull requests. Run review agents locally using your own AI tools and API keys — OpenCara never touches your credentials.
+
+## How It Works
+
+```
+GitHub PR → OpenCara server creates review task
+  → Your agent polls for tasks → Claims one → Fetches diff from GitHub
+  → Reviews locally with your AI tool → Submits result
+  → Server posts the review to the PR
+```
+
+## Quick Start
+
+```bash
+# 1. Install
+npm i -g opencara
+
+# 2. Create config
+mkdir -p ~/.opencara
+cat > ~/.opencara/config.yml << 'EOF'
+platform_url: https://opencara-server.opencara.workers.dev
+agents:
+  - model: claude-sonnet-4-6
+    tool: claude
+    command: claude --model claude-sonnet-4-6 --allowedTools '*' --print
+EOF
+
+# 3. Start
+opencara agent start
+```
+
+Your agent is now polling for review tasks every 10 seconds.
+
+## Supported AI Tools
+
+| Tool       | Install                              | Example models                     |
+| ---------- | ------------------------------------ | ---------------------------------- |
+| Claude     | `npm i -g @anthropic-ai/claude-code` | claude-sonnet-4-6, claude-opus-4-6 |
+| Codex      | `npm i -g @openai/codex`             | gpt-5.4-codex                      |
+| Gemini CLI | `npm i -g @google/gemini-cli`        | gemini-2.5-pro, gemini-2.5-flash   |
+| Qwen CLI   | `npm i -g qwen`                      | qwen3.5-plus, glm-5, kimi-k2.5     |
+
+Each tool requires its own API key configured per its documentation.
+
+## Configuration
+
+Edit `~/.opencara/config.yml`:
+
+```yaml
+platform_url: https://opencara-server.opencara.workers.dev
+
+agents:
+  - model: claude-sonnet-4-6
+    tool: claude
+    command: claude --model claude-sonnet-4-6 --allowedTools '*' --print
+
+  - model: gemini-2.5-pro
+    tool: gemini
+    command: gemini -m gemini-2.5-pro
+```
+
+Review prompts are delivered via **stdin** to your command. The command reads stdin, processes it with the AI model, and writes the review to stdout.
+
+### Agent Config Fields
+
+| Field          | Required | Default | Description                                            |
+| -------------- | -------- | ------- | ------------------------------------------------------ |
+| `model`        | Yes      | --      | AI model identifier (e.g., `claude-sonnet-4-6`)        |
+| `tool`         | Yes      | --      | AI tool identifier (e.g., `claude`, `codex`, `gemini`) |
+| `command`      | Yes\*    | --      | Shell command to execute reviews (stdin -> stdout)     |
+| `name`         | No       | --      | Display name in CLI logs (local only)                  |
+| `review_only`  | No       | `false` | If `true`, agent only reviews, never synthesizes       |
+| `github_token` | No       | --      | Per-agent GitHub token for private repos               |
+| `codebase_dir` | No       | --      | Local clone directory for context-aware reviews        |
+| `repos`        | No       | --      | Repo filtering (mode: all/own/whitelist/blacklist)     |
+
+\*Required unless `agent_command` is set globally.
+
+### Global Config Fields
+
+| Field                    | Default                    | Description                           |
+| ------------------------ | -------------------------- | ------------------------------------- |
+| `platform_url`           | `https://api.opencara.dev` | OpenCara server URL                   |
+| `github_token`           | --                         | GitHub token for private repo diffs   |
+| `codebase_dir`           | --                         | Default clone directory for repos     |
+| `max_diff_size_kb`       | `100`                      | Skip PRs with diffs larger than this  |
+| `max_consecutive_errors` | `10`                       | Stop agent after N consecutive errors |
+
+## CLI Reference
+
+### Commands
+
+| Command                | Description                                     |
+| ---------------------- | ----------------------------------------------- |
+| `opencara`             | Start agent in router mode (stdin/stdout relay) |
+| `opencara agent start` | Start an agent in polling mode                  |
+
+### `opencara agent start` Options
+
+| Option                      | Default | Description                              |
+| --------------------------- | ------- | ---------------------------------------- |
+| `--agent <index>`           | `0`     | Agent index from config.yml (0-based)    |
+| `--all`                     | --      | Start all configured agents concurrently |
+| `--poll-interval <seconds>` | `10`    | Poll interval in seconds                 |
+
+## Environment Variables
+
+| Variable                | Description                                                        |
+| ----------------------- | ------------------------------------------------------------------ |
+| `OPENCARA_CONFIG`       | Path to alternate config file (overrides `~/.opencara/config.yml`) |
+| `OPENCARA_PLATFORM_URL` | Override the platform URL from config                              |
+| `GITHUB_TOKEN`          | GitHub token (fallback for private repo access)                    |
+
+## Private Repos
+
+The CLI resolves GitHub tokens using a fallback chain:
+
+1. `GITHUB_TOKEN` environment variable
+2. `gh auth token` (if GitHub CLI is installed)
+3. `github_token` in config.yml (global or per-agent)
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,17 +1,40 @@
 {
   "name": "opencara",
   "version": "0.11.0",
+  "description": "Distributed AI code review agent — poll, review, and submit PR reviews using your own AI tools",
   "type": "module",
+  "license": "MIT",
+  "author": "OpenCara <https://github.com/OpenCara>",
+  "homepage": "https://github.com/OpenCara/OpenCara#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/OpenCara/OpenCara.git",
     "directory": "packages/cli"
   },
+  "bugs": {
+    "url": "https://github.com/OpenCara/OpenCara/issues"
+  },
+  "keywords": [
+    "ai",
+    "code-review",
+    "github",
+    "pull-request",
+    "cli",
+    "agent",
+    "review",
+    "openai",
+    "claude",
+    "gemini"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "opencara": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/cli/src/__tests__/npm-publish.test.ts
+++ b/packages/cli/src/__tests__/npm-publish.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const CLI_DIR = path.resolve(import.meta.dirname, '..', '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(CLI_DIR, 'package.json'), 'utf-8'));
+
+describe('npm publish readiness', () => {
+  describe('package.json required fields', () => {
+    it('has name', () => {
+      expect(pkg.name).toBe('opencara');
+    });
+
+    it('has description', () => {
+      expect(typeof pkg.description).toBe('string');
+      expect(pkg.description.length).toBeGreaterThan(0);
+    });
+
+    it('has license', () => {
+      expect(pkg.license).toBe('MIT');
+    });
+
+    it('has repository', () => {
+      expect(pkg.repository).toBeDefined();
+      expect(pkg.repository.url).toContain('github.com/OpenCara/OpenCara');
+      expect(pkg.repository.directory).toBe('packages/cli');
+    });
+
+    it('has homepage', () => {
+      expect(typeof pkg.homepage).toBe('string');
+      expect(pkg.homepage).toContain('github.com/OpenCara/OpenCara');
+    });
+
+    it('has bugs', () => {
+      expect(pkg.bugs).toBeDefined();
+      expect(pkg.bugs.url).toContain('github.com/OpenCara/OpenCara/issues');
+    });
+
+    it('has author', () => {
+      expect(typeof pkg.author).toBe('string');
+      expect(pkg.author.length).toBeGreaterThan(0);
+    });
+
+    it('has keywords', () => {
+      expect(Array.isArray(pkg.keywords)).toBe(true);
+      expect(pkg.keywords.length).toBeGreaterThan(0);
+      expect(pkg.keywords).toContain('ai');
+      expect(pkg.keywords).toContain('code-review');
+      expect(pkg.keywords).toContain('cli');
+    });
+
+    it('has engines specifying node >= 20', () => {
+      expect(pkg.engines).toBeDefined();
+      expect(pkg.engines.node).toBe('>=20');
+    });
+  });
+
+  describe('bin entry', () => {
+    it('declares opencara bin', () => {
+      expect(pkg.bin).toBeDefined();
+      expect(pkg.bin.opencara).toBe('dist/index.js');
+    });
+
+    it('bin target has shebang line after build', () => {
+      const binPath = path.join(CLI_DIR, pkg.bin.opencara);
+      if (fs.existsSync(binPath)) {
+        const content = fs.readFileSync(binPath, 'utf-8');
+        expect(content.startsWith('#!/usr/bin/env node')).toBe(true);
+      }
+    });
+  });
+
+  describe('files whitelist', () => {
+    it('has files field', () => {
+      expect(Array.isArray(pkg.files)).toBe(true);
+    });
+
+    it('includes dist directory', () => {
+      expect(pkg.files).toContain('dist');
+    });
+
+    it('includes README.md', () => {
+      expect(pkg.files).toContain('README.md');
+    });
+
+    it('does not include src (source should not be published)', () => {
+      expect(pkg.files).not.toContain('src');
+    });
+  });
+
+  describe('README', () => {
+    it('README.md exists', () => {
+      const readmePath = path.join(CLI_DIR, 'README.md');
+      expect(fs.existsSync(readmePath)).toBe(true);
+    });
+
+    it('README has meaningful content', () => {
+      const readmePath = path.join(CLI_DIR, 'README.md');
+      const content = fs.readFileSync(readmePath, 'utf-8');
+      expect(content.length).toBeGreaterThan(500);
+      expect(content).toContain('opencara');
+      expect(content).toContain('Quick Start');
+      expect(content).toContain('npm i -g opencara');
+    });
+  });
+
+  describe('no TypeScript declarations leak', () => {
+    it('files whitelist does not include .d.ts patterns', () => {
+      for (const entry of pkg.files) {
+        expect(entry).not.toMatch(/\.d\.ts/);
+      }
+    });
+  });
+
+  describe('module type', () => {
+    it('is ESM', () => {
+      expect(pkg.type).toBe('module');
+    });
+  });
+
+  describe('is not marked private', () => {
+    it('private field is not true', () => {
+      expect(pkg.private).not.toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #288

## Summary
- Polished `packages/cli/package.json` with missing npm fields: description, license, author, homepage, bugs, keywords, engines
- Added `README.md` for npm page with quick start, config reference, CLI reference, environment variables, and private repo setup
- Added `files` whitelist including `README.md` (previously only `dist`)
- Added 20 tests in `npm-publish.test.ts` verifying package.json completeness, bin entry shebang, files whitelist, README presence, no `.d.ts` leak, ESM type, and not-private flag

## Test plan
- [x] `pnpm build && pnpm test` — 815 tests pass (34 files)
- [x] `pnpm lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run typecheck` — clean
- [x] `npm pack --dry-run` — 3 files (package.json, dist/index.js, README.md), 18.2 kB
- [x] Bin entry has `#!/usr/bin/env node` shebang
- [x] No `.d.ts` files in published package