### PR TITLE
[server-dev] E2E integration tests for M12 features and CLI-server contract (#290)

### DIFF
--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -1,0 +1,426 @@
+/**
+ * CLI ↔ Server integration tests.
+ *
+ * Runs the real CLI startAgent() against an in-process Hono server with
+ * MemoryTaskStore. Verifies cross-package contract: shared types, poll/claim
+ * responses, result submission, and error handling match between CLI and server.
+ *
+ * Mocks: tool-executor (no real AI calls), globalThis.fetch (routes to Hono app).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
+import type { ReviewExecutorDeps } from '../review.js';
+import { createSessionTracker } from '../consumption.js';
+import { executeTool } from '../tool-executor.js';
+import { FakeServer, FAKE_SERVER_URL } from './helpers/fake-server.js';
+
+// ── Mock tool executor ───────────────────────────────────────
+
+vi.mock('../tool-executor.js', () => ({
+  executeTool: vi.fn(async () => ({
+    stdout:
+      '## Summary\nLooks good. No issues found.\n\n## Findings\nNo issues found.\n\n## Verdict\nAPPROVE',
+    stderr: '',
+    exitCode: 0,
+    tokensUsed: 500,
+    tokensParsed: true,
+  })),
+  estimateTokens: (text: string) => Math.ceil(text.length / 4),
+  validateCommandBinary: () => true,
+  parseCommandTemplate: (cmd: string) => cmd.split(' '),
+  testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
+}));
+
+const mockedExecuteTool = vi.mocked(executeTool);
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeDeps(agentId = 'cli-agent'): {
+  reviewDeps: ReviewExecutorDeps;
+  consumptionDeps: ConsumptionDeps;
+} {
+  const session = createSessionTracker();
+  return {
+    reviewDeps: { commandTemplate: 'echo test', maxDiffSizeKb: 500 },
+    consumptionDeps: { agentId, session },
+  };
+}
+
+async function advanceTime(totalMs: number, stepMs = 100): Promise<void> {
+  const steps = Math.ceil(totalMs / stepMs);
+  for (let i = 0; i < steps; i++) {
+    await vi.advanceTimersByTimeAsync(stepMs);
+  }
+}
+
+async function stopAgent(promise: Promise<void>, server: FakeServer): Promise<void> {
+  server.uninstallFetch();
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'shutdown' } }),
+  });
+  await advanceTime(3000);
+  await promise;
+}
+
+// ── Test Suite ───────────────────────────────────────────────
+
+describe('CLI ↔ Server Integration', () => {
+  let server: FakeServer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(process, 'on').mockImplementation(() => process);
+
+    server = new FakeServer();
+    server.install();
+
+    mockedExecuteTool.mockReset();
+    mockedExecuteTool.mockResolvedValue({
+      stdout:
+        '## Summary\nLooks good. No issues found.\n\n## Findings\nNo issues found.\n\n## Verdict\nAPPROVE',
+      stderr: '',
+      exitCode: 0,
+      tokensUsed: 500,
+      tokensParsed: true,
+    });
+  });
+
+  afterEach(() => {
+    server.restore();
+    vi.useRealTimers();
+  });
+
+  function startTestAgent(
+    agentId: string,
+    opts?: {
+      reviewOnly?: boolean;
+      repoConfig?: import('@opencara/shared').RepoConfig;
+    },
+  ): Promise<void> {
+    const deps = makeDeps(agentId);
+    return startAgent(
+      agentId,
+      FAKE_SERVER_URL,
+      { model: 'test-model', tool: 'test-tool' },
+      deps.reviewDeps,
+      deps.consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        reviewOnly: opts?.reviewOnly,
+        repoConfig: opts?.repoConfig,
+      },
+    );
+  }
+
+  // ═══════════════════════════════════════════════════════════
+  // A. CLI poll → claim → review → submit lifecycle
+  // ═══════════════════════════════════════════════════════════
+
+  describe('A. CLI agent poll → claim → submit lifecycle', () => {
+    it('CLI agent claims review task and submits result via server API', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      const agentPromise = startTestAgent('cli-review-agent');
+      await advanceTime(500);
+
+      // Verify claim was created in server store
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].agent_id).toBe('cli-review-agent');
+      expect(claims[0].role).toBe('review');
+      expect(claims[0].status).toBe('completed');
+      expect(claims[0].model).toBe('test-model');
+      expect(claims[0].tool).toBe('test-tool');
+      expect(claims[0].review_text).toBeDefined();
+      expect(claims[0].tokens_used).toBe(500);
+
+      // Tool was called
+      expect(mockedExecuteTool).toHaveBeenCalled();
+
+      // Server task updated
+      const task = await server.getTask(taskId);
+      expect(task?.completed_reviews).toBe(1);
+
+      await stopAgent(agentPromise, server);
+    });
+
+    it('two CLI agents complete review slots sequentially', async () => {
+      const taskId = await server.injectTask({ reviewCount: 3 });
+
+      // First agent completes review
+      const agent1Promise = startTestAgent('cli-r1');
+      await advanceTime(500);
+
+      let claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].status).toBe('completed');
+
+      await stopAgent(agent1Promise, server);
+      server.install();
+
+      // Second agent completes review
+      const agent2Promise = startTestAgent('cli-r2');
+      await advanceTime(500);
+
+      claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(2);
+      expect(claims.every((c) => c.status === 'completed')).toBe(true);
+
+      const task = await server.getTask(taskId);
+      expect(task?.completed_reviews).toBe(2);
+
+      await stopAgent(agent2Promise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // B. CLI handles structured error responses from server
+  // ═══════════════════════════════════════════════════════════
+
+  describe('B. CLI handles structured server errors', () => {
+    it('CLI handles claim conflict gracefully (slot taken)', async () => {
+      const taskId = await server.injectTask();
+
+      // Pre-claim the slot
+      await server.store.updateTask(taskId, {
+        claimed_agents: ['other-agent'],
+        summary_claimed: true,
+        status: 'reviewing',
+      });
+      await server.store.createClaim({
+        id: `${taskId}:other-agent`,
+        task_id: taskId,
+        agent_id: 'other-agent',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      const agentPromise = startTestAgent('late-cli-agent');
+      await advanceTime(500);
+
+      // Agent should not have crashed — just failed to claim
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // C. CLI with review_only flag
+  // ═══════════════════════════════════════════════════════════
+
+  describe('C. review_only flag via CLI', () => {
+    it('CLI agent with reviewOnly skips summary-only tasks', async () => {
+      await server.injectTask({ reviewCount: 1 }); // summary only
+
+      const agentPromise = startTestAgent('review-only-cli', { reviewOnly: true });
+      await advanceTime(500);
+
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+
+    it('CLI agent with reviewOnly claims review tasks', async () => {
+      const taskId = await server.injectTask({ reviewCount: 3 });
+
+      const agentPromise = startTestAgent('review-only-cli', { reviewOnly: true });
+      await advanceTime(500);
+
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].role).toBe('review');
+      expect(claims[0].status).toBe('completed');
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // D. CLI repo filtering via server poll
+  // ═══════════════════════════════════════════════════════════
+
+  describe('D. CLI repo config filtering', () => {
+    it('CLI agent with repo whitelist skips non-matching tasks', async () => {
+      await server.injectTask({ reviewCount: 2 }); // owner: test-org, repo: test-repo
+
+      const agentPromise = startTestAgent('filtered-cli', {
+        repoConfig: { mode: 'whitelist', list: ['other-org/other-repo'] },
+      });
+      await advanceTime(500);
+
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+
+    it('CLI agent with matching whitelist claims the task', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      const agentPromise = startTestAgent('filtered-cli', {
+        repoConfig: { mode: 'whitelist', list: ['test-org/test-repo'] },
+      });
+      await advanceTime(500);
+
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].status).toBe('completed');
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // E. CLI tool execution failure → server error report
+  // ═══════════════════════════════════════════════════════════
+
+  describe('E. Tool execution failure → error reported to server', () => {
+    it('tool crash reports error to server, slot is freed', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+      mockedExecuteTool.mockRejectedValue(new Error('Tool SIGSEGV'));
+
+      const agentPromise = startTestAgent('crash-cli');
+      await advanceTime(3000);
+
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error on task'));
+
+      // Slot freed — task should be re-claimable
+      const task = await server.getTask(taskId);
+      expect(task?.review_claims).toBe(0);
+
+      // Mark completed to stop loop
+      await server.store.updateTask(taskId, { status: 'completed' });
+      await stopAgent(agentPromise, server);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // F. Schema contract: shared types match between CLI and server
+  // ═══════════════════════════════════════════════════════════
+
+  describe('F. Schema contract verification', () => {
+    it('server poll response matches shared PollResponse shape', async () => {
+      await server.injectTask({ reviewCount: 2 });
+
+      // Make a raw poll request to verify response shape
+      const res = await server.app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'schema-test' }),
+        },
+        server.env,
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      // PollResponse shape
+      expect(body).toHaveProperty('tasks');
+      expect(Array.isArray(body.tasks)).toBe(true);
+
+      const tasks = body.tasks as Record<string, unknown>[];
+      expect(tasks).toHaveLength(1);
+
+      // PollTask shape — every field the CLI expects
+      const task = tasks[0];
+      expect(typeof task.task_id).toBe('string');
+      expect(typeof task.owner).toBe('string');
+      expect(typeof task.repo).toBe('string');
+      expect(typeof task.pr_number).toBe('number');
+      expect(typeof task.diff_url).toBe('string');
+      expect(typeof task.timeout_seconds).toBe('number');
+      expect(typeof task.prompt).toBe('string');
+      expect(typeof task.role).toBe('string');
+      expect(['review', 'summary']).toContain(task.role);
+    });
+
+    it('server claim response matches shared ClaimResponse shape', async () => {
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      const res = await server.app.request(
+        `/api/tasks/${taskId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'schema-test', role: 'review', model: 'm', tool: 't' }),
+        },
+        server.env,
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      // ClaimResponse shape
+      expect(res.status).toBe(200);
+      expect(body.claimed).toBe(true);
+    });
+
+    it('server error response matches shared ErrorResponse shape', async () => {
+      const res = await server.app.request(
+        '/api/tasks/any/claim',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'a' }), // missing role
+        },
+        server.env,
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      // ErrorResponse shape
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+      const error = body.error as Record<string, unknown>;
+      expect(typeof error.code).toBe('string');
+      expect(typeof error.message).toBe('string');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // G. Private repo task visibility from CLI
+  // ═══════════════════════════════════════════════════════════
+
+  describe('G. Private repo tasks via CLI', () => {
+    it('CLI agent with repo whitelist can see and claim private tasks', async () => {
+      const taskId = await server.injectTask({
+        owner: 'corp',
+        repo: 'secret',
+        reviewCount: 2,
+        private: true,
+      });
+
+      const agentPromise = startTestAgent('private-cli-agent', {
+        repoConfig: { mode: 'whitelist', list: ['corp/secret'] },
+      });
+      await advanceTime(500);
+
+      const claims = await server.getClaims(taskId);
+      expect(claims).toHaveLength(1);
+      expect(claims[0].status).toBe('completed');
+      expect(claims[0].agent_id).toBe('private-cli-agent');
+
+      await stopAgent(agentPromise, server);
+    });
+
+    it('CLI agent without repo whitelist cannot see private tasks', async () => {
+      await server.injectTask({
+        owner: 'corp',
+        repo: 'secret',
+        reviewCount: 2,
+        private: true,
+      });
+
+      const agentPromise = startTestAgent('no-repos-cli');
+      await advanceTime(500);
+
+      // Agent should not have picked up the private task
+      expect(mockedExecuteTool).not.toHaveBeenCalled();
+
+      await stopAgent(agentPromise, server);
+    });
+  });
+});

--- a/packages/server/src/__tests__/e2e-m12-features.test.ts
+++ b/packages/server/src/__tests__/e2e-m12-features.test.ts
@@ -1,0 +1,766 @@
+/**
+ * E2E tests for M12 features — exercises new capabilities end-to-end.
+ *
+ * Features tested:
+ * - Private repo task filtering at poll time (#282)
+ * - Structured error code responses (#283)
+ * - Rate limiting under load (#234)
+ * - Task TTL cleanup (#285)
+ * - Structured logging / X-Request-Id header (#289)
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import { MemoryTaskStore } from '../store/memory.js';
+import { resetTimeoutThrottle, POLL_RATE_LIMIT } from '../routes/tasks.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import type { Env } from '../types.js';
+import { createTestApp } from './helpers/test-server.js';
+import { createGitHubMock } from './helpers/github-mock.js';
+import { MockAgent } from './helpers/mock-agent.js';
+
+// ── Setup ────────────────────────────────────────────────────
+
+let TEST_PEM: string;
+beforeAll(() => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  TEST_PEM = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+});
+
+function getMockEnv(): Env {
+  return {
+    GITHUB_WEBHOOK_SECRET: 'test-secret',
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: TEST_PEM,
+    TASK_STORE: {} as KVNamespace,
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+describe('M12 Feature E2E Tests', () => {
+  let store: MemoryTaskStore;
+  let app: ReturnType<typeof createTestApp>;
+  let env: Env;
+  let github: ReturnType<typeof createGitHubMock>;
+
+  function agent(id: string): MockAgent {
+    return new MockAgent(id, app, env);
+  }
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryTaskStore();
+    app = createTestApp(store);
+    env = getMockEnv();
+    github = createGitHubMock();
+    github.install();
+  });
+
+  afterEach(() => {
+    github.restore();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // A. Private Repo Task Filtering (#282)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('A. Private repo task filtering', () => {
+    async function injectPrivateTask(opts?: {
+      owner?: string;
+      repo?: string;
+      prNumber?: number;
+      reviewCount?: number;
+    }): Promise<string> {
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        agents: {
+          ...DEFAULT_REVIEW_CONFIG.agents,
+          reviewCount: opts?.reviewCount ?? 1,
+        },
+      };
+
+      const res = await app.request(
+        '/test/events/pr',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            owner: opts?.owner ?? 'private-org',
+            repo: opts?.repo ?? 'secret-repo',
+            pr_number: opts?.prNumber ?? 1,
+            private: true,
+            config,
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { created: boolean; task_id?: string };
+      expect(body.created).toBe(true);
+      return body.task_id!;
+    }
+
+    async function injectPublicTask(opts?: { prNumber?: number }): Promise<string> {
+      const res = await app.request(
+        '/test/events/pr',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            owner: 'public-org',
+            repo: 'open-repo',
+            pr_number: opts?.prNumber ?? 2,
+            config: DEFAULT_REVIEW_CONFIG,
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { created: boolean; task_id?: string };
+      expect(body.created).toBe(true);
+      return body.task_id!;
+    }
+
+    it('agent without repos declaration cannot see private tasks', async () => {
+      await injectPrivateTask();
+
+      const a = agent('no-repos-agent');
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('agent with matching repos can see private tasks', async () => {
+      const taskId = await injectPrivateTask();
+
+      // Poll with repos list (sent via raw request since MockAgent doesn't support repos)
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agent_id: 'private-agent',
+            repos: ['private-org/secret-repo'],
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { tasks: Array<{ task_id: string }> };
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe(taskId);
+    });
+
+    it('agent with non-matching repos cannot see private tasks', async () => {
+      await injectPrivateTask();
+
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agent_id: 'wrong-repos-agent',
+            repos: ['other-org/other-repo'],
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { tasks: unknown[] };
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('public tasks are visible to all agents regardless of repos', async () => {
+      const taskId = await injectPublicTask();
+
+      // Agent without repos declaration
+      const a = agent('any-agent');
+      const tasks = await a.poll();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].task_id).toBe(taskId);
+    });
+
+    it('mixed public and private: agent sees only public + matching private', async () => {
+      await injectPrivateTask({ prNumber: 10 });
+      await injectPublicTask({ prNumber: 20 });
+      await injectPrivateTask({ owner: 'other-org', repo: 'other-repo', prNumber: 30 });
+
+      // Poll with repos matching first private task only
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agent_id: 'mixed-agent',
+            repos: ['private-org/secret-repo'],
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { tasks: Array<{ pr_number: number }> };
+      expect(body.tasks).toHaveLength(2);
+      const prNumbers = body.tasks.map((t) => t.pr_number).sort();
+      expect(prNumbers).toEqual([10, 20]);
+    });
+
+    it('private task can be claimed and completed normally', async () => {
+      const taskId = await injectPrivateTask();
+
+      // Poll with matching repos
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agent_id: 'private-worker',
+            repos: ['private-org/secret-repo'],
+          }),
+        },
+        env,
+      );
+      const body = (await res.json()) as { tasks: Array<{ task_id: string; role: string }> };
+      expect(body.tasks).toHaveLength(1);
+
+      // Claim and complete
+      const a = agent('private-worker');
+      const claim = await a.claim(taskId, 'summary');
+      expect(claim.claimed).toBe(true);
+
+      const result = await a.submitResult(taskId, 'summary', '## Summary\nLGTM.', 'approve', 500);
+      expect(result.status).toBe(200);
+
+      const task = await store.getTask(taskId);
+      expect(['completed', 'failed']).toContain(task?.status);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // B. Structured Error Codes (#283)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('B. Structured error codes', () => {
+    it('claim on non-existent task returns TASK_NOT_FOUND', async () => {
+      const a = agent('err-agent');
+      const result = await a.claim('nonexistent-id', 'summary');
+      expect(result.claimed).toBe(false);
+      if ('error' in result) {
+        expect(result.error.code).toBe('TASK_NOT_FOUND');
+        expect(typeof result.error.message).toBe('string');
+      }
+      expect(result._status).toBe(404);
+    });
+
+    it('duplicate claim returns CLAIM_CONFLICT', async () => {
+      const { taskId } = (await agent('a1').injectPR()) as { taskId: string };
+
+      const a1 = agent('claimer-1');
+      const c1 = await a1.claim(taskId, 'summary');
+      expect(c1.claimed).toBe(true);
+
+      const a2 = agent('claimer-2');
+      const c2 = await a2.claim(taskId, 'summary');
+      expect(c2.claimed).toBe(false);
+      if ('error' in c2) {
+        expect(c2.error.code).toBe('CLAIM_CONFLICT');
+      }
+      expect(c2._status).toBe(409);
+    });
+
+    it('missing required fields returns INVALID_REQUEST', async () => {
+      const res = await app.request(
+        '/api/tasks/any/claim',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'a' }), // missing role
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { code: string; message: string } };
+      expect(body.error.code).toBe('INVALID_REQUEST');
+    });
+
+    it('reject with no active claim returns CLAIM_NOT_FOUND', async () => {
+      const res = await app.request(
+        '/api/tasks/nonexistent/reject',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'ghost', reason: 'test' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: { code: string; message: string } };
+      expect(body.error.code).toBe('CLAIM_NOT_FOUND');
+    });
+
+    it('error report with no active claim returns CLAIM_NOT_FOUND', async () => {
+      const res = await app.request(
+        '/api/tasks/nonexistent/error',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'ghost', error: 'crash' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: { code: string; message: string } };
+      expect(body.error.code).toBe('CLAIM_NOT_FOUND');
+    });
+
+    it('result for completed claim returns 409 with correct code', async () => {
+      const { taskId } = (await agent('a').injectPR()) as { taskId: string };
+      const a = agent('dup-agent');
+      await a.claim(taskId, 'summary');
+      await a.submitResult(taskId, 'summary', 'First.', 'approve');
+
+      const r2 = await a.submitResult(taskId, 'summary', 'Second.');
+      expect(r2.status).toBe(409);
+    });
+
+    it('all error responses include {error: {code, message}} shape', async () => {
+      // 400: missing agent_id on poll
+      const r400 = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        },
+        env,
+      );
+      expect(r400.status).toBe(400);
+      const b400 = (await r400.json()) as { error?: { code: string; message: string } };
+      expect(b400.error).toBeDefined();
+      expect(b400.error!.code).toBeDefined();
+      expect(b400.error!.message).toBeDefined();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // C. Rate Limiting (#234)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('C. Rate limiting', () => {
+    it('exceeding poll rate limit returns 429 with Retry-After', async () => {
+      const a = agent('spammer');
+
+      // Send requests up to the limit
+      for (let i = 0; i < POLL_RATE_LIMIT.maxRequests; i++) {
+        const tasks = await a.poll();
+        expect(Array.isArray(tasks)).toBe(true);
+      }
+
+      // Next request should be rate limited
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'spammer' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(429);
+
+      const body = (await res.json()) as { error: { code: string; message: string } };
+      expect(body.error.code).toBe('RATE_LIMITED');
+      expect(body.error.message).toContain('Rate limit');
+
+      // Retry-After header present
+      const retryAfter = res.headers.get('Retry-After');
+      expect(retryAfter).toBeDefined();
+      expect(Number(retryAfter)).toBeGreaterThan(0);
+    });
+
+    it('different agents have independent rate limits', async () => {
+      const a1 = agent('agent-fast');
+      const a2 = agent('agent-slow');
+
+      // Fill up a1's rate limit
+      for (let i = 0; i < POLL_RATE_LIMIT.maxRequests; i++) {
+        await a1.poll();
+      }
+
+      // a2 should still work
+      const tasks = await a2.poll();
+      expect(Array.isArray(tasks)).toBe(true);
+    });
+
+    it('rate limit applies to claim endpoint too', async () => {
+      const { MUTATION_RATE_LIMIT } = await import('../routes/tasks.js');
+      const { taskId } = (await agent('a').injectPR({ reviewCount: 100 })) as { taskId: string };
+
+      // Single agent rapid-fire claims to exhaust rate limit
+      for (let i = 0; i < MUTATION_RATE_LIMIT.maxRequests; i++) {
+        await app.request(
+          `/api/tasks/${taskId}/claim`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: 'single-flood', role: 'review' }),
+          },
+          env,
+        );
+      }
+
+      const limitedRes = await app.request(
+        `/api/tasks/${taskId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'single-flood', role: 'review' }),
+        },
+        env,
+      );
+      expect(limitedRes.status).toBe(429);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // D. Task TTL Cleanup (#285)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('D. Task TTL cleanup', () => {
+    it('cleanupTerminalTasks removes old completed tasks', async () => {
+      // Create a completed task with old created_at
+      const oldTimestamp = Date.now() - 8 * 24 * 60 * 60 * 1000; // 8 days ago
+      await store.createTask({
+        id: 'old-completed',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        pr_url: 'https://github.com/org/repo/pull/1',
+        diff_url: 'https://github.com/org/repo/pull/1.diff',
+        base_ref: 'main',
+        head_ref: 'feat',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: oldTimestamp + 600_000,
+        status: 'completed',
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: oldTimestamp,
+      });
+
+      // Create a recent completed task
+      await store.createTask({
+        id: 'recent-completed',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 2,
+        pr_url: 'https://github.com/org/repo/pull/2',
+        diff_url: 'https://github.com/org/repo/pull/2.diff',
+        base_ref: 'main',
+        head_ref: 'feat2',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: Date.now() + 600_000,
+        status: 'completed',
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: Date.now(),
+      });
+
+      // Create old pending task (should NOT be cleaned up — not terminal)
+      await store.createTask({
+        id: 'old-pending',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 3,
+        pr_url: 'https://github.com/org/repo/pull/3',
+        diff_url: 'https://github.com/org/repo/pull/3.diff',
+        base_ref: 'main',
+        head_ref: 'feat3',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: oldTimestamp + 600_000,
+        status: 'pending',
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: oldTimestamp,
+      });
+
+      const deleted = await store.cleanupTerminalTasks();
+      expect(deleted).toBe(1);
+
+      // Old completed: gone
+      expect(await store.getTask('old-completed')).toBeNull();
+      // Recent completed: still here
+      expect(await store.getTask('recent-completed')).not.toBeNull();
+      // Old pending: still here (not terminal)
+      expect(await store.getTask('old-pending')).not.toBeNull();
+    });
+
+    it('cleanup also removes associated claims', async () => {
+      const oldTimestamp = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      await store.createTask({
+        id: 'old-task',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        pr_url: 'https://github.com/org/repo/pull/1',
+        diff_url: 'https://github.com/org/repo/pull/1.diff',
+        base_ref: 'main',
+        head_ref: 'feat',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: oldTimestamp + 600_000,
+        status: 'completed',
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: oldTimestamp,
+      });
+      await store.createClaim({
+        id: 'old-task:agent-1',
+        task_id: 'old-task',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'completed',
+        review_text: 'Done.',
+        created_at: oldTimestamp,
+      });
+
+      await store.cleanupTerminalTasks();
+
+      expect(await store.getTask('old-task')).toBeNull();
+      const claims = await store.getClaims('old-task');
+      expect(claims).toHaveLength(0);
+    });
+
+    it('cleanup removes timeout and failed tasks too', async () => {
+      const oldTimestamp = Date.now() - 8 * 24 * 60 * 60 * 1000;
+      const baseTask = {
+        owner: 'org',
+        repo: 'repo',
+        pr_url: 'https://github.com/org/repo/pull/1',
+        diff_url: 'https://github.com/org/repo/pull/1.diff',
+        base_ref: 'main',
+        head_ref: 'feat',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: oldTimestamp + 600_000,
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: oldTimestamp,
+      };
+
+      await store.createTask({ ...baseTask, id: 'old-timeout', pr_number: 1, status: 'timeout' });
+      await store.createTask({ ...baseTask, id: 'old-failed', pr_number: 2, status: 'failed' });
+
+      const deleted = await store.cleanupTerminalTasks();
+      expect(deleted).toBe(2);
+      expect(await store.getTask('old-timeout')).toBeNull();
+      expect(await store.getTask('old-failed')).toBeNull();
+    });
+
+    it('custom TTL controls cleanup threshold', async () => {
+      const shortTtlStore = new MemoryTaskStore(1); // 1 day TTL
+      const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
+
+      await shortTtlStore.createTask({
+        id: 'short-ttl-task',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        pr_url: 'https://github.com/org/repo/pull/1',
+        diff_url: 'https://github.com/org/repo/pull/1.diff',
+        base_ref: 'main',
+        head_ref: 'feat',
+        review_count: 1,
+        prompt: 'Review.',
+        timeout_at: twoDaysAgo + 600_000,
+        status: 'completed',
+        github_installation_id: 999,
+        private: false,
+        config: DEFAULT_REVIEW_CONFIG,
+        created_at: twoDaysAgo,
+      });
+
+      const deleted = await shortTtlStore.cleanupTerminalTasks();
+      expect(deleted).toBe(1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // E. Structured Logging / X-Request-Id (#289)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('E. X-Request-Id header', () => {
+    it('poll response includes X-Request-Id header', async () => {
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'header-test' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const requestId = res.headers.get('X-Request-Id');
+      expect(requestId).toBeDefined();
+      expect(requestId).not.toBe('');
+      // Should be a valid UUID format
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it('claim response includes X-Request-Id header', async () => {
+      const { taskId } = (await agent('a').injectPR()) as { taskId: string };
+
+      const res = await app.request(
+        `/api/tasks/${taskId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'header-test', role: 'summary' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const requestId = res.headers.get('X-Request-Id');
+      expect(requestId).toBeDefined();
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it('error response includes X-Request-Id header', async () => {
+      const res = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}), // missing agent_id
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+
+      const requestId = res.headers.get('X-Request-Id');
+      expect(requestId).toBeDefined();
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it('each request gets a unique X-Request-Id', async () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 5; i++) {
+        resetRateLimits(); // Prevent rate limiting
+        const res = await app.request(
+          '/api/tasks/poll',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ agent_id: `unique-test-${i}` }),
+          },
+          env,
+        );
+        ids.add(res.headers.get('X-Request-Id')!);
+      }
+      expect(ids.size).toBe(5);
+    });
+
+    it('health endpoint also includes X-Request-Id', async () => {
+      const res = await app.request('/', { method: 'GET' }, env);
+      expect(res.status).toBe(200);
+
+      const requestId = res.headers.get('X-Request-Id');
+      expect(requestId).toBeDefined();
+      expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // F. Combined M12 Scenarios
+  // ═══════════════════════════════════════════════════════════
+
+  describe('F. Combined M12 scenarios', () => {
+    it('private task lifecycle with structured errors and request IDs', async () => {
+      // Inject private task
+      const res = await app.request(
+        '/test/events/pr',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            owner: 'corp',
+            repo: 'internal',
+            pr_number: 42,
+            private: true,
+            config: DEFAULT_REVIEW_CONFIG,
+          }),
+        },
+        env,
+      );
+      const { task_id: taskId } = (await res.json()) as { task_id: string };
+
+      // Agent without repos: empty poll with X-Request-Id
+      const pollRes = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'outsider' }),
+        },
+        env,
+      );
+      expect(pollRes.status).toBe(200);
+      expect(pollRes.headers.get('X-Request-Id')).toBeDefined();
+      const pollBody = (await pollRes.json()) as { tasks: unknown[] };
+      expect(pollBody.tasks).toHaveLength(0);
+
+      // Agent with repos: sees the task
+      const authPollRes = await app.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'insider', repos: ['corp/internal'] }),
+        },
+        env,
+      );
+      const authPollBody = (await authPollRes.json()) as {
+        tasks: Array<{ task_id: string }>;
+      };
+      expect(authPollBody.tasks).toHaveLength(1);
+
+      // Claim and complete with structured response
+      const claimRes = await app.request(
+        `/api/tasks/${taskId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'insider', role: 'summary' }),
+        },
+        env,
+      );
+      expect(claimRes.status).toBe(200);
+      expect(claimRes.headers.get('X-Request-Id')).toBeDefined();
+      const claimBody = (await claimRes.json()) as { claimed: boolean };
+      expect(claimBody.claimed).toBe(true);
+
+      // Duplicate claim returns structured error
+      const dupRes = await app.request(
+        `/api/tasks/${taskId}/claim`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent_id: 'outsider', role: 'summary' }),
+        },
+        env,
+      );
+      expect(dupRes.status).toBe(409);
+      expect(dupRes.headers.get('X-Request-Id')).toBeDefined();
+      const dupBody = (await dupRes.json()) as { error: { code: string } };
+      expect(dupBody.error.code).toBe('CLAIM_CONFLICT');
+    });
+  });
+});


### PR DESCRIPTION
Closes #290

## Summary
- **CLI ↔ Server integration tests** (13 tests in `packages/cli/src/__tests__/cli-server-integration.test.ts`): Exercises the real CLI `startAgent()` against an in-process Hono server with MemoryTaskStore. Verifies poll/claim/submit lifecycle, structured error handling, review_only filtering, repo config filtering, tool failure → error report, schema contract (PollResponse/ClaimResponse/ErrorResponse shapes), and private repo task visibility.
- **M12 feature E2E tests** (26 tests in `packages/server/src/__tests__/e2e-m12-features.test.ts`): End-to-end coverage for M12 features:
  - Private repo task filtering at poll time (#282)
  - Structured error codes — TASK_NOT_FOUND, CLAIM_CONFLICT, INVALID_REQUEST, CLAIM_NOT_FOUND, RATE_LIMITED (#283)
  - Rate limiting under load with 429/Retry-After (#234)
  - Task TTL cleanup for terminal tasks (#285)
  - X-Request-Id header on all responses (#289)
  - Combined cross-feature scenario

## Test plan
- [x] 26 M12 feature E2E tests pass
- [x] 13 CLI-Server integration tests pass
- [x] All 890 existing tests pass
- [x] `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` all pass