### PR TITLE
[architect] Add release script and versioned prod deploys

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -63,10 +63,7 @@ jobs:
         run: |
           OUTPUT="$(pnpm exec wrangler versions upload 2>&1)"
           echo "$OUTPUT"
-          VERSION_ID="$(echo "$OUTPUT" | grep -oP 'Version ID:\s*\K[a-f0-9-]+' || true)"
-          if [ -z "$VERSION_ID" ]; then
-            VERSION_ID="$(echo "$OUTPUT" | grep -oP '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | tail -1 || true)"
-          fi
+          VERSION_ID="$(echo "$OUTPUT" | grep -oP '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | tail -1 || true)"
           if [ -z "$VERSION_ID" ]; then
             echo "ERROR: Failed to extract version ID from wrangler output"
             exit 1
@@ -83,8 +80,8 @@ jobs:
       - name: Verify deployment
         run: |
           sleep 5
-          RESPONSE="$(curl -sf https://opencara-server.opencara.workers.dev/api/meta || true)"
-          if [ -n "$RESPONSE" ]; then
+          RESPONSE="$(curl -sf --max-time 10 https://opencara-server.opencara.workers.dev/api/meta || true)"
+          if echo "$RESPONSE" | grep -q '"server_version"'; then
             echo "Deployment verified: ${RESPONSE}"
           else
             echo "WARNING: Could not verify deployment — check manually"
@@ -92,7 +89,7 @@ jobs:
 
   create-release:
     needs: [publish, deploy-prod]
-    if: ${{ !cancelled() }}
+    if: ${{ needs.deploy-prod.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,6 +26,11 @@ confirm() {
   [[ "$response" =~ ^[Yy]$ ]]
 }
 
+# Cleanup handler to restore wrangler.toml on exit/failure
+cleanup() {
+  git checkout -- "${SERVER_DIR}/wrangler.toml" 2>/dev/null || true
+}
+
 # ── Rollback ─────────────────────────────────────────────────────
 
 if [[ "${1:-}" == "rollback" ]]; then
@@ -72,6 +77,8 @@ info "Pre-flight checks passed."
 
 # ── Inject infrastructure IDs ────────────────────────────────────
 
+trap cleanup EXIT
+
 info "Injecting infrastructure IDs..."
 
 if [[ -z "${CF_PROD_D1_ID:-}" ]]; then
@@ -93,22 +100,14 @@ info "Uploading new version..."
 UPLOAD_OUTPUT="$(cd "$SERVER_DIR" && npx wrangler versions upload 2>&1)"
 echo "$UPLOAD_OUTPUT"
 
-# Extract version ID from wrangler output
-VERSION_ID="$(echo "$UPLOAD_OUTPUT" | grep -oP 'Version ID:\s*\K[a-f0-9-]+' || true)"
-if [[ -z "$VERSION_ID" ]]; then
-  # Try alternative output format
-  VERSION_ID="$(echo "$UPLOAD_OUTPUT" | grep -oP '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | tail -1 || true)"
-fi
+# Extract version ID (UUID) from wrangler output
+VERSION_ID="$(echo "$UPLOAD_OUTPUT" | grep -oP '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | tail -1 || true)"
 
 if [[ -z "$VERSION_ID" ]]; then
   die "Failed to extract version ID from wrangler output. Check output above."
 fi
 
 info "Uploaded version: ${VERSION_ID}"
-
-# ── Restore wrangler.toml (undo sed) ────────────────────────────
-
-git checkout -- "${SERVER_DIR}/wrangler.toml"
 
 # ── Pre-deploy test ──────────────────────────────────────────────
 
@@ -118,12 +117,12 @@ if [[ "$TEST_MODE" == true ]]; then
   echo ""
   echo "Test the new version against prod without deploying:"
   echo ""
-  echo "  curl -H 'Cloudflare-Workers-Version-Overrides: ${WORKER_NAME}=${VERSION_ID}' \\"
+  echo "  curl -H 'Cloudflare-Workers-Version-Overrides: ${WORKER_NAME}=\"${VERSION_ID}\"' \\"
   echo "       ${PROD_URL}/api/meta"
   echo ""
   echo "Run a health check:"
   echo ""
-  echo "  curl -sf -H 'Cloudflare-Workers-Version-Overrides: ${WORKER_NAME}=${VERSION_ID}' \\"
+  echo "  curl -sf -H 'Cloudflare-Workers-Version-Overrides: ${WORKER_NAME}=\"${VERSION_ID}\"' \\"
   echo "       ${PROD_URL}/api/meta | jq ."
   echo ""
 
@@ -141,7 +140,7 @@ info "Deploying version ${VERSION_ID} to 100% traffic..."
 
 # Verify deployment
 info "Verifying deployment..."
-META_RESPONSE="$(curl -sf "${PROD_URL}/api/meta" 2>/dev/null || true)"
+META_RESPONSE="$(curl -sf --max-time 10 "${PROD_URL}/api/meta" 2>/dev/null || true)"
 if [[ -n "$META_RESPONSE" ]]; then
   echo "  /api/meta response: ${META_RESPONSE}"
 else
@@ -163,8 +162,8 @@ info "Creating git tag v${VERSION}..."
 git tag "v${VERSION}"
 
 info "Pushing tag v${VERSION} (triggers publish-cli.yml for npm publish)..."
-git push origin main
 git push origin "v${VERSION}"
+git push origin main
 
 # ── Done ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Part of #394
Part of #395

## Summary
- Add `scripts/release.sh` — interactive release script using CF Workers Versions & Deployments
  - Pre-flight checks (clean tree, main branch, build+test pass)
  - Injects infrastructure IDs, runs D1 migrations
  - Uploads new version via `wrangler versions upload`
  - Optional `--test` flag: prints version override header for manual testing, pauses before deploy
  - Deploys to 100% traffic via `wrangler versions deploy`
  - Bumps CLI version, creates git tag, pushes (triggers npm publish)
  - `scripts/release.sh rollback` for instant rollback
- Update `publish-cli.yml` to use versioned deploys instead of `wrangler deploy`
  - Split into 3 jobs: `publish` (npm), `deploy-prod` (versioned upload+deploy), `create-release` (GitHub release)
  - Removed KV ID injection (no longer used in prod wrangler.toml)
  - Added deployment verification step

## Test plan
- Verify workflow YAML syntax is valid
- Verify `scripts/release.sh` runs pre-flight checks correctly
- Verify dev deploy workflow is unchanged
- Manual test: push a tag and verify versioned deployment flow