### PR TITLE
[cli-dev] Display contributor GitHub profile link in review report

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -107,6 +107,7 @@ describe('Agent Coverage Tests', () => {
       repoConfig?: import('@opencara/shared').RepoConfig;
       githubToken?: string;
       codebaseDir?: string;
+      githubUsername?: string;
     },
   ): Promise<void> {
     const deps = makeDeps(agentId);
@@ -123,7 +124,12 @@ describe('Agent Coverage Tests', () => {
       { model: 'test-model', tool: 'test-tool' },
       reviewDeps,
       deps.consumptionDeps,
-      { pollIntervalMs: 100, reviewOnly: opts?.reviewOnly, repoConfig: opts?.repoConfig },
+      {
+        pollIntervalMs: 100,
+        reviewOnly: opts?.reviewOnly,
+        repoConfig: opts?.repoConfig,
+        githubUsername: opts?.githubUsername,
+      },
     );
   }
 
@@ -1162,6 +1168,76 @@ describe('Agent Coverage Tests', () => {
         await stopAgent(promise, server);
       } finally {
         globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Contributor attribution in review submissions
+  // ═══════════════════════════════════════════════════════════
+
+  describe('Contributor attribution', () => {
+    it('appends attribution to review text when githubUsername is configured', async () => {
+      const taskId = await server.injectTask({ reviewCount: 1 });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const savedFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return savedFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('attrib-agent', { githubUsername: 'octocat' });
+        await advanceTime(2000);
+
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.review_text).toContain(
+          '---\nContributed by [@octocat](https://github.com/octocat)',
+        );
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+
+    it('does not append attribution when githubUsername is not configured', async () => {
+      const taskId = await server.injectTask({ reviewCount: 1 });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const savedFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return savedFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('no-attrib-agent');
+        await advanceTime(2000);
+
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.review_text).not.toContain('Contributed by');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = savedFetch;
       }
     });
   });

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { startAgent, computeRoles, type ConsumptionDeps } from '../commands/agent.js';
+import {
+  startAgent,
+  computeRoles,
+  appendContributorAttribution,
+  type ConsumptionDeps,
+} from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
 import type { RouterRelay } from '../router.js';
 import { createSessionTracker } from '../consumption.js';
@@ -999,5 +1004,27 @@ describe('computeRoles', () => {
   it('returns ["review", "summary"] for agent with neither flag', () => {
     const agent: LocalAgentConfig = { model: 'claude-opus-4-6', tool: 'claude' };
     expect(computeRoles(agent)).toEqual(['review', 'summary']);
+  });
+});
+
+describe('appendContributorAttribution', () => {
+  it('appends GitHub profile link when username is provided', () => {
+    const text = 'Review looks good.';
+    const result = appendContributorAttribution(text, 'octocat');
+    expect(result).toBe(
+      'Review looks good.\n\n---\nContributed by [@octocat](https://github.com/octocat)',
+    );
+  });
+
+  it('returns text unchanged when username is undefined', () => {
+    const text = 'Review looks good.';
+    const result = appendContributorAttribution(text, undefined);
+    expect(result).toBe('Review looks good.');
+  });
+
+  it('returns text unchanged when username is empty string', () => {
+    const text = 'Review looks good.';
+    const result = appendContributorAttribution(text, '');
+    expect(result).toBe('Review looks good.');
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -135,6 +135,15 @@ async function fetchDiff(
 const MAX_DIFF_FETCH_ATTEMPTS = 3;
 
 /**
+ * Append contributor attribution to review/summary text when github_username is configured.
+ * Anonymous agents (no github_username) return text unchanged.
+ */
+export function appendContributorAttribution(text: string, githubUsername?: string): string {
+  if (!githubUsername) return text;
+  return `${text}\n\n---\nContributed by [@${githubUsername}](https://github.com/${githubUsername})`;
+}
+
+/**
  * Poll → Claim → Review → Submit loop for a single agent.
  */
 async function pollLoop(
@@ -427,6 +436,7 @@ async function handleTask(
         routerRelay,
         signal,
         contextBlock,
+        githubUsername,
       );
     } else {
       await executeReviewTask(
@@ -445,6 +455,7 @@ async function handleTask(
         routerRelay,
         signal,
         contextBlock,
+        githubUsername,
       );
     }
     agentSession.tasksCompleted++;
@@ -534,6 +545,7 @@ async function executeReviewTask(
   routerRelay?: RouterRelay,
   signal?: AbortSignal,
   contextBlock?: string,
+  githubUsername?: string,
 ): Promise<void> {
   let reviewText: string;
   let verdict: ReviewVerdict;
@@ -583,7 +595,7 @@ async function executeReviewTask(
   }
 
   // Sanitize review text before submission to prevent token leakage
-  const sanitizedReview = sanitizeTokens(reviewText);
+  const sanitizedReview = appendContributorAttribution(sanitizeTokens(reviewText), githubUsername);
 
   // Submit result — retry up to 3 times (highest-risk operation)
   await withRetry(
@@ -621,6 +633,7 @@ async function executeSummaryTask(
   routerRelay?: RouterRelay,
   signal?: AbortSignal,
   contextBlock?: string,
+  githubUsername?: string,
 ): Promise<void> {
   if (reviews.length === 0) {
     // Single-agent mode (review_count=1): this IS the review, run it as a regular
@@ -670,7 +683,10 @@ async function executeSummaryTask(
       tokensUsed = result.tokensUsed;
     }
 
-    const sanitizedReview = sanitizeTokens(reviewText);
+    const sanitizedReview = appendContributorAttribution(
+      sanitizeTokens(reviewText),
+      githubUsername,
+    );
 
     await withRetry(
       () =>
@@ -742,7 +758,10 @@ async function executeSummaryTask(
     tokensUsed = result.tokensUsed;
   }
 
-  const sanitizedSummary = sanitizeTokens(summaryText);
+  const sanitizedSummary = appendContributorAttribution(
+    sanitizeTokens(summaryText),
+    githubUsername,
+  );
 
   // Submit result — retry up to 3 times (highest-risk operation)
   await withRetry(


### PR DESCRIPTION
Part of #368

## Summary
- Added `appendContributorAttribution()` helper that appends `[@username](https://github.com/username)` to review text when `github_username` is configured
- Applied attribution in `executeReviewTask` and `executeSummaryTask` (both single-agent and multi-agent summary paths)
- Anonymous agents (no `github_username`) submit review text unchanged

## Test plan
- Unit tests for `appendContributorAttribution` (with username, without username, empty string)
- Integration tests in `agent-coverage.test.ts` verifying attribution flows through the full review submission pipeline
- Verified no attribution appended when `githubUsername` is not configured
- All 1135 tests pass, lint/format/typecheck clean