### PR TITLE
[server-dev] Enforce GitHub identity in synthesizer eligibility

### DIFF
--- a/packages/server/src/__tests__/eligibility.test.ts
+++ b/packages/server/src/__tests__/eligibility.test.ts
@@ -251,4 +251,130 @@ describe('isAgentEligibleForRole', () => {
       expect(result.eligible).toBe(true);
     });
   });
+
+  describe('GitHub username matching', () => {
+    it('allows agent matching by github username in whitelist', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ github: 'alice' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-unknown', 'alice');
+      expect(result.eligible).toBe(true);
+    });
+
+    it('blocks agent when github username not in whitelist', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ github: 'alice' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-unknown', 'bob');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('not in the review whitelist');
+    });
+
+    it('blocks agent matching by github username in blacklist', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          blacklist: [{ github: 'spammer' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-good', 'spammer');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('blacklisted');
+    });
+
+    it('matches github username case-insensitively', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ github: 'Alice' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-unknown', 'alice');
+      expect(result.eligible).toBe(true);
+    });
+
+    it('matches mixed agent + github entries in whitelist', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ agent: 'agent-abc' }, { github: 'bob' }],
+        },
+      };
+      // Agent ID match
+      expect(isAgentEligibleForRole(config, 'review', 'agent-abc').eligible).toBe(true);
+      // GitHub username match
+      expect(isAgentEligibleForRole(config, 'review', 'agent-unknown', 'bob').eligible).toBe(true);
+      // Neither matches
+      expect(isAgentEligibleForRole(config, 'review', 'agent-other', 'charlie').eligible).toBe(
+        false,
+      );
+    });
+
+    it('blacklist github takes priority over whitelist agent', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ agent: 'agent-abc' }],
+          blacklist: [{ github: 'blocked-user' }],
+        },
+      };
+      // Agent is whitelisted but github user is blacklisted
+      const result = isAgentEligibleForRole(config, 'review', 'agent-abc', 'blocked-user');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('blacklisted');
+    });
+
+    it('allows agent without github_username when whitelist has only agent entries', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ agent: 'agent-abc' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-abc');
+      expect(result.eligible).toBe(true);
+    });
+
+    it('does not match when github_username is not provided and whitelist has only github entries', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ github: 'alice' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'review', 'agent-abc');
+      expect(result.eligible).toBe(false);
+    });
+
+    it('works for summarizer role with github entries', () => {
+      const config = {
+        ...baseConfig,
+        summarizer: {
+          whitelist: [{ github: 'synth-user' }],
+          blacklist: [],
+          preferred: [],
+        },
+      };
+      expect(isAgentEligibleForRole(config, 'summary', 'agent-x', 'synth-user').eligible).toBe(
+        true,
+      );
+      expect(isAgentEligibleForRole(config, 'summary', 'agent-x', 'other-user').eligible).toBe(
+        false,
+      );
+    });
+  });
 });

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -212,6 +212,141 @@ describe('Task Routes', () => {
       const ids = body.tasks.map((t: { task_id: string }) => t.task_id).sort();
       expect(ids).toEqual(['private-match', 'public-task']);
     });
+
+    // ── Roles filtering ────────────────────────────────────
+
+    it('filters tasks by roles — review only', async () => {
+      await store.createTask(makeTask({ id: 'summary-task', review_count: 1, queue: 'summary' }));
+      await store.createTask(makeTask({ id: 'review-task', review_count: 3, queue: 'review' }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['review'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('review-task');
+      expect(body.tasks[0].role).toBe('review');
+    });
+
+    it('filters tasks by roles — summary only', async () => {
+      await store.createTask(makeTask({ id: 'summary-task', review_count: 1, queue: 'summary' }));
+      await store.createTask(makeTask({ id: 'review-task', review_count: 3, queue: 'review' }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['summary'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('summary-task');
+      expect(body.tasks[0].role).toBe('summary');
+    });
+
+    it('returns both roles when roles includes both', async () => {
+      await store.createTask(makeTask({ id: 'summary-task', review_count: 1, queue: 'summary' }));
+      await store.createTask(makeTask({ id: 'review-task', review_count: 3, queue: 'review' }));
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['review', 'summary'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('returns all tasks when roles is omitted (backward compatible)', async () => {
+      await store.createTask(makeTask({ id: 'summary-task', review_count: 1, queue: 'summary' }));
+      await store.createTask(makeTask({ id: 'review-task', review_count: 3, queue: 'review' }));
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('roles takes precedence over review_only', async () => {
+      await store.createTask(makeTask({ id: 'summary-task', review_count: 1, queue: 'summary' }));
+      await store.createTask(makeTask({ id: 'review-task', review_count: 3, queue: 'review' }));
+      // roles says summary, review_only says true — roles wins
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['summary'],
+        review_only: true,
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('summary');
+    });
+
+    // ── synthesize_repos filtering ─────────────────────────
+
+    it('filters summary tasks by synthesize_repos whitelist', async () => {
+      await store.createTask(
+        makeTask({ id: 'task-a', review_count: 1, queue: 'summary', owner: 'org', repo: 'repo-a' }),
+      );
+      await store.createTask(
+        makeTask({ id: 'task-b', review_count: 1, queue: 'summary', owner: 'org', repo: 'repo-b' }),
+      );
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        synthesize_repos: { mode: 'whitelist', list: ['org/repo-a'] },
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('task-a');
+    });
+
+    it('does not filter review tasks by synthesize_repos', async () => {
+      await store.createTask(
+        makeTask({
+          id: 'review-task',
+          review_count: 3,
+          queue: 'review',
+          owner: 'org',
+          repo: 'repo-x',
+        }),
+      );
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        synthesize_repos: { mode: 'whitelist', list: ['org/repo-other'] },
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('review');
+    });
+
+    it('returns all summary tasks when synthesize_repos is omitted', async () => {
+      await store.createTask(
+        makeTask({ id: 'task-a', review_count: 1, queue: 'summary', owner: 'org', repo: 'repo-a' }),
+      );
+      await store.createTask(
+        makeTask({ id: 'task-b', review_count: 1, queue: 'summary', owner: 'org', repo: 'repo-b' }),
+      );
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    // ── github_username in poll ─────────────────────────────
+
+    it('passes github_username to eligibility check during poll', async () => {
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        summarizer: {
+          whitelist: [{ github: 'alice' }],
+          blacklist: [],
+          preferred: [],
+        },
+      };
+      await store.createTask(makeTask({ config }));
+      // Without github_username — not eligible
+      const res1 = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body1 = await res1.json();
+      expect(body1.tasks).toHaveLength(0);
+      // With matching github_username — eligible
+      const res2 = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        github_username: 'alice',
+      });
+      const body2 = await res2.json();
+      expect(body2.tasks).toHaveLength(1);
+    });
   });
 
   // ── Rate Limiting ────────────────────────────────────────
@@ -378,6 +513,51 @@ describe('Task Routes', () => {
       });
       const body = await res.json();
       expect(body.claimed).toBe(true);
+    });
+
+    it('passes github_username to eligibility check during claim', async () => {
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        summarizer: {
+          whitelist: [{ github: 'alice' }],
+          blacklist: [],
+          preferred: [],
+        },
+      };
+      await store.createTask(makeTask({ config }));
+      // Claim without github_username — rejected (not in whitelist)
+      const res1 = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-1',
+        role: 'summary',
+      });
+      expect(res1.status).toBe(409);
+      // Claim with matching github_username — allowed
+      const res2 = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-1',
+        role: 'summary',
+        github_username: 'alice',
+      });
+      const body2 = await res2.json();
+      expect(body2.claimed).toBe(true);
+    });
+
+    it('rejects claim when github_username is blacklisted', async () => {
+      const config = {
+        ...DEFAULT_REVIEW_CONFIG,
+        summarizer: {
+          ...DEFAULT_REVIEW_CONFIG.summarizer,
+          blacklist: [{ github: 'blocked' }],
+        },
+      };
+      await store.createTask(makeTask({ config }));
+      const res = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-1',
+        role: 'summary',
+        github_username: 'blocked',
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
   });
 

--- a/packages/server/src/eligibility.ts
+++ b/packages/server/src/eligibility.ts
@@ -1,4 +1,5 @@
 import type { ReviewConfig, ClaimRole } from '@opencara/shared';
+import { isEntityMatch } from '@opencara/shared';
 import { createLogger } from './logger.js';
 export { isRepoAllowed } from '@opencara/shared';
 
@@ -45,26 +46,31 @@ function matchGlob(pattern: string, text: string): boolean {
 /**
  * Check if an agent is eligible for a given role based on the review config's
  * whitelist/blacklist settings. Blacklist is checked first (deny takes priority).
+ *
+ * Matching uses isEntityMatch() from shared — entries with `agent` field match
+ * against agentId, entries with `github` field match against githubUsername
+ * (case-insensitive).
  */
 export function isAgentEligibleForRole(
   config: ReviewConfig,
   role: ClaimRole,
   agentId: string,
+  githubUsername?: string,
 ): { eligible: boolean; reason?: string } {
   const roleConfig = role === 'review' ? config.reviewer : config.summarizer;
   const { whitelist, blacklist } = roleConfig;
 
   // Blacklist check — deny takes priority
   if (blacklist.length > 0) {
-    const blocked = blacklist.some((entry) => entry.agent === agentId);
+    const blocked = blacklist.some((entry) => isEntityMatch(entry, agentId, githubUsername));
     if (blocked) {
       return { eligible: false, reason: `Agent "${agentId}" is blacklisted for ${role}` };
     }
   }
 
-  // Whitelist check — if non-empty, only listed agents are allowed
+  // Whitelist check — if non-empty, only listed agents/users are allowed
   if (whitelist.length > 0) {
-    const allowed = whitelist.some((entry) => entry.agent === agentId);
+    const allowed = whitelist.some((entry) => isEntityMatch(entry, agentId, githubUsername));
     if (!allowed) {
       return { eligible: false, reason: `Agent "${agentId}" is not in the ${role} whitelist` };
     }

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -12,6 +12,7 @@ import type {
   ReviewVerdict,
   ReviewTask,
 } from '@opencara/shared';
+import { isRepoAllowed, isEntityMatch } from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
@@ -38,11 +39,15 @@ export const PREFERRED_SYNTH_GRACE_PERIOD_MS = 60_000;
  * - If the agent is NOT preferred, summary is only available after the grace period
  *   has elapsed since the task entered the summary queue.
  */
-function isSummaryVisibleToAgent(task: ReviewTask, agentId: string): boolean {
+function isSummaryVisibleToAgent(
+  task: ReviewTask,
+  agentId: string,
+  githubUsername?: string,
+): boolean {
   const preferred = task.config?.summarizer?.preferred ?? [];
   if (preferred.length === 0) return true;
 
-  const isPreferred = preferred.some((p) => p.agent === agentId);
+  const isPreferred = preferred.some((p) => isEntityMatch(p, agentId, githubUsername));
   if (isPreferred) return true;
 
   // Non-preferred agent: check if grace period has elapsed
@@ -261,11 +266,19 @@ export function taskRoutes() {
     const github = c.get('github');
     const logger = c.get('logger');
     const body = await c.req.json<PollRequest>();
-    const { agent_id, review_only, repos } = body;
+    const { agent_id, github_username, roles, review_only, repos, synthesize_repos } = body;
 
     if (!agent_id) {
       return apiError(c, 400, 'INVALID_REQUEST', 'agent_id is required');
     }
+
+    // Determine which roles this agent will accept
+    // `roles` takes precedence over deprecated `review_only`
+    const acceptedRoles: Set<string> | null = roles
+      ? new Set(roles)
+      : review_only
+        ? new Set(['review'])
+        : null; // null = accept all roles
 
     // Build a set of repos the agent declares for fast lookup
     const agentRepos = repos && repos.length > 0 ? new Set(repos) : null;
@@ -291,11 +304,21 @@ export function taskRoutes() {
 
       // Queue-based role assignment
       if (task.queue === 'summary') {
-        // Summary queue — check eligibility and grace period
-        if (review_only) continue;
-        const { eligible } = isAgentEligibleForRole(task.config, 'summary', agent_id);
+        // Summary queue — check role filter, eligibility, grace period, and repo preference
+        if (acceptedRoles && !acceptedRoles.has('summary')) continue;
+        const { eligible } = isAgentEligibleForRole(
+          task.config,
+          'summary',
+          agent_id,
+          github_username,
+        );
         if (!eligible) continue;
-        if (!isSummaryVisibleToAgent(task, agent_id)) continue;
+        if (!isSummaryVisibleToAgent(task, agent_id, github_username)) continue;
+
+        // synthesize_repos filter — if provided, only offer summary tasks for matching repos
+        if (synthesize_repos) {
+          if (!isRepoAllowed(synthesize_repos, task.owner, task.repo)) continue;
+        }
 
         available.push({
           task_id: task.id,
@@ -308,12 +331,18 @@ export function taskRoutes() {
           role: 'summary',
         });
       } else if (task.queue === 'review') {
-        // Review queue — check if review slots are available
+        // Review queue — check role filter and review slots
+        if (acceptedRoles && !acceptedRoles.has('review')) continue;
         const reviewSlots = task.review_count - 1;
         const reviewClaims = task.review_claims ?? 0;
         if (reviewClaims >= reviewSlots) continue;
 
-        const { eligible } = isAgentEligibleForRole(task.config, 'review', agent_id);
+        const { eligible } = isAgentEligibleForRole(
+          task.config,
+          'review',
+          agent_id,
+          github_username,
+        );
         if (!eligible) continue;
 
         // Check if agent already has a review claim on this task
@@ -349,7 +378,7 @@ export function taskRoutes() {
     const store = c.get('store');
     const taskId = c.req.param('taskId');
     const body = await c.req.json<ClaimRequest>();
-    const { agent_id, role, model, tool } = body;
+    const { agent_id, role, github_username, model, tool } = body;
 
     if (!agent_id || !role) {
       return apiError(c, 400, 'INVALID_REQUEST', 'agent_id and role are required');
@@ -369,7 +398,7 @@ export function taskRoutes() {
     }
 
     // Check whitelist/blacklist eligibility before slot availability
-    const eligibility = isAgentEligibleForRole(task.config, role, agent_id);
+    const eligibility = isAgentEligibleForRole(task.config, role, agent_id, github_username);
     if (!eligibility.eligible) {
       return apiError(
         c,
@@ -394,7 +423,7 @@ export function taskRoutes() {
         return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
       }
       // Check preferred synthesizer grace period
-      if (!isSummaryVisibleToAgent(task, agent_id)) {
+      if (!isSummaryVisibleToAgent(task, agent_id, github_username)) {
         return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
       }
     }


### PR DESCRIPTION
Closes #327

## Summary
- Updated `isAgentEligibleForRole()` to accept `githubUsername` parameter, using `isEntityMatch()` from shared for whitelist/blacklist matching against both agent ID and GitHub username
- Poll handler now supports `roles` field (replaces deprecated `review_only`), `synthesize_repos` field (filters summary tasks by repo preference), and `github_username` (passed to eligibility checks)
- Claim handler passes `github_username` from request body to eligibility verification
- `isSummaryVisibleToAgent()` now matches preferred synthesizer list by GitHub username (case-insensitive)

## Test plan
- [x] 12 new tests for GitHub identity matching in eligibility (agent, github, mixed, case-insensitive)
- [x] 8 new tests for roles filtering in poll (review only, summary only, both, backward compat, precedence over review_only)
- [x] 3 new tests for synthesize_repos filtering in poll
- [x] 1 new test for github_username passthrough in poll eligibility
- [x] 2 new tests for github_username in claim (whitelist match, blacklist rejection)
- [x] All 1047 existing tests pass
- [x] Build, lint, format, typecheck all pass