### PR TITLE
[server-dev] Use atomic releaseReviewSlot in reject/error paths

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -996,7 +996,51 @@ describe('Task Routes', () => {
       });
 
       const task = await store.getTask('task-1');
-      expect(task?.review_claims).toBe(0); // Math.max(0, -1) = 0
+      expect(task?.review_claims).toBe(0); // underflow protected by releaseReviewSlot
+    });
+
+    it('concurrent rejections decrement review_claims correctly', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          queue: 'review',
+          review_claims: 2,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1:review',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.createClaim({
+        id: 'task-1:agent-2:review',
+        task_id: 'task-1',
+        agent_id: 'agent-2',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // Both agents reject concurrently
+      const [res1, res2] = await Promise.all([
+        request('POST', '/api/tasks/task-1/reject', {
+          agent_id: 'agent-1',
+          reason: 'test',
+        }),
+        request('POST', '/api/tasks/task-1/reject', {
+          agent_id: 'agent-2',
+          reason: 'test',
+        }),
+      ]);
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      const task = await store.getTask('task-1');
+      expect(task?.review_claims).toBe(0); // both decrements applied atomically
     });
   });
 
@@ -1105,6 +1149,50 @@ describe('Task Routes', () => {
       const task = await store.getTask('task-1');
       expect(task?.queue).toBe('summary');
       expect(task?.summary_agent_id).toBeUndefined();
+    });
+
+    it('concurrent errors decrement review_claims correctly', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 3,
+          queue: 'review',
+          review_claims: 2,
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1:review',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.createClaim({
+        id: 'task-1:agent-2:review',
+        task_id: 'task-1',
+        agent_id: 'agent-2',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      // Both agents report error concurrently
+      const [res1, res2] = await Promise.all([
+        request('POST', '/api/tasks/task-1/error', {
+          agent_id: 'agent-1',
+          error: 'crash',
+        }),
+        request('POST', '/api/tasks/task-1/error', {
+          agent_id: 'agent-2',
+          error: 'crash',
+        }),
+      ]);
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      const task = await store.getTask('task-1');
+      expect(task?.review_claims).toBe(0); // both decrements applied atomically
     });
   });
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -637,16 +637,11 @@ export function taskRoutes() {
 
     await store.updateClaim(claim.id, { status: 'rejected' });
 
-    // Free the slot so another agent can claim it
-    const task = await store.getTask(taskId);
-    if (task) {
-      if (claim.role === 'review') {
-        await store.updateTask(taskId, {
-          review_claims: Math.max(0, (task.review_claims ?? 0) - 1),
-        });
-      } else if (claim.role === 'summary') {
-        await store.releaseSummarySlot(taskId);
-      }
+    // Free the slot so another agent can claim it (atomic to avoid races)
+    if (claim.role === 'review') {
+      await store.releaseReviewSlot(taskId);
+    } else if (claim.role === 'summary') {
+      await store.releaseSummarySlot(taskId);
     }
 
     logger.error('Agent rejected task', {
@@ -686,16 +681,11 @@ export function taskRoutes() {
 
     await store.updateClaim(claim.id, { status: 'error' });
 
-    // Free the slot so another agent can claim it
-    const task = await store.getTask(taskId);
-    if (task) {
-      if (claim.role === 'review') {
-        await store.updateTask(taskId, {
-          review_claims: Math.max(0, (task.review_claims ?? 0) - 1),
-        });
-      } else if (claim.role === 'summary') {
-        await store.releaseSummarySlot(taskId);
-      }
+    // Free the slot so another agent can claim it (atomic to avoid races)
+    if (claim.role === 'review') {
+      await store.releaseReviewSlot(taskId);
+    } else if (claim.role === 'summary') {
+      await store.releaseSummarySlot(taskId);
     }
 
     logger.error('Agent reported error', {


### PR DESCRIPTION
Part of #406

## Summary
- Replace stale read-then-decrement pattern in reject and error handlers with atomic `store.releaseReviewSlot(taskId)`
- The old code read `task.review_claims`, decremented locally with `Math.max(0, n - 1)`, and wrote back — two concurrent rejections could both read the same value and lose a decrement
- The claim failure path (line 486) already used `releaseReviewSlot()` correctly; this aligns reject/error to the same atomic pattern
- Also removes the unnecessary `getTask` call that was only needed for the stale read

## Test plan
- Existing tests for reject/error slot release continue to pass
- Added concurrent rejection test: two agents reject simultaneously, both decrements apply correctly (review_claims goes from 2 to 0)
- Added concurrent error test: same pattern for the error path
- All 1208 tests pass