### PR TITLE
[cli-dev] Add backward compat warning for YAML to TOML config migration

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -63,6 +63,47 @@ describe('config', () => {
       expect(config.agentCommand).toBeNull();
     });
 
+    it('warns when config.yml exists but config.toml does not', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+        const s = String(p);
+        if (s.endsWith('config.toml')) return false;
+        if (s.endsWith('config.yml')) return true;
+        return false;
+      });
+
+      const config = loadConfig();
+
+      expect(config.platformUrl).toBe(DEFAULT_PLATFORM_URL);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Found config.yml but config.toml expected'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('does not warn about config.yml when config.toml exists', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('platform_url = "https://custom.dev"\n');
+
+      loadConfig();
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Found config.yml but config.toml expected'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('does not warn when neither config.yml nor config.toml exist', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      loadConfig();
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Found config.yml'));
+      warnSpy.mockRestore();
+    });
+
     it('parses valid config file', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue('platform_url = "https://custom.dev"\n');

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -280,6 +280,13 @@ export function loadConfig(): CliConfig {
   };
 
   if (!fs.existsSync(CONFIG_FILE)) {
+    // Backward compatibility: warn if old config.yml exists
+    const legacyFile = path.join(CONFIG_DIR, 'config.yml');
+    if (fs.existsSync(legacyFile)) {
+      console.warn(
+        '\u26a0 Found config.yml but config.toml expected. Run `opencara config migrate` or manually rename.',
+      );
+    }
     return defaults;
   }
 


### PR DESCRIPTION
Part of #465

## Summary
- Add backward compatibility warning when `config.yml` exists but `config.toml` doesn't
- Warns users to run `opencara config migrate` or manually rename
- All other YAML-to-TOML migration was completed in PR #478 (Phase 1)
- Add 3 tests for the migration warning (warns when yml exists, no warn when toml exists, no warn when neither exists)

## Context
PR #478 already migrated the CLI config from YAML to TOML:
- `loadConfig()`/`saveConfig()` use `smol-toml`
- `CONFIG_FILE` points to `config.toml`
- `yaml` dependency removed
- `config.template.toml` created, `config.template.yml` deleted

This PR adds the one missing acceptance criterion: the backward compat warning for users who still have `config.yml`.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 1520 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)
- [x] Format clean (`pnpm run format:check`)
- [x] Typecheck clean (`pnpm run typecheck`)