### PR TITLE
Fix test suite hanging — resolve leaked handles (#318)

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -96,6 +96,7 @@ describe('Agent Coverage Tests', () => {
 
   afterEach(() => {
     server.restore();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -738,15 +738,15 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve();
       return;
     }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -799,22 +799,24 @@ export async function startAgent(
 
   const abortController = new AbortController();
 
-  // Handle graceful shutdown
-  process.on('SIGINT', () => {
-    abortController.abort();
-  });
-  process.on('SIGTERM', () => {
-    abortController.abort();
-  });
+  // Handle graceful shutdown — named handler so it can be removed in finally
+  const onSignal = () => abortController.abort();
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
 
-  await pollLoop(client, agentId, reviewDeps, deps, agentInfo, logger, agentSession, {
-    pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-    maxConsecutiveErrors: options?.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
-    routerRelay: options?.routerRelay,
-    reviewOnly: options?.reviewOnly,
-    repoConfig: options?.repoConfig,
-    signal: abortController.signal,
-  });
+  try {
+    await pollLoop(client, agentId, reviewDeps, deps, agentInfo, logger, agentSession, {
+      pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      maxConsecutiveErrors: options?.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
+      routerRelay: options?.routerRelay,
+      reviewOnly: options?.reviewOnly,
+      repoConfig: options?.repoConfig,
+      signal: abortController.signal,
+    });
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  }
 
   log(formatExitSummary(agentSession));
 }

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -44,19 +44,20 @@ export interface LoggerOptions {
 }
 
 /**
- * Try to open a log file for appending. Returns the file descriptor on success,
- * or null if the file is not writable (with a warning printed to stderr).
+ * Verify a log file path is writable. Creates parent directories if needed.
+ * Returns true on success, false otherwise (with a warning printed to stderr).
  */
-function openLogFile(filePath: string): number | null {
+function verifyLogFile(filePath: string): boolean {
   try {
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });
-    return fs.openSync(filePath, 'a');
+    fs.appendFileSync(filePath, '');
+    return true;
   } catch (err) {
     console.warn(
       `Warning: Cannot open log file "${filePath}": ${(err as Error).message}. Continuing with console-only logging.`,
     );
-    return null;
+    return false;
   }
 }
 
@@ -67,12 +68,12 @@ export function createLogger(labelOrOptions?: string | LoggerOptions): Logger {
 
   const labelStr = label ? ` ${pc.dim(`[${label}]`)}` : '';
 
-  const fd = logFile ? openLogFile(logFile) : null;
+  const logFileOk = logFile ? verifyLogFile(logFile) : false;
 
   function writeToFile(line: string): void {
-    if (fd === null) return;
+    if (!logFileOk || !logFile) return;
     try {
-      fs.writeSync(fd, stripAnsi(line) + '\n');
+      fs.appendFileSync(logFile, stripAnsi(line) + '\n');
     } catch {
       // If writing fails mid-session, silently skip — console output continues
     }

--- a/packages/cli/src/retry.ts
+++ b/packages/cli/src/retry.ts
@@ -50,14 +50,14 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve();
       return;
     }
-    const timer = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }


### PR DESCRIPTION
## Summary

- **logger.ts**: Replace leaked `fs.openSync()` fd with `fs.appendFileSync()` per-write (no persistent file descriptor)
- **agent.ts signal handlers**: Named handler + `try/finally { process.removeListener() }` instead of anonymous arrow functions
- **agent.ts/retry.ts sleep()**: Explicitly `removeEventListener('abort')` when timer fires normally (previously only cleaned up on abort path)
- **agent-coverage.test.ts**: Add missing `vi.restoreAllMocks()` in `afterEach` to clean up `process.on` and `console.*` spies

## Root Cause

The vitest process hung after all tests passed because leaked handles kept the Node.js event loop alive:
1. Open file descriptors from `fs.openSync` without `closeSync`
2. Accumulated `process.on('SIGINT/SIGTERM')` listeners from anonymous handlers
3. Orphaned `AbortSignal` event listeners from `sleep()` when timers completed normally
4. Unreleased vitest spies on `process.on` and `console.*`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` exits cleanly (verified 3/3 runs with EXIT 0)
- [x] Multi-agent review (Codex, GLM-5, Kimi-K2.5, Qwen3.5-Plus) — all confirmed fixes correct

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)