### PR TITLE
[cli-dev] OAuth Device Flow auth module with token storage and refresh

### DIFF
--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -394,6 +394,24 @@ describe('auth', () => {
       ).rejects.toThrow('Authorization timed out, please try again');
     });
 
+    it('re-checks deadline after delay to avoid unnecessary requests', async () => {
+      // Use a short expiry and a delay that "consumes" the remaining time
+      const shortExpiry = { ...DEVICE_RESPONSE, expires_in: 1, interval: 5 };
+      const fetchFn = vi
+        .fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
+        .mockResolvedValueOnce(mockResponse(shortExpiry));
+
+      // Simulate delay that takes longer than the deadline
+      const delayFn = vi.fn(() => new Promise<void>((resolve) => setTimeout(resolve, 1100)));
+
+      await expect(login(PLATFORM_URL, { fetchFn, delayFn, log: vi.fn() })).rejects.toThrow(
+        'Authorization timed out, please try again',
+      );
+
+      // Only the device initiation call should have been made, no token poll
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
     it('saves auth to file on success', async () => {
       const fetchFn = vi
         .fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
@@ -568,7 +586,31 @@ describe('auth', () => {
       ).rejects.toThrow('Refresh token expired');
     });
 
-    it('handles unparseable refresh error response', async () => {
+    it('falls back to text body when refresh JSON parse fails', async () => {
+      const now = Date.now();
+      const auth = { ...MOCK_AUTH, expires_at: now - 1000 };
+
+      const badResponse = {
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new Error('bad json')),
+        text: () => Promise.resolve('Bad Gateway'),
+      } as unknown as Response;
+
+      const fetchFn = vi
+        .fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
+        .mockResolvedValueOnce(badResponse);
+
+      await expect(
+        getValidToken(PLATFORM_URL, {
+          fetchFn,
+          loadAuthFn: () => auth,
+          nowFn: () => now,
+        }),
+      ).rejects.toThrow('Token refresh failed (502): Bad Gateway');
+    });
+
+    it('handles fully unparseable refresh error response', async () => {
       const now = Date.now();
       const auth = { ...MOCK_AUTH, expires_at: now - 1000 };
 
@@ -576,6 +618,7 @@ describe('auth', () => {
         ok: false,
         status: 500,
         json: () => Promise.reject(new Error('bad json')),
+        text: () => Promise.reject(new Error('text also failed')),
       } as unknown as Response;
 
       const fetchFn = vi

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -147,6 +147,11 @@ export async function login(platformUrl: string, deps: LoginDeps = {}): Promise<
   while (Date.now() < deadline) {
     await delayFn(interval);
 
+    // Re-check deadline after delay to avoid unnecessary requests
+    if (Date.now() >= deadline) {
+      break;
+    }
+
     const tokenRes = await fetchFn(`${platformUrl}/api/auth/device/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -178,7 +183,7 @@ export async function login(platformUrl: string, deps: LoginDeps = {}): Promise<
     try {
       errorBody = (await tokenRes.json()) as ErrorResponse;
     } catch {
-      // ignore parse errors
+      // Unparseable response — continue polling (may be transient)
     }
 
     const errorCode = errorBody?.error?.code;
@@ -197,8 +202,7 @@ export async function login(platformUrl: string, deps: LoginDeps = {}): Promise<
       continue;
     }
 
-    // authorization_pending — continue polling
-    // For any unrecognized error, also continue polling until deadline
+    // authorization_pending or transient errors — continue polling until deadline
   }
 
   throw new AuthError('Authorization timed out, please try again');
@@ -253,7 +257,15 @@ export async function getValidToken(platformUrl: string, deps: GetTokenDeps = {}
         message = errorBody.error.message;
       }
     } catch {
-      // ignore parse errors
+      // JSON parse failed — try text fallback
+      try {
+        const text = await refreshRes.text();
+        if (text) {
+          message = `Token refresh failed (${refreshRes.status}): ${text.slice(0, 200)}`;
+        }
+      } catch {
+        // ignore — keep generic message
+      }
     }
     throw new AuthError(`${message}. Run \`opencara auth login\` to re-authenticate.`);
   }


### PR DESCRIPTION
Part of #450

## Summary
- New `packages/cli/src/auth.ts` implementing full OAuth Device Flow authentication
- Token storage in `~/.opencara/auth.json` with `0o600` permissions and atomic writes
- `login()` with Device Flow UX: user code display, polling with slow_down/timeout/denied handling
- `getValidToken()` with transparent token refresh (5-minute pre-expiry buffer)
- `resolveUser()` for GitHub username/id resolution from access token
- `OPENCARA_AUTH_FILE` env var override for CI/testing
- 50 tests with 98%+ line coverage

## Test plan
- [x] Token storage: save, load, delete with proper file permissions
- [x] OPENCARA_AUTH_FILE env var override
- [x] Device Flow: full success flow, authorization_pending, slow_down, expired_token, access_denied
- [x] Token refresh: valid token returns immediately, expired triggers refresh, refresh failure throws
- [x] resolveUser: success, HTTP error, invalid response
- [x] All 1371 existing tests still pass
- [x] Build, lint, typecheck, format all pass