### PR TITLE
[server-dev] Fix CLAIM_CONFLICT spam: filter already-claimed summary tasks in poll

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -96,6 +96,74 @@ describe('Task Routes', () => {
       expect(body.tasks).toHaveLength(0);
     });
 
+    it('skips summary tasks where agent has a pending summary claim', async () => {
+      // Simulate claim-release cycle: task back in summary queue, agent already has a claim
+      await store.createTask(makeTask({ queue: 'summary' }));
+      await store.createClaim({
+        id: 'task-1:agent-1:summary',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('skips summary tasks where agent has a completed summary claim', async () => {
+      await store.createTask(makeTask({ queue: 'summary' }));
+      await store.createClaim({
+        id: 'task-1:agent-1:summary',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'completed',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('returns summary tasks where agent has an error summary claim', async () => {
+      // Agents with terminal error claims should be able to re-claim
+      await store.createTask(makeTask({ queue: 'summary' }));
+      await store.createClaim({
+        id: 'task-1:agent-1:summary',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'error',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('summary');
+    });
+
+    it('returns summary tasks where agent has a rejected summary claim', async () => {
+      await store.createTask(makeTask({ queue: 'summary' }));
+      await store.createClaim({
+        id: 'task-1:agent-1:summary',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'rejected',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].role).toBe('summary');
+    });
+
     it('does not return timed-out tasks', async () => {
       await store.createTask(makeTask({ timeout_at: Date.now() - 1000 }));
       const res = await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -347,6 +347,16 @@ export function taskRoutes() {
           if (!isRepoAllowed(synthesize_repos, task.owner, task.repo)) continue;
         }
 
+        // Check if agent already has a summary claim on this task
+        const existingSummaryClaim = await store.getClaim(`${task.id}:${agent_id}:summary`);
+        if (
+          existingSummaryClaim &&
+          existingSummaryClaim.status !== 'rejected' &&
+          existingSummaryClaim.status !== 'error'
+        ) {
+          continue;
+        }
+
         available.push({
           task_id: task.id,
           owner: task.owner,


### PR DESCRIPTION
Part of #367

## Summary
- Add summary-claim dedup check in poll endpoint, mirroring the existing review-claim check
- Agents with pending/completed summary claims no longer see the task in poll results
- Agents with error/rejected claims can still retry (allowing re-claim after failures)
- Prevents CLAIM_CONFLICT 409 spam in claim-release cycles

## Test plan
- [x] Agent with pending summary claim does not see task in poll
- [x] Agent with completed summary claim does not see task in poll
- [x] Agent with error summary claim still sees task in poll
- [x] Agent with rejected summary claim still sees task in poll
- [x] All 1118 existing tests pass
- [x] Build, lint, typecheck, format all pass