### PR TITLE
[server-dev] Fix summary claim timeout causing stuck task

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -2141,4 +2141,97 @@ describe('Task Routes', () => {
       });
     });
   });
+
+  // ── Summary claim timeout recovery (#462) ──────────────────
+
+  describe('summary claim timeout recovery (#462)', () => {
+    it('task returns to summary queue after summary claim is reclaimed', async () => {
+      const now = Date.now();
+      // Task in summary queue, agent-A claims it
+      await store.createTask(makeTask({ queue: 'summary' }));
+      const claimRes = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-A',
+        role: 'summary',
+      });
+      expect(claimRes.status).toBe(200);
+
+      // Verify task moved to finished queue
+      let task = await store.getTask('task-1');
+      expect(task?.queue).toBe('finished');
+      expect(task?.summary_agent_id).toBe('agent-A');
+
+      // Simulate agent going stale (heartbeat expired)
+      await store.setAgentLastSeen('agent-A', now - 300_000);
+
+      // Reclaim abandoned claims — should free the summary claim AND release the slot
+      const freed = await store.reclaimAbandonedClaims(180_000);
+      expect(freed).toBe(1);
+
+      // Task should be back in summary queue
+      task = await store.getTask('task-1');
+      expect(task?.queue).toBe('summary');
+      expect(task?.summary_agent_id).toBeUndefined();
+
+      // Another agent should see it in poll
+      const pollRes = await request('POST', '/api/tasks/poll', { agent_id: 'agent-B' });
+      const pollBody = await pollRes.json();
+      expect(pollBody.tasks).toHaveLength(1);
+      expect(pollBody.tasks[0].role).toBe('summary');
+    });
+
+    it('another agent can claim summary after previous claim was reclaimed', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ queue: 'summary' }));
+
+      // Agent-A claims summary
+      await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-A',
+        role: 'summary',
+      });
+
+      // Agent-A goes stale, claim is reclaimed
+      await store.setAgentLastSeen('agent-A', now - 300_000);
+      await store.reclaimAbandonedClaims(180_000);
+
+      // Agent-B can now claim the summary
+      const claimRes = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-B',
+        role: 'summary',
+      });
+      expect(claimRes.status).toBe(200);
+      const body = await claimRes.json();
+      expect(body.claimed).toBe(true);
+
+      // Task should be in finished queue with agent-B
+      const task = await store.getTask('task-1');
+      expect(task?.queue).toBe('finished');
+      expect(task?.summary_agent_id).toBe('agent-B');
+    });
+
+    it('original agent gets 409 when submitting result after claim was reclaimed', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ queue: 'summary' }));
+
+      // Agent-A claims summary
+      await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-A',
+        role: 'summary',
+      });
+
+      // Agent-A goes stale, claim is reclaimed
+      await store.setAgentLastSeen('agent-A', now - 300_000);
+      await store.reclaimAbandonedClaims(180_000);
+
+      // Agent-A tries to submit result — should fail
+      const resultRes = await request('POST', '/api/tasks/task-1/result', {
+        agent_id: 'agent-A',
+        type: 'summary',
+        review_text: 'This is a synthesized review of the changes. '.repeat(10),
+        verdict: 'approve',
+      });
+      expect(resultRes.status).toBe(409);
+      const body = await resultRes.json();
+      expect(body.error.message).toContain('Claim already error');
+    });
+  });
 });

--- a/packages/server/src/__tests__/store-memory.test.ts
+++ b/packages/server/src/__tests__/store-memory.test.ts
@@ -651,6 +651,56 @@ describe('MemoryDataStore', () => {
       const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
       expect(freed).toBe(0);
     });
+
+    it('releases summary slot when summary claim is reclaimed (#462)', async () => {
+      const now = Date.now();
+      // Task in finished queue (summary was claimed)
+      await store.createTask(makeTask({ queue: 'finished', summary_agent_id: 'stale-synth' }));
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:stale-synth:summary',
+          agent_id: 'stale-synth',
+          role: 'summary',
+        }),
+      );
+      // Agent last seen 5 minutes ago (stale)
+      await store.setAgentLastSeen('stale-synth', now - 300_000);
+
+      const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+      expect(freed).toBe(1);
+
+      // Claim should be errored
+      const claim = await store.getClaim('task-1:stale-synth:summary');
+      expect(claim?.status).toBe('error');
+
+      // Summary slot should be released — task back in summary queue
+      const task = await store.getTask('task-1');
+      expect(task?.queue).toBe('summary');
+      expect(task?.summary_agent_id).toBeUndefined();
+    });
+
+    it('freed summary slot can be re-claimed by another agent (#462)', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ queue: 'finished', summary_agent_id: 'stale-synth' }));
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:stale-synth:summary',
+          agent_id: 'stale-synth',
+          role: 'summary',
+        }),
+      );
+      await store.setAgentLastSeen('stale-synth', now - 300_000);
+
+      await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+
+      // Another agent should be able to claim the summary slot
+      const claimed = await store.claimSummarySlot('task-1', 'new-agent');
+      expect(claimed).toBe(true);
+
+      const task = await store.getTask('task-1');
+      expect(task?.queue).toBe('finished');
+      expect(task?.summary_agent_id).toBe('new-agent');
+    });
   });
 
   // ── reclaimAbandonedSummarySlots ────────────────────────────

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -608,13 +608,22 @@ export class D1DataStore implements DataStore {
       const changed = result.meta?.changes ?? 0;
       if (changed === 0) continue; // Claim was already resolved — skip slot release
       freed++;
-      // Release the review slot only if we actually freed the claim
+      // Release the slot only if we actually freed the claim
       if (claim.role === 'review') {
         await this.db
           .prepare(
             `UPDATE tasks SET review_claims = review_claims - 1 WHERE id = ? AND review_claims > 0`,
           )
           .bind(claim.task_id)
+          .run();
+      } else if (claim.role === 'summary') {
+        // Release summary slot immediately so the task becomes re-claimable
+        // without waiting for the separate reclaimAbandonedSummarySlots pass.
+        await this.db
+          .prepare(
+            `UPDATE tasks SET queue = 'summary', summary_agent_id = NULL WHERE id = ? AND queue = 'finished' AND summary_agent_id = ?`,
+          )
+          .bind(claim.task_id, claim.agent_id)
           .run();
       }
     }

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -248,10 +248,17 @@ export class MemoryDataStore implements DataStore {
         if (claim.created_at >= cutoff) continue;
       }
       claim.status = 'error';
+      const task = this.tasks.get(claim.task_id);
       if (claim.role === 'review') {
-        const task = this.tasks.get(claim.task_id);
         if (task && (task.review_claims ?? 0) > 0) {
           task.review_claims = (task.review_claims ?? 0) - 1;
+        }
+      } else if (claim.role === 'summary') {
+        // Release summary slot immediately so the task becomes re-claimable
+        // without waiting for the separate reclaimAbandonedSummarySlots pass.
+        if (task && task.queue === 'finished' && task.summary_agent_id === claim.agent_id) {
+          task.queue = 'summary';
+          task.summary_agent_id = undefined;
         }
       }
       freed++;


### PR DESCRIPTION
Part of #462

## Summary
- When `reclaimAbandonedClaims` frees a stale summary claim, it now also releases the summary slot on the task (resets queue from `finished` to `summary`, clears `summary_agent_id`)
- Previously, summary slot release was deferred to `reclaimAbandonedSummarySlots` which uses a longer threshold (5 min vs 3 min), leaving the task stuck in `finished` queue during that gap
- Fix applied to both `MemoryDataStore` and `D1DataStore` implementations

## Test plan
- Added unit tests to `store-memory.test.ts` verifying summary slot is released and re-claimable after claim reclaim
- Added integration tests to `routes-tasks.test.ts` covering the full scenario: claim → stale → reclaim → re-poll → re-claim
- All 1451 existing tests continue to pass