### PR TITLE
[cli-dev] Add synthesizer_only config and send identity in poll/claim

### DIFF
--- a/packages/cli/src/__tests__/agent-cli.test.ts
+++ b/packages/cli/src/__tests__/agent-cli.test.ts
@@ -18,6 +18,7 @@ vi.mock('../config.js', () => ({
     maxDiffSizeKb: 100,
     maxConsecutiveErrors: 3,
     githubToken: 'config-token',
+    githubUsername: null,
     codebaseDir: null,
     agentCommand: 'echo test',
     agents: [
@@ -29,6 +30,7 @@ vi.mock('../config.js', () => ({
   resolveGithubToken: vi.fn(
     (agentToken?: string, globalToken?: string | null) => agentToken ?? globalToken ?? null,
   ),
+  resolveGithubUsername: vi.fn(async () => null),
   DEFAULT_MAX_CONSECUTIVE_ERRORS: 10,
 }));
 
@@ -136,6 +138,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [{ model: 'claude', tool: 'cli' }],
@@ -163,6 +166,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: 'nonexistent-tool review',
         agents: [{ model: 'claude', tool: 'cli', command: 'nonexistent-tool review' }],
@@ -186,6 +190,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [
@@ -211,6 +216,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,
@@ -233,6 +239,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [{ model: 'claude', tool: 'cli', command: 'echo test' }],
@@ -292,6 +299,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [
@@ -317,6 +325,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [
@@ -345,6 +354,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [
@@ -369,6 +379,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [{ model: 'claude', tool: 'cli', command: 'echo test' }],
@@ -390,6 +401,7 @@ describe('Agent CLI tests', () => {
         maxDiffSizeKb: 100,
         maxConsecutiveErrors: 3,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
+import { startAgent, computeRoles, type ConsumptionDeps } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
 import type { RouterRelay } from '../router.js';
 import { createSessionTracker } from '../consumption.js';
+import type { LocalAgentConfig } from '../config.js';
 
 vi.mock('../tool-executor.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -783,5 +784,220 @@ describe('agent poll loop', () => {
     expect(console.error).not.toHaveBeenCalledWith(
       expect.stringContaining('Too many consecutive errors'),
     );
+  });
+
+  it('sends roles, github_username, and synthesize_repos in poll request', async () => {
+    let pollCount = 0;
+    const fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.body) {
+        fetchCalls.push({ url, body: JSON.parse(init.body as string) });
+      }
+      if (typeof url === 'string' && url.includes('/api/tasks/poll')) {
+        pollCount++;
+        if (pollCount >= 2) {
+          // Force exit via auth error after we've captured the first poll
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            json: () =>
+              Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
+          });
+        }
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        maxConsecutiveErrors: 1,
+        roles: ['review', 'summary'],
+        githubUsername: 'octocat',
+        synthesizeRepos: { mode: 'whitelist', list: ['org/repo'] },
+      },
+    );
+
+    // Let the first poll fire (testCommand dry-run + poll)
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Find the poll request
+    const pollCall = fetchCalls.find((c) => c.url.includes('/api/tasks/poll'));
+    expect(pollCall).toBeDefined();
+    expect(pollCall!.body.roles).toEqual(['review', 'summary']);
+    expect(pollCall!.body.github_username).toBe('octocat');
+    expect(pollCall!.body.synthesize_repos).toEqual({
+      mode: 'whitelist',
+      list: ['org/repo'],
+    });
+
+    // Advance to let the loop exit on the next error
+    await vi.advanceTimersByTimeAsync(200);
+    await promise;
+  });
+
+  it('sends github_username in claim request', async () => {
+    let pollCount = 0;
+    const fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.body) {
+        fetchCalls.push({ url, body: JSON.parse(init.body as string) });
+      }
+      if (typeof url === 'string' && url.includes('/api/tasks/poll')) {
+        pollCount++;
+        if (pollCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                tasks: [
+                  {
+                    task_id: 'task-1',
+                    owner: 'org',
+                    repo: 'repo',
+                    pr_number: 42,
+                    diff_url: 'https://github.com/org/repo/pull/42.diff',
+                    timeout_seconds: 300,
+                    prompt: 'Review this',
+                    role: 'review',
+                  },
+                ],
+              }),
+          });
+        }
+        // Exit on second poll
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
+        });
+      }
+      if (typeof url === 'string' && url.includes('/claim')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ claimed: true }),
+        });
+      }
+      // diff fetch
+      if (typeof url === 'string' && url.includes('github.com')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('diff content'),
+        });
+      }
+      // result submission
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        maxConsecutiveErrors: 1,
+        githubUsername: 'octocat',
+      },
+    );
+
+    // Let the poll + claim cycle complete
+    await vi.advanceTimersByTimeAsync(0);
+    // Allow microtasks for claim/review to complete
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    // Find the claim request
+    const claimCall = fetchCalls.find((c) => c.url.includes('/claim'));
+    expect(claimCall).toBeDefined();
+    expect(claimCall!.body.github_username).toBe('octocat');
+  });
+
+  it('does not send github_username in poll when not provided', async () => {
+    let pollCount = 0;
+    const fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.body) {
+        fetchCalls.push({ url, body: JSON.parse(init.body as string) });
+      }
+      if (typeof url === 'string' && url.includes('/api/tasks/poll')) {
+        pollCount++;
+        if (pollCount >= 2) {
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            json: () =>
+              Promise.resolve({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }),
+          });
+        }
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      });
+    });
+
+    const { reviewDeps, consumptionDeps } = makeDeps();
+
+    const promise = startAgent(
+      'test-agent',
+      'https://api.test.com',
+      { model: 'test-model', tool: 'test-tool' },
+      reviewDeps,
+      consumptionDeps,
+      {
+        pollIntervalMs: 100,
+        maxConsecutiveErrors: 1,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const pollCall = fetchCalls.find((c) => c.url.includes('/api/tasks/poll'));
+    expect(pollCall).toBeDefined();
+    expect(pollCall!.body.github_username).toBeUndefined();
+    expect(pollCall!.body.roles).toBeUndefined();
+    expect(pollCall!.body.synthesize_repos).toBeUndefined();
+
+    // Let the loop exit
+    await vi.advanceTimersByTimeAsync(200);
+    await promise;
+  });
+});
+
+describe('computeRoles', () => {
+  it('returns ["review"] for review_only agent', () => {
+    const agent: LocalAgentConfig = { model: 'claude-opus-4-6', tool: 'claude', review_only: true };
+    expect(computeRoles(agent)).toEqual(['review']);
+  });
+
+  it('returns ["summary"] for synthesizer_only agent', () => {
+    const agent: LocalAgentConfig = {
+      model: 'claude-opus-4-6',
+      tool: 'claude',
+      synthesizer_only: true,
+    };
+    expect(computeRoles(agent)).toEqual(['summary']);
+  });
+
+  it('returns ["review", "summary"] for agent with neither flag', () => {
+    const agent: LocalAgentConfig = { model: 'claude-opus-4-6', tool: 'claude' };
+    expect(computeRoles(agent)).toEqual(['review', 'summary']);
   });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -18,6 +18,7 @@ import {
   ensureConfigDir,
   resolveCodebaseDir,
   resolveGithubToken,
+  resolveGithubUsername,
   RepoConfigError,
   ConfigValidationError,
   CONFIG_DIR,
@@ -61,6 +62,7 @@ describe('config', () => {
       expect(config.maxDiffSizeKb).toBe(DEFAULT_MAX_DIFF_SIZE_KB);
       expect(config.maxConsecutiveErrors).toBe(DEFAULT_MAX_CONSECUTIVE_ERRORS);
       expect(config.githubToken).toBeNull();
+      expect(config.githubUsername).toBeNull();
       expect(config.codebaseDir).toBeNull();
       expect(config.agentCommand).toBeNull();
     });
@@ -256,6 +258,7 @@ describe('config', () => {
       maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
       maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
       githubToken: null as string | null,
+      githubUsername: null as string | null,
       codebaseDir: null as string | null,
 
       agentCommand: null as string | null,
@@ -383,6 +386,7 @@ describe('config', () => {
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [{ model: 'glm-5', tool: 'qwen', command: 'qwen -y -m glm-5' }],
@@ -399,6 +403,7 @@ describe('config', () => {
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,
@@ -432,6 +437,7 @@ agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [{ model: 'claude-sonnet-4-6', tool: 'claude', name: 'MyBot' }],
@@ -707,6 +713,7 @@ agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: [
@@ -756,6 +763,7 @@ agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: 'ghp_xyz789',
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,
@@ -771,6 +779,7 @@ agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,
@@ -864,6 +873,7 @@ anonymous_agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: '~/.opencara/repos',
         agentCommand: null,
         agents: null,
@@ -879,6 +889,7 @@ anonymous_agents:
         maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
         maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
         githubToken: null,
+        githubUsername: null,
         codebaseDir: null,
         agentCommand: null,
         agents: null,
@@ -1171,6 +1182,247 @@ agents:
         );
         warnSpy.mockRestore();
       });
+    });
+  });
+
+  describe('synthesizer_only config', () => {
+    it('parses synthesizer_only: true from agent entries', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    synthesizer_only: true
+  - model: glm-5
+    tool: qwen
+`);
+      const config = loadConfig();
+      expect(config.agents).toHaveLength(2);
+      expect(config.agents![0].synthesizer_only).toBe(true);
+      expect(config.agents![1].synthesizer_only).toBeUndefined();
+    });
+
+    it('ignores synthesizer_only: false', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    synthesizer_only: false
+`);
+      const config = loadConfig();
+      expect(config.agents![0].synthesizer_only).toBeUndefined();
+    });
+
+    it('throws ConfigValidationError when both review_only and synthesizer_only are true', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    review_only: true
+    synthesizer_only: true
+`);
+      expect(() => loadConfig()).toThrow(ConfigValidationError);
+      expect(() => loadConfig()).toThrow('review_only and synthesizer_only cannot both be true');
+    });
+
+    it('allows review_only: true without synthesizer_only', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    review_only: true
+`);
+      const config = loadConfig();
+      expect(config.agents![0].review_only).toBe(true);
+      expect(config.agents![0].synthesizer_only).toBeUndefined();
+    });
+
+    it('allows synthesizer_only: true without review_only', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    synthesizer_only: true
+`);
+      const config = loadConfig();
+      expect(config.agents![0].synthesizer_only).toBe(true);
+      expect(config.agents![0].review_only).toBeUndefined();
+    });
+  });
+
+  describe('synthesize_repos config', () => {
+    it('parses synthesize_repos with mode: whitelist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    synthesize_repos:
+      mode: whitelist
+      list:
+        - OpenCara/OpenCara
+`);
+      const config = loadConfig();
+      expect(config.agents![0].synthesize_repos).toEqual({
+        mode: 'whitelist',
+        list: ['OpenCara/OpenCara'],
+      });
+    });
+
+    it('defaults to undefined synthesize_repos when omitted', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+`);
+      const config = loadConfig();
+      expect(config.agents![0].synthesize_repos).toBeUndefined();
+    });
+
+    it('throws RepoConfigError for invalid synthesize_repos mode', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    synthesize_repos:
+      mode: invalid
+`);
+      expect(() => loadConfig()).toThrow(RepoConfigError);
+      expect(() => loadConfig()).toThrow('synthesize_repos.mode must be one of');
+    });
+
+    it('allows both repos and synthesize_repos on same agent', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(`
+agents:
+  - model: claude-opus-4-6
+    tool: claude
+    repos:
+      mode: all
+    synthesize_repos:
+      mode: whitelist
+      list:
+        - org/repo
+`);
+      const config = loadConfig();
+      expect(config.agents![0].repos).toEqual({ mode: 'all' });
+      expect(config.agents![0].synthesize_repos).toEqual({
+        mode: 'whitelist',
+        list: ['org/repo'],
+      });
+    });
+  });
+
+  describe('github_username config', () => {
+    it('parses github_username from config file', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('github_username: octocat\n');
+
+      const config = loadConfig();
+      expect(config.githubUsername).toBe('octocat');
+    });
+
+    it('returns null for non-string github_username', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('github_username: 123\n');
+
+      const config = loadConfig();
+      expect(config.githubUsername).toBeNull();
+    });
+
+    it('returns null when github_username is absent', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('platform_url: https://test.dev\n');
+
+      const config = loadConfig();
+      expect(config.githubUsername).toBeNull();
+    });
+
+    it('saveConfig writes github_username when present', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        githubToken: null,
+        githubUsername: 'octocat',
+        codebaseDir: null,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('github_username: octocat');
+    });
+
+    it('saveConfig omits github_username when null', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        githubToken: null,
+        githubUsername: null,
+        codebaseDir: null,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).not.toContain('github_username');
+    });
+  });
+
+  describe('resolveGithubUsername', () => {
+    it('returns null when token is null', async () => {
+      const result = await resolveGithubUsername(null);
+      expect(result).toBeNull();
+    });
+
+    it('returns username on successful API call', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ login: 'octocat' }),
+      });
+      const result = await resolveGithubUsername(
+        'ghp_test123',
+        mockFetch as unknown as typeof fetch,
+      );
+      expect(result).toBe('octocat');
+      expect(mockFetch).toHaveBeenCalledWith('https://api.github.com/user', {
+        headers: {
+          Authorization: 'Bearer ghp_test123',
+          Accept: 'application/vnd.github+json',
+        },
+      });
+    });
+
+    it('returns null on API error', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+      const result = await resolveGithubUsername('bad-token', mockFetch as unknown as typeof fetch);
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      const result = await resolveGithubUsername('ghp_test', mockFetch as unknown as typeof fetch);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API response has no login field', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 123 }),
+      });
+      const result = await resolveGithubUsername('ghp_test', mockFetch as unknown as typeof fetch);
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -16,6 +16,7 @@ import {
   loadConfig,
   resolveCodebaseDir,
   resolveGithubToken as resolveConfigToken,
+  resolveGithubUsername,
   DEFAULT_MAX_CONSECUTIVE_ERRORS,
   CONFIG_DIR,
   type LocalAgentConfig,
@@ -70,6 +71,15 @@ function toApiDiffUrl(webUrl: string): string | null {
   if (!match) return null;
   const [, owner, repo, prNumber] = match;
   return `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
+}
+
+/**
+ * Compute the roles this agent is willing to take based on its config.
+ */
+export function computeRoles(agent: LocalAgentConfig): ClaimRole[] {
+  if (agent.review_only) return ['review'];
+  if (agent.synthesizer_only) return ['summary'];
+  return ['review', 'summary'];
 }
 
 /**
@@ -141,11 +151,23 @@ async function pollLoop(
     routerRelay?: RouterRelay;
     reviewOnly?: boolean;
     repoConfig?: RepoConfig;
+    roles?: ClaimRole[];
+    synthesizeRepos?: RepoConfig;
+    githubUsername?: string;
     signal?: AbortSignal;
   },
 ): Promise<void> {
-  const { pollIntervalMs, maxConsecutiveErrors, routerRelay, reviewOnly, repoConfig, signal } =
-    options;
+  const {
+    pollIntervalMs,
+    maxConsecutiveErrors,
+    routerRelay,
+    reviewOnly,
+    repoConfig,
+    roles,
+    synthesizeRepos,
+    githubUsername,
+    signal,
+  } = options;
   const { log, logError, logWarn } = logger;
 
   log(`${icons.polling} Polling every ${pollIntervalMs / 1000}s...`);
@@ -160,10 +182,13 @@ async function pollLoop(
       // Poll for tasks — include declared repos so server can return matching private tasks.
       // Server validates permissions; sending repos here doesn't bypass access control.
       const pollBody: Record<string, unknown> = { agent_id: agentId };
+      if (githubUsername) pollBody.github_username = githubUsername;
+      if (roles) pollBody.roles = roles;
       if (reviewOnly) pollBody.review_only = true;
       if (repoConfig?.list?.length) {
         pollBody.repos = repoConfig.list;
       }
+      if (synthesizeRepos) pollBody.synthesize_repos = synthesizeRepos;
       const pollResponse = await client.post<PollResponse>('/api/tasks/poll', pollBody);
 
       consecutiveAuthErrors = 0;
@@ -189,6 +214,7 @@ async function pollLoop(
           agentSession,
           routerRelay,
           signal,
+          githubUsername,
         );
         if (result.diffFetchFailed) {
           agentSession.errorsEncountered++;
@@ -269,6 +295,7 @@ async function handleTask(
   agentSession: AgentSessionStats,
   routerRelay?: RouterRelay,
   signal?: AbortSignal,
+  githubUsername?: string,
 ): Promise<HandleTaskResult> {
   const { task_id, owner, repo, pr_number, diff_url, timeout_seconds, prompt, role } = task;
   const { log, logError, logWarn } = logger;
@@ -281,14 +308,15 @@ async function handleTask(
   // which the ApiClient converts to an HttpError.
   let claimResponse: ClaimResponse;
   try {
+    const claimBody: Record<string, unknown> = {
+      agent_id: agentId,
+      role,
+      model: agentInfo.model,
+      tool: agentInfo.tool,
+    };
+    if (githubUsername) claimBody.github_username = githubUsername;
     claimResponse = await withRetry(
-      () =>
-        client.post<ClaimResponse>(`/api/tasks/${task_id}/claim`, {
-          agent_id: agentId,
-          role,
-          model: agentInfo.model,
-          tool: agentInfo.tool,
-        }),
+      () => client.post<ClaimResponse>(`/api/tasks/${task_id}/claim`, claimBody),
       { maxAttempts: 2 },
       signal,
     );
@@ -765,6 +793,9 @@ export async function startAgent(
     routerRelay?: RouterRelay;
     reviewOnly?: boolean;
     repoConfig?: RepoConfig;
+    roles?: ClaimRole[];
+    synthesizeRepos?: RepoConfig;
+    githubUsername?: string;
     label?: string;
   },
 ): Promise<void> {
@@ -812,6 +843,9 @@ export async function startAgent(
     routerRelay: options?.routerRelay,
     reviewOnly: options?.reviewOnly,
     repoConfig: options?.repoConfig,
+    roles: options?.roles,
+    synthesizeRepos: options?.synthesizeRepos,
+    githubUsername: options?.githubUsername,
     signal: abortController.signal,
   });
 
@@ -845,6 +879,13 @@ export async function startAgentRouter(): Promise<void> {
   const logger = createLogger(agentConfig?.name ?? 'agent[0]');
   logAuthMethod(auth.method, logger.log);
 
+  // Resolve GitHub username from token for identity
+  const githubUsername =
+    config.githubUsername ?? (await resolveGithubUsername(auth.token)) ?? undefined;
+  if (githubUsername) {
+    logger.log(`GitHub identity: ${githubUsername}`);
+  }
+
   const codebaseDir = resolveCodebaseDir(agentConfig?.codebase_dir, config.codebaseDir);
   const reviewDeps: ReviewExecutorDeps = {
     commandTemplate: commandTemplate ?? '',
@@ -858,6 +899,7 @@ export async function startAgentRouter(): Promise<void> {
   const model = agentConfig?.model ?? 'unknown';
   const tool = agentConfig?.tool ?? 'unknown';
   const label = agentConfig?.name ?? 'agent[0]';
+  const roles = agentConfig ? computeRoles(agentConfig) : undefined;
 
   await startAgent(
     agentId,
@@ -873,6 +915,9 @@ export async function startAgentRouter(): Promise<void> {
       routerRelay: router,
       reviewOnly: agentConfig?.review_only,
       repoConfig: agentConfig?.repos,
+      roles,
+      synthesizeRepos: agentConfig?.synthesize_repos,
+      githubUsername,
       label,
     },
   );
@@ -896,6 +941,7 @@ function startAgentByIndex(
   agentIndex: number,
   pollIntervalMs: number,
   auth: GithubAuthResult,
+  githubUsername?: string,
 ): Promise<void> | null {
   const agentId = crypto.randomUUID();
   let commandTemplate: string | undefined;
@@ -952,6 +998,7 @@ function startAgentByIndex(
   const session = createSessionTracker();
   const model = agentConfig?.model ?? 'unknown';
   const tool = agentConfig?.tool ?? 'unknown';
+  const roles = agentConfig ? computeRoles(agentConfig) : undefined;
 
   const agentPromise = startAgent(
     agentId,
@@ -965,6 +1012,9 @@ function startAgentByIndex(
       routerRelay,
       reviewOnly: agentConfig?.review_only,
       repoConfig: agentConfig?.repos,
+      roles,
+      synthesizeRepos: agentConfig?.synthesize_repos,
+      githubUsername,
       label,
     },
   ).finally(() => {
@@ -991,6 +1041,13 @@ agentCommand
     const auth = resolveGithubToken(configToken);
     logAuthMethod(auth.method, console.log.bind(console));
 
+    // Resolve GitHub username from token for identity
+    const githubUsername =
+      config.githubUsername ?? (await resolveGithubUsername(auth.token)) ?? undefined;
+    if (githubUsername) {
+      console.log(`GitHub identity: ${githubUsername}`);
+    }
+
     if (opts.all) {
       // Start all agents concurrently
       if (!config.agents || config.agents.length === 0) {
@@ -1004,7 +1061,7 @@ agentCommand
       const promises: Promise<void>[] = [];
       let startFailed = false;
       for (let i = 0; i < config.agents.length; i++) {
-        const p = startAgentByIndex(config, i, pollIntervalMs, auth);
+        const p = startAgentByIndex(config, i, pollIntervalMs, auth, githubUsername);
         if (p) {
           promises.push(p);
         } else {
@@ -1048,7 +1105,7 @@ agentCommand
         process.exit(1);
         return;
       }
-      const p = startAgentByIndex(config, agentIndex, pollIntervalMs, auth);
+      const p = startAgentByIndex(config, agentIndex, pollIntervalMs, auth, githubUsername);
       if (!p) {
         // startAgentByIndex already logged the specific reason
         process.exit(1);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,6 +12,8 @@ export interface LocalAgentConfig {
   command?: string;
   router?: boolean;
   review_only?: boolean;
+  synthesizer_only?: boolean;
+  synthesize_repos?: RepoConfig;
   github_token?: string;
   codebase_dir?: string;
   repos?: RepoConfig;
@@ -22,6 +24,7 @@ export interface CliConfig {
   maxDiffSizeKb: number;
   maxConsecutiveErrors: number;
   githubToken: string | null;
+  githubUsername: string | null;
   codebaseDir: string | null;
   agentCommand: string | null;
   agents: LocalAgentConfig[] | null; // null = key absent = old server-side behavior
@@ -66,22 +69,26 @@ const TOOL_ALIASES: Record<string, string> = {
   'claude-code': 'claude',
 };
 
-function parseRepoConfig(obj: Record<string, unknown>, index: number): RepoConfig | undefined {
-  const raw = obj.repos;
+function parseRepoConfig(
+  obj: Record<string, unknown>,
+  index: number,
+  field: string = 'repos',
+): RepoConfig | undefined {
+  const raw = obj[field];
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== 'object') {
-    throw new RepoConfigError(`agents[${index}].repos must be an object`);
+    throw new RepoConfigError(`agents[${index}].${field} must be an object`);
   }
 
   const reposObj = raw as Record<string, unknown>;
   const mode = reposObj.mode;
 
   if (mode === undefined) {
-    throw new RepoConfigError(`agents[${index}].repos.mode is required`);
+    throw new RepoConfigError(`agents[${index}].${field}.mode is required`);
   }
   if (typeof mode !== 'string' || !VALID_REPO_MODES.includes(mode as RepoFilterMode)) {
     throw new RepoConfigError(
-      `agents[${index}].repos.mode must be one of: ${VALID_REPO_MODES.join(', ')}`,
+      `agents[${index}].${field}.mode must be one of: ${VALID_REPO_MODES.join(', ')}`,
     );
   }
 
@@ -91,7 +98,7 @@ function parseRepoConfig(obj: Record<string, unknown>, index: number): RepoConfi
   if (mode === 'whitelist' || mode === 'blacklist') {
     if (!Array.isArray(list) || list.length === 0) {
       throw new RepoConfigError(
-        `agents[${index}].repos.list is required and must be non-empty for mode '${mode}'`,
+        `agents[${index}].${field}.list is required and must be non-empty for mode '${mode}'`,
       );
     }
   }
@@ -99,7 +106,7 @@ function parseRepoConfig(obj: Record<string, unknown>, index: number): RepoConfi
     for (let j = 0; j < list.length; j++) {
       if (typeof list[j] !== 'string' || !REPO_PATTERN.test(list[j])) {
         throw new RepoConfigError(
-          `agents[${index}].repos.list[${j}] must match 'owner/repo' format`,
+          `agents[${index}].${field}.list[${j}] must match 'owner/repo' format`,
         );
       }
     }
@@ -149,10 +156,18 @@ function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
     if (typeof obj.command === 'string') agent.command = obj.command;
     if (obj.router === true) agent.router = true;
     if (obj.review_only === true) agent.review_only = true;
+    if (obj.synthesizer_only === true) agent.synthesizer_only = true;
+    if (agent.review_only && agent.synthesizer_only) {
+      throw new ConfigValidationError(
+        `agents[${i}]: review_only and synthesizer_only cannot both be true`,
+      );
+    }
     if (typeof obj.github_token === 'string') agent.github_token = obj.github_token;
     if (typeof obj.codebase_dir === 'string') agent.codebase_dir = obj.codebase_dir;
     const repoConfig = parseRepoConfig(obj, i);
     if (repoConfig) agent.repos = repoConfig;
+    const synthesizeRepoConfig = parseRepoConfig(obj, i, 'synthesize_repos');
+    if (synthesizeRepoConfig) agent.synthesize_repos = synthesizeRepoConfig;
     agents.push(agent);
   }
   return agents;
@@ -219,6 +234,7 @@ export function loadConfig(): CliConfig {
     maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
     maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
     githubToken: null,
+    githubUsername: null,
     codebaseDir: null,
     agentCommand: null,
     agents: null,
@@ -252,6 +268,7 @@ export function loadConfig(): CliConfig {
         ? data.max_consecutive_errors
         : DEFAULT_MAX_CONSECUTIVE_ERRORS),
     githubToken: typeof data.github_token === 'string' ? data.github_token : null,
+    githubUsername: typeof data.github_username === 'string' ? data.github_username : null,
     codebaseDir: typeof data.codebase_dir === 'string' ? data.codebase_dir : null,
     agentCommand: typeof data.agent_command === 'string' ? data.agent_command : null,
     agents: parseAgents(data),
@@ -265,6 +282,9 @@ export function saveConfig(config: CliConfig): void {
   };
   if (config.githubToken) {
     data.github_token = config.githubToken;
+  }
+  if (config.githubUsername) {
+    data.github_username = config.githubUsername;
   }
   if (config.codebaseDir) {
     data.codebase_dir = config.codebaseDir;
@@ -308,4 +328,28 @@ export function resolveCodebaseDir(
     return path.join(os.homedir(), raw.slice(1));
   }
   return path.resolve(raw);
+}
+
+/**
+ * Resolve GitHub username from a token by calling the GitHub API.
+ * Returns null if the token is missing or the API call fails.
+ */
+export async function resolveGithubUsername(
+  githubToken: string | null,
+  fetchFn: typeof fetch = fetch,
+): Promise<string | null> {
+  if (!githubToken) return null;
+  try {
+    const response = await fetchFn('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as { login?: string };
+    return typeof data.login === 'string' ? data.login : null;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Closes #328

## Summary
- Add `synthesizer_only` and `synthesize_repos` fields to `LocalAgentConfig` for role-based agent configuration
- Add `github_username` to `CliConfig`, resolved from GitHub token via `GET /user` API at startup
- Validate that `review_only` and `synthesizer_only` cannot both be true (throws `ConfigValidationError`)
- Send `roles`, `synthesize_repos`, and `github_username` in poll requests
- Send `github_username` in claim requests
- Add `computeRoles()` helper to derive agent roles from config flags
- Reuse `parseRepoConfig()` for `synthesize_repos` parsing via new `field` parameter

## Test plan
- [x] `synthesizer_only: true` config field parses correctly
- [x] `synthesize_repos` config field parses using same logic as `repos`
- [x] `review_only + synthesizer_only` throws ConfigValidationError
- [x] `github_username` parsed from config and resolved from token
- [x] `resolveGithubUsername` handles success, error, network failure, missing login
- [x] Poll request includes `roles`, `synthesize_repos`, and `github_username`
- [x] Claim request includes `github_username`
- [x] `computeRoles()` returns correct roles for each config combination
- [x] All existing tests pass unchanged
- [x] `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` all pass