### PR TITLE
[server-dev] Remove server-side review formatting, post CLI text as-is

### DIFF
--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests covering server source gaps:
- * - review-formatter.ts: formatSummaryComment edge cases
+ * - review-formatter.ts: formatTimeoutComment edge cases
  * - github/config.ts: loadReviewConfig error paths
  * - github/reviews.ts: postPrComment error path
  * - index.ts: error handler and 404
@@ -19,60 +19,13 @@ afterEach(() => {
 // ── review-formatter.ts ──────────────────────────────────────
 
 describe('review-formatter edge cases', () => {
-  it('formatSummaryComment with no agents and no synthesizer', async () => {
-    const { formatSummaryComment } = await import('../review-formatter.js');
-    const result = formatSummaryComment('My summary text', [], null);
-    expect(result).toContain('My summary text');
-    expect(result).toContain('OpenCara Review');
-    // No agents line when both are empty
-    expect(result).not.toContain('**Agents**');
-  });
-
-  it('formatSummaryComment with agents and synthesizer', async () => {
-    const { formatSummaryComment } = await import('../review-formatter.js');
-    const result = formatSummaryComment(
-      'Summary',
-      [
-        { model: 'claude', tool: 'claude-cli' },
-        { model: 'gpt-4', tool: 'codex', displayName: 'My Agent' },
-      ],
-      { model: 'claude', tool: 'claude-cli', displayName: 'Synth' },
-    );
-    expect(result).toContain('`claude/claude-cli`');
-    expect(result).toContain('My Agent');
-    expect(result).toContain('synthesized by');
-    expect(result).toContain('Synth');
-  });
-
-  it('formatSummaryComment with synthesizer only (no review agents)', async () => {
-    const { formatSummaryComment } = await import('../review-formatter.js');
-    const result = formatSummaryComment('Summary', [], {
-      model: 'claude',
-      tool: 'claude-cli',
-    });
-    expect(result).toContain('**Agents**: `claude/claude-cli`');
-  });
-
-  it('formatIndividualReviewComment formats review with emoji', async () => {
-    const { formatIndividualReviewComment } = await import('../review-formatter.js');
-
-    const approve = formatIndividualReviewComment('claude', 'cli', 'approve', 'LGTM');
-    expect(approve).toContain('Agent: `claude` / `cli`');
-    expect(approve).toContain('approve');
-    expect(approve).toContain('LGTM');
-
-    const changes = formatIndividualReviewComment('gpt', 'codex', 'request_changes', 'Fix bugs');
-    expect(changes).toContain('request_changes');
-
-    const comment = formatIndividualReviewComment('gemini', 'tool', 'comment', 'Looks ok');
-    expect(comment).toContain('comment');
-  });
-
   it('formatTimeoutComment with no reviews returns simple timeout message', async () => {
     const { formatTimeoutComment } = await import('../review-formatter.js');
     const result = formatTimeoutComment(10, []);
-    expect(result).toBe('**OpenCara**: Review timed out after 10 minutes.');
+    expect(result).toContain('## OpenCara Review');
+    expect(result).toContain('> Review timed out after 10 minutes.');
     expect(result).not.toContain('partial review');
+    expect(result).toContain('<sub>Reviewed by');
   });
 
   it('formatTimeoutComment with reviews returns consolidated comment', async () => {
@@ -81,16 +34,19 @@ describe('review-formatter edge cases', () => {
       { model: 'claude', tool: 'cli', verdict: 'approve', review_text: 'LGTM' },
       { model: 'gemini', tool: 'codex', verdict: 'request_changes', review_text: 'Fix bugs' },
     ]);
+    expect(result).toContain('## OpenCara Review');
     expect(result).toContain('timed out after 10 minutes');
     expect(result).toContain('2 partial review(s) collected');
     expect(result).toContain('Review 1');
+    expect(result).toContain('`claude/cli`');
     expect(result).toContain('approve');
     expect(result).toContain('LGTM');
     expect(result).toContain('Review 2');
+    expect(result).toContain('`gemini/codex`');
     expect(result).toContain('request_changes');
     expect(result).toContain('Fix bugs');
-    // Verify sections are separated by horizontal rules
     expect(result).toContain('---');
+    expect(result).toContain('<sub>Reviewed by');
   });
 
   it('formatTimeoutComment with single review', async () => {
@@ -98,9 +54,12 @@ describe('review-formatter edge cases', () => {
     const result = formatTimeoutComment(5, [
       { model: 'gpt', tool: 'tool', verdict: 'comment', review_text: 'Minor suggestions' },
     ]);
+    expect(result).toContain('## OpenCara Review');
     expect(result).toContain('1 partial review(s) collected');
     expect(result).toContain('Review 1');
+    expect(result).toContain('`gpt/tool`');
     expect(result).toContain('Minor suggestions');
+    expect(result).toContain('<sub>Reviewed by');
   });
 });
 

--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -939,56 +939,23 @@ describe('E2E Scenarios', () => {
       expect(commentBody).toContain('This should still be posted.');
     });
 
-    it('review uses model/tool from directly passed summary data, not stale KV', async () => {
-      // Use multi-agent mode so synthesizer model/tool appears in the comment
-      const taskId = await injectPR({ reviewCount: 2 });
-      const reviewer = agent('reviewer-agent');
-      const synth = agent('model-agent');
+    it('server posts review_text as-is without re-formatting', async () => {
+      const taskId = await injectPR();
+      const a = agent('passthrough-agent');
 
-      // Reviewer claims and completes the review
-      await reviewer.claim(taskId, 'review', { model: 'gpt-4', tool: 'other-cli' });
-      await reviewer.submitResult(taskId, 'review', 'LGTM', 'approve', 300);
+      await a.claim(taskId, 'summary');
 
-      // Synthesizer claims with correct model and tool
-      await synth.claim(taskId, 'summary', { model: 'claude-3', tool: 'opencara-cli' });
-
-      // Intercept getClaim to return stale data on the SECOND call (postFinalReview's
-      // observability check), not the first call (result handler's claim lookup)
-      const originalGetClaim = store.getClaim.bind(store);
-      let callCount = 0;
-      vi.spyOn(store, 'getClaim').mockImplementation(async (claimId: string) => {
-        const claim = await originalGetClaim(claimId);
-        if (claim && claimId === `${taskId}:model-agent:summary`) {
-          callCount++;
-          if (callCount > 1) {
-            // Second call (postFinalReview observability) — return stale data
-            return { ...claim, review_text: undefined, model: 'stale-model', tool: 'stale-tool' };
-          }
-        }
-        return claim;
-      });
-
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      // Submit result
-      const result = await synth.submitResult(
-        taskId,
-        'summary',
-        '## Summary\nModel test.',
-        'approve',
-        500,
-      );
+      // CLI pre-formats the review_text with header/footer
+      const preformatted =
+        '## OpenCara Review\n\n**Reviewer**: `claude-3/opencara-cli`\n**Verdict**: approve\n\n---\nLooks good.\n---\n<sub>Reviewed by OpenCara</sub>';
+      const result = await a.submitResult(taskId, 'summary', preformatted, 'approve', 500);
       expect(result.status).toBe(200);
 
-      // GitHub comment should use the model/tool from the claim (set at claim time),
-      // not the stale KV re-read
+      // Server should post the exact pre-formatted text without modification
       const commentPost = github.calls.find((c) => c.method === 'postPrComment');
       expect(commentPost).toBeDefined();
       const commentBody = commentPost!.args.body as string;
-      // Should contain correct model/tool (formatted as `model/tool`) and NOT stale ones
-      expect(commentBody).toContain('claude-3/opencara-cli');
-      expect(commentBody).not.toContain('stale-model');
-      expect(commentBody).not.toContain('stale-tool');
+      expect(commentBody).toBe(preformatted);
     });
   });
 

--- a/packages/server/src/review-formatter.ts
+++ b/packages/server/src/review-formatter.ts
@@ -1,76 +1,10 @@
 import type { ReviewVerdict } from '@opencara/shared';
 
-/** Agent info displayed in review headers */
-export interface ReviewAgentInfo {
-  model: string;
-  tool: string;
-  displayName?: string;
-}
-
 const VERDICT_EMOJI: Record<ReviewVerdict, string> = {
   approve: '\u2705',
   request_changes: '\u274C',
   comment: '\uD83D\uDCAC',
 };
-
-/** Escape markdown special characters to prevent injection. */
-function escapeMarkdown(text: string): string {
-  return text.replace(/[\\`*_{}[\]()#+\-.!|~>]/g, '\\$&');
-}
-
-/** Format a single agent as `model/tool`, prefixed with displayName if set. */
-function formatAgentLabel(agent: ReviewAgentInfo): string {
-  const base = `\`${agent.model}/${agent.tool}\``;
-  return agent.displayName ? `${escapeMarkdown(agent.displayName)} (${base})` : base;
-}
-
-/**
- * Format the summary as the main PR comment.
- */
-export function formatSummaryComment(
-  summary: string,
-  agents: ReviewAgentInfo[],
-  synthesizerAgent: ReviewAgentInfo | null,
-): string {
-  const agentLabels = agents.map(formatAgentLabel);
-  const synthLabel = synthesizerAgent ? formatAgentLabel(synthesizerAgent) : null;
-  const agentsLine =
-    agentLabels.length > 0
-      ? `**Agents**: ${agentLabels.join(', ')}${synthLabel ? ` (synthesized by ${synthLabel})` : ''}`
-      : synthLabel
-        ? `**Agents**: ${synthLabel}`
-        : '';
-  return [
-    '## \uD83D\uDD0D OpenCara Review',
-    '',
-    ...(agentsLine ? [agentsLine] : []),
-    '',
-    '---',
-    '',
-    summary,
-    '',
-    '---',
-    '<sub>Reviewed by <a href="https://github.com/apps/opencara">OpenCara</a></sub>',
-  ].join('\n');
-}
-
-/**
- * Format an individual review as a follow-up comment.
- */
-export function formatIndividualReviewComment(
-  model: string,
-  tool: string,
-  verdict: ReviewVerdict,
-  review: string,
-): string {
-  const emoji = VERDICT_EMOJI[verdict];
-  return [
-    `### Agent: \`${model}\` / \`${tool}\``,
-    `**Verdict**: ${emoji} ${verdict}`,
-    '',
-    review,
-  ].join('\n');
-}
 
 /** A partial review collected before timeout. */
 export interface TimeoutReview {
@@ -83,24 +17,34 @@ export interface TimeoutReview {
 /**
  * Format a consolidated timeout comment containing all partial reviews
  * and the timeout message in a single GitHub comment.
+ *
+ * This is the only server-side formatter — normal reviews are pre-formatted
+ * by the CLI and posted as-is.
  */
 export function formatTimeoutComment(timeoutMinutes: number, reviews: TimeoutReview[]): string {
+  const parts: string[] = ['## OpenCara Review', ''];
+
   if (reviews.length === 0) {
-    return `**OpenCara**: Review timed out after ${timeoutMinutes} minutes.`;
+    parts.push(`> Review timed out after ${timeoutMinutes} minutes.`);
+  } else {
+    parts.push(
+      `> Review timed out after ${timeoutMinutes} minutes. ${reviews.length} partial review(s) collected.`,
+    );
+
+    for (let i = 0; i < reviews.length; i++) {
+      const r = reviews[i];
+      const emoji = VERDICT_EMOJI[r.verdict];
+      parts.push('');
+      parts.push('---');
+      parts.push(`### Review ${i + 1} — ${emoji} ${r.verdict} (\`${r.model}/${r.tool}\`)`);
+      parts.push('');
+      parts.push(r.review_text);
+    }
   }
 
-  const parts: string[] = [
-    `**OpenCara**: Review timed out after ${timeoutMinutes} minutes. ${reviews.length} partial review(s) collected:`,
-  ];
-
-  for (let i = 0; i < reviews.length; i++) {
-    const r = reviews[i];
-    const emoji = VERDICT_EMOJI[r.verdict];
-    parts.push('---');
-    parts.push(`### Review ${i + 1} — ${emoji} ${r.verdict} (${r.model} / ${r.tool})`);
-    parts.push('');
-    parts.push(r.review_text);
-  }
+  parts.push('');
+  parts.push('---');
+  parts.push('<sub>Reviewed by <a href="https://github.com/apps/opencara">OpenCara</a></sub>');
 
   return parts.join('\n');
 }

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -13,12 +13,7 @@ import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
 import type { Logger } from '../logger.js';
 import { createLogger } from '../logger.js';
-import {
-  formatSummaryComment,
-  formatTimeoutComment,
-  type ReviewAgentInfo,
-  type TimeoutReview,
-} from '../review-formatter.js';
+import { formatTimeoutComment, type TimeoutReview } from '../review-formatter.js';
 import { isAgentEligibleForRole } from '../eligibility.js';
 import { rateLimitByAgent } from '../middleware/rate-limit.js';
 import { requireApiKey } from '../middleware/auth.js';
@@ -197,8 +192,6 @@ export async function checkTimeouts(
 /** Data passed directly from the result endpoint to avoid KV read-after-write staleness. */
 export interface SummaryData {
   review_text: string;
-  model?: string;
-  tool?: string;
 }
 
 /**
@@ -230,33 +223,17 @@ async function postFinalReview(
     return;
   }
 
-  const claims = await store.getClaims(taskId);
-
   try {
     const token = await github.getInstallationToken(task.github_installation_id);
 
-    // Build agent info from claims
-    const reviewClaims = claims.filter((c) => c.role === 'review' && c.status === 'completed');
-    const reviewerAgents: ReviewAgentInfo[] = reviewClaims.map((c) => ({
-      model: c.model ?? 'unknown',
-      tool: c.tool ?? 'unknown',
-    }));
-    const synthAgent: ReviewAgentInfo = {
-      model: summaryData.model ?? 'unknown',
-      tool: summaryData.tool ?? 'unknown',
-    };
-
-    // Format the body — use summaryData.review_text directly (never re-read from KV)
-    let body: string;
-    if (task.review_count === 1) {
-      // Single agent — post directly
-      body = formatSummaryComment(summaryData.review_text, [], null);
-    } else {
-      // Multi-agent — include reviewer info in header
-      body = formatSummaryComment(summaryData.review_text, reviewerAgents, synthAgent);
-    }
-
-    await github.postPrComment(task.owner, task.repo, task.pr_number, body, token);
+    // Post review_text as-is — CLI pre-formats with header/footer
+    await github.postPrComment(
+      task.owner,
+      task.repo,
+      task.pr_number,
+      summaryData.review_text,
+      token,
+    );
 
     await store.deleteTask(taskId);
     logger.info('Review posted to GitHub — task deleted', {
@@ -606,18 +583,7 @@ export function taskRoutes() {
       }
 
       // Summary submitted — post the final review to GitHub
-      await postFinalReview(
-        store,
-        github,
-        taskId,
-        agent_id,
-        {
-          review_text,
-          model: claim.model,
-          tool: claim.tool,
-        },
-        logger,
-      );
+      await postFinalReview(store, github, taskId, agent_id, { review_text }, logger);
     } else {
       // Review submitted — atomically increment completed_reviews counter
       const result = await store.incrementCompletedReviews(taskId);


### PR DESCRIPTION
Part of #378

## Summary
- Removed `formatSummaryComment` and `formatIndividualReviewComment` from server — CLI now pre-formats review text with header/footer before submitting
- Simplified `postFinalReview` to post `review_text` directly without re-formatting
- Updated `formatTimeoutComment` to new consistent format: `## OpenCara Review` title, blockquote timeout message, `model/tool` in backticks, `<sub>` footer
- Removed `SummaryData.model/tool` fields (no longer needed for server-side formatting)
- Net -164 lines of code

## Test plan
- [x] All 1159 existing tests pass
- [x] Updated `formatTimeoutComment` tests verify new format (title, blockquote, footer)
- [x] Removed obsolete `formatSummaryComment` and `formatIndividualReviewComment` tests
- [x] Added e2e test verifying server posts `review_text` as-is (passthrough)
- [x] Build, lint, format, typecheck all pass