### PR TITLE
[server-dev] Fix late review results overwriting summary queue state

### DIFF
--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -991,4 +991,139 @@ describe('E2E Scenarios', () => {
       expect(commentBody).not.toContain('stale-tool');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════
+  // Late Review Results (Issue #370)
+  // ═══════════════════════════════════════════════════════════
+
+  describe('Late Review Results', () => {
+    it('late review after queue=summary does not overwrite queue back to summary', async () => {
+      // Setup: reviewCount=3 → 2 review slots
+      const taskId = await injectPR({ reviewCount: 3 });
+      const r1 = agent('reviewer-1');
+      const r2 = agent('reviewer-2');
+      const r3 = agent('late-reviewer');
+
+      // Both reviewers claim
+      await r1.claim(taskId, 'review');
+      await r2.claim(taskId, 'review');
+
+      // r1 submits — 1 of 2 done, still in review queue
+      await r1.submitResult(taskId, 'review', 'Review 1', 'approve', 500);
+      let task = await store.getTask(taskId);
+      expect(task?.queue).toBe('review');
+
+      // r2 submits — 2 of 2 done, queue transitions to summary
+      await r2.submitResult(taskId, 'review', 'Review 2', 'approve', 600);
+      task = await store.getTask(taskId);
+      expect(task?.queue).toBe('summary');
+      const originalCompletedAt = task?.reviews_completed_at;
+      expect(originalCompletedAt).toBeDefined();
+
+      // Simulate late reviewer: manually create a claim and submit result
+      // (in practice this happens when a claim was created before slots filled,
+      // but result arrives after queue already moved to summary)
+      await store.createClaim({
+        id: `${taskId}:late-reviewer:review`,
+        task_id: taskId,
+        agent_id: 'late-reviewer',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // Late review submits — queue should NOT change from summary
+      await r3.submitResult(taskId, 'review', 'Late review', 'approve', 400);
+      task = await store.getTask(taskId);
+      expect(task?.queue).toBe('summary');
+      // reviews_completed_at should not have been reset
+      expect(task?.reviews_completed_at).toBe(originalCompletedAt);
+    });
+
+    it('late review after queue=finished does not overwrite queue', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const r1 = agent('reviewer-1');
+      const r2 = agent('reviewer-2');
+      const r3 = agent('late-reviewer');
+      const synth = agent('synthesizer');
+
+      // Both reviewers claim and submit
+      await r1.claim(taskId, 'review');
+      await r2.claim(taskId, 'review');
+      await r1.submitResult(taskId, 'review', 'Review 1', 'approve', 500);
+      await r2.submitResult(taskId, 'review', 'Review 2', 'approve', 600);
+
+      // Synthesizer claims — queue moves to 'finished'
+      await synth.claim(taskId, 'summary');
+      let task = await store.getTask(taskId);
+      expect(task?.queue).toBe('finished');
+
+      // Simulate late review claim
+      await store.createClaim({
+        id: `${taskId}:late-reviewer:review`,
+        task_id: taskId,
+        agent_id: 'late-reviewer',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // Late review submits — queue should stay 'finished'
+      await r3.submitResult(taskId, 'review', 'Late review', 'approve', 400);
+      task = await store.getTask(taskId);
+      expect(task?.queue).toBe('finished');
+    });
+
+    it('completed_reviews increments correctly even with late reviews', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const r1 = agent('reviewer-1');
+      const r2 = agent('reviewer-2');
+      const r3 = agent('late-reviewer');
+
+      await r1.claim(taskId, 'review');
+      await r2.claim(taskId, 'review');
+      await r1.submitResult(taskId, 'review', 'Review 1', 'approve', 500);
+      await r2.submitResult(taskId, 'review', 'Review 2', 'approve', 600);
+
+      let task = await store.getTask(taskId);
+      expect(task?.completed_reviews).toBe(2);
+
+      // Simulate late review claim
+      await store.createClaim({
+        id: `${taskId}:late-reviewer:review`,
+        task_id: taskId,
+        agent_id: 'late-reviewer',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      await r3.submitResult(taskId, 'review', 'Late review', 'approve', 400);
+      task = await store.getTask(taskId);
+      // Count should be 3 (incremented, but queue not changed)
+      expect(task?.completed_reviews).toBe(3);
+      expect(task?.queue).toBe('summary');
+    });
+
+    it('queue transitions to summary only once on the review that crosses threshold', async () => {
+      const taskId = await injectPR({ reviewCount: 3 });
+      const r1 = agent('reviewer-1');
+      const r2 = agent('reviewer-2');
+
+      await r1.claim(taskId, 'review');
+      await r2.claim(taskId, 'review');
+
+      // First review: 1 of 2 — should not transition
+      await r1.submitResult(taskId, 'review', 'Review 1', 'approve', 500);
+      let task = await store.getTask(taskId);
+      expect(task?.queue).toBe('review');
+      expect(task?.reviews_completed_at).toBeUndefined();
+
+      // Second review: 2 of 2 — should transition exactly once
+      await r2.submitResult(taskId, 'review', 'Review 2', 'approve', 600);
+      task = await store.getTask(taskId);
+      expect(task?.queue).toBe('summary');
+      expect(task?.reviews_completed_at).toBeDefined();
+    });
+  });
 });

--- a/packages/server/src/__tests__/store-d1.test.ts
+++ b/packages/server/src/__tests__/store-d1.test.ts
@@ -799,6 +799,35 @@ describe('D1DataStore', () => {
     });
   });
 
+  // ── Completed reviews (atomic increment) ────────────────
+
+  describe('incrementCompletedReviews', () => {
+    it('increments completed_reviews and returns new count and queue', async () => {
+      await store.createTask(makeTask({ completed_reviews: 0, queue: 'review' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 1, queue: 'review' });
+      const task = await store.getTask('task-1');
+      expect(task?.completed_reviews).toBe(1);
+    });
+
+    it('returns null for nonexistent task', async () => {
+      const result = await store.incrementCompletedReviews('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('increments from existing count', async () => {
+      await store.createTask(makeTask({ completed_reviews: 2, queue: 'summary' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 3, queue: 'summary' });
+    });
+
+    it('returns current queue state (not just review)', async () => {
+      await store.createTask(makeTask({ completed_reviews: 1, queue: 'finished' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 2, queue: 'finished' });
+    });
+  });
+
   // ── Review slot (atomic conditional increment) ──────────
 
   describe('claimReviewSlot', () => {

--- a/packages/server/src/__tests__/store-memory.test.ts
+++ b/packages/server/src/__tests__/store-memory.test.ts
@@ -233,6 +233,35 @@ describe('MemoryDataStore', () => {
     });
   });
 
+  // ── Completed reviews (atomic increment) ────────────────
+
+  describe('incrementCompletedReviews', () => {
+    it('increments completed_reviews and returns new count and queue', async () => {
+      await store.createTask(makeTask({ completed_reviews: 0, queue: 'review' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 1, queue: 'review' });
+      const task = await store.getTask('task-1');
+      expect(task?.completed_reviews).toBe(1);
+    });
+
+    it('returns null for nonexistent task', async () => {
+      const result = await store.incrementCompletedReviews('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('increments from existing count', async () => {
+      await store.createTask(makeTask({ completed_reviews: 2, queue: 'summary' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 3, queue: 'summary' });
+    });
+
+    it('increments from undefined completed_reviews', async () => {
+      await store.createTask(makeTask({ completed_reviews: undefined, queue: 'review' }));
+      const result = await store.incrementCompletedReviews('task-1');
+      expect(result).toEqual({ newCount: 1, queue: 'review' });
+    });
+  });
+
   // ── Review slot (atomic increment) ──────────────────────
 
   describe('claimReviewSlot', () => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -619,21 +619,25 @@ export function taskRoutes() {
         logger,
       );
     } else {
-      // Review submitted — increment completed_reviews counter on task
-      const newCompleted = (task.completed_reviews ?? 0) + 1;
-      const taskUpdates: Partial<ReviewTask> = { completed_reviews: newCompleted };
-
-      const reviewSlots = task.review_count > 1 ? task.review_count - 1 : 0;
-      if (reviewSlots > 0 && newCompleted >= reviewSlots) {
-        // All reviews done — move task to summary queue
-        taskUpdates.queue = 'summary';
-        taskUpdates.reviews_completed_at = Date.now();
-        logger.info('All reviews complete, task moved to summary queue', {
-          taskId,
-          reviewSlots,
-        });
+      // Review submitted — atomically increment completed_reviews counter
+      const result = await store.incrementCompletedReviews(taskId);
+      if (result) {
+        const { newCount, queue } = result;
+        const reviewSlots = task.review_count > 1 ? task.review_count - 1 : 0;
+        if (reviewSlots > 0 && newCount >= reviewSlots && queue === 'review') {
+          // All reviews done — move task to summary queue
+          // Guard: only transition if queue is still 'review' to prevent
+          // late review results from overwriting 'summary' or 'finished' state
+          await store.updateTask(taskId, {
+            queue: 'summary',
+            reviews_completed_at: Date.now(),
+          });
+          logger.info('All reviews complete, task moved to summary queue', {
+            taskId,
+            reviewSlots,
+          });
+        }
       }
-      await store.updateTask(taskId, taskUpdates);
     }
 
     return c.json<ResultResponse>({ success: true });

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -371,6 +371,23 @@ export class D1DataStore implements DataStore {
       .run();
   }
 
+  // ── Completed reviews (atomic increment) ────────────────────
+
+  async incrementCompletedReviews(
+    taskId: string,
+  ): Promise<{ newCount: number; queue: string } | null> {
+    await this.db
+      .prepare(`UPDATE tasks SET completed_reviews = completed_reviews + 1 WHERE id = ?`)
+      .bind(taskId)
+      .run();
+    const row = await this.db
+      .prepare('SELECT completed_reviews, queue FROM tasks WHERE id = ?')
+      .bind(taskId)
+      .first<{ completed_reviews: number; queue: string }>();
+    if (!row) return null;
+    return { newCount: row.completed_reviews, queue: row.queue };
+  }
+
   // ── Review slot (atomic conditional increment) ──────────────
 
   async claimReviewSlot(taskId: string, maxSlots: number): Promise<boolean> {

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -21,6 +21,10 @@ export interface DataStore {
   getClaims(taskId: string): Promise<TaskClaim[]>;
   updateClaim(claimId: string, updates: Partial<TaskClaim>): Promise<void>;
 
+  // Completed reviews — atomic increment (prevents lost increments under concurrency)
+  /** Atomically increment completed_reviews and return the new count plus the current queue state. */
+  incrementCompletedReviews(taskId: string): Promise<{ newCount: number; queue: string } | null>;
+
   // Review slot — atomic increment-if-below (prevents oversubscription)
   /** Atomically increment review_claims if review_claims < maxSlots (exclusive). Returns true if a slot was reserved. */
   claimReviewSlot(taskId: string, maxSlots: number): Promise<boolean>;

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -117,6 +117,17 @@ export class MemoryDataStore implements DataStore {
     }
   }
 
+  // Completed reviews — atomic increment
+
+  async incrementCompletedReviews(
+    taskId: string,
+  ): Promise<{ newCount: number; queue: string } | null> {
+    const task = this.tasks.get(taskId);
+    if (!task) return null;
+    task.completed_reviews = (task.completed_reviews ?? 0) + 1;
+    return { newCount: task.completed_reviews, queue: task.queue };
+  }
+
   // Review slot — atomic check-and-increment
 
   async claimReviewSlot(taskId: string, maxSlots: number): Promise<boolean> {


### PR DESCRIPTION
Part of #370

## Summary
- Guard queue transition: only set `queue = 'summary'` when current queue is `'review'`, preventing late review results from overwriting `'summary'` or `'finished'` state
- Add atomic `incrementCompletedReviews()` method to DataStore interface, D1DataStore, and MemoryDataStore — replaces the non-atomic read-increment-write pattern
- Use returned queue state from the atomic increment to decide transition, avoiding the race where concurrent review submissions read the same stale state

## Test plan
- E2E test: late review after queue='summary' does not overwrite queue
- E2E test: late review after queue='finished' does not overwrite queue
- E2E test: completed_reviews increments correctly even with late reviews
- E2E test: queue transitions to summary only once on crossing threshold
- Unit tests for incrementCompletedReviews in both MemoryDataStore and D1DataStore
- All 1130 existing tests pass