### PR TITLE
fix: inject prod KV namespace ID in CI deploy

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -50,6 +50,13 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - name: Inject infrastructure IDs
+        run: sed -i "s/REPLACE_WITH_KV_NAMESPACE_ID/${{ secrets.CF_PROD_KV_ID }}/" packages/server/wrangler.toml
+      - name: Run D1 migrations
+        run: pnpm exec wrangler d1 migrations apply opencara-db --remote
+        working-directory: packages/server
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       - name: Deploy prod worker
         run: pnpm exec wrangler deploy
         working-directory: packages/server


### PR DESCRIPTION
## Summary
- Add `sed` injection step to replace `REPLACE_WITH_KV_NAMESPACE_ID` placeholder with `CF_PROD_KV_ID` secret (matching the pattern in `deploy-dev.yml`)
- Add pre-deploy D1 migration step for prod

The `deploy-prod` job in `publish-cli.yml` was deploying with the raw placeholder, causing Cloudflare API error 10042: `KV namespace 'REPLACE_WITH_KV_NAMESPACE_ID' is not valid.`

## Test plan
- [ ] Next `v*.*.*` tag push triggers the workflow and prod deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)