### PR TITLE
[server-dev] Return 503 for transient webhook failures

### DIFF
--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -440,7 +440,7 @@ describe('webhook.ts edge cases', () => {
     );
   });
 
-  it('PR event with failed installation token is skipped', async () => {
+  it('PR event with failed installation token returns 503', async () => {
     // Inject a GitHubService that throws on getInstallationToken
     const failingGithub: GitHubService = {
       async getInstallationToken() {
@@ -469,10 +469,10 @@ describe('webhook.ts edge cases', () => {
         head: { ref: 'feat' },
       },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
   });
 
-  it('PR event with .review.toml parse error aborts', async () => {
+  it('PR event with .review.toml parse error returns 503', async () => {
     // Inject a GitHubService that returns parseError: true from loadReviewConfig
     const parseErrorGithub: GitHubService = {
       async getInstallationToken() {
@@ -501,10 +501,10 @@ describe('webhook.ts edge cases', () => {
         head: { ref: 'feat' },
       },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
   });
 
-  it('issue_comment with .review.toml parse error aborts', async () => {
+  it('issue_comment with .review.toml parse error returns 503', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     // Inject a GitHubService that returns parseError: true from loadReviewConfig
     const parseErrorGithub: GitHubService = {
@@ -537,7 +537,7 @@ describe('webhook.ts edge cases', () => {
       issue: { number: 1, pull_request: { url: 'https://example.com' } },
       comment: { body: '/opencara review', user: { login: 'u' }, author_association: 'OWNER' },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     // Verify no task was created
     const tasks = await store.listTasks({ status: 'pending' });
     expect(tasks).toHaveLength(0);
@@ -574,7 +574,7 @@ describe('webhook.ts edge cases', () => {
     );
   });
 
-  it('issue_comment with failed installation token is skipped', async () => {
+  it('issue_comment with failed installation token returns 503', async () => {
     // Inject a GitHubService that throws on getInstallationToken
     const failingGithub: GitHubService = {
       async getInstallationToken() {
@@ -598,10 +598,10 @@ describe('webhook.ts edge cases', () => {
       issue: { number: 1, pull_request: { url: 'https://example.com' } },
       comment: { body: '/opencara review', user: { login: 'u' }, author_association: 'OWNER' },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
   });
 
-  it('issue_comment with failed PR details fetch is skipped', async () => {
+  it('issue_comment with failed PR details fetch returns 503', async () => {
     // Inject a GitHubService where fetchPrDetails returns null
     const failingGithub: GitHubService = {
       async getInstallationToken() {
@@ -625,7 +625,7 @@ describe('webhook.ts edge cases', () => {
       issue: { number: 1, pull_request: { url: 'https://example.com' } },
       comment: { body: '/opencara review', user: { login: 'u' }, author_association: 'OWNER' },
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
   });
 
   it('issue_comment with non-matching trigger command is skipped', async () => {

--- a/packages/server/src/__tests__/webhook-503.test.ts
+++ b/packages/server/src/__tests__/webhook-503.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for webhook 503 responses on transient failures.
+ *
+ * Verifies that transient/retriable failures (token fetch, config parse, store write,
+ * PR details fetch) return 503 Service Unavailable so GitHub retries, while intentional
+ * skips (draft PRs, action not in trigger list, no installation) return 200 OK.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import type { ReviewConfig } from '@opencara/shared';
+import type { GitHubService, PrDetails } from '../github/service.js';
+import { MemoryDataStore } from '../store/memory.js';
+import { createApp } from '../index.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+function getMockEnv() {
+  return {
+    GITHUB_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: 'unused-in-mock',
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+/**
+ * Configurable mock GitHubService for testing failure modes.
+ */
+class FailableGitHubService implements GitHubService {
+  tokenError: Error | null = null;
+  parseError = false;
+  fetchPrResult: PrDetails | null = {
+    number: 1,
+    html_url: 'https://github.com/acme/widget/pull/1',
+    diff_url: 'https://github.com/acme/widget/pull/1.diff',
+    base: { ref: 'main' },
+    head: { ref: 'feat/test' },
+    draft: false,
+    labels: [],
+  };
+
+  async getInstallationToken(_installationId: number): Promise<string> {
+    if (this.tokenError) throw this.tokenError;
+    return 'ghs_mock_token';
+  }
+
+  async postPrComment(
+    _owner: string,
+    _repo: string,
+    _prNumber: number,
+    _body: string,
+    _token: string,
+  ): Promise<string> {
+    return 'https://github.com/test/repo/pull/1#comment-mock';
+  }
+
+  async fetchPrDetails(
+    _owner: string,
+    _repo: string,
+    _prNumber: number,
+  ): Promise<PrDetails | null> {
+    return this.fetchPrResult;
+  }
+
+  async loadReviewConfig(
+    _owner: string,
+    _repo: string,
+    _baseRef: string,
+    _prNumber: number,
+    _token: string,
+  ): Promise<{ config: ReviewConfig; parseError: boolean }> {
+    return { config: DEFAULT_REVIEW_CONFIG, parseError: this.parseError };
+  }
+}
+
+function makePRPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 999 },
+    repository: { owner: { login: 'acme' }, name: 'widget' },
+    pull_request: {
+      number: 42,
+      html_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base: { ref: 'main' },
+      head: { ref: 'feat/test' },
+      draft: false,
+      labels: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeCommentPayload(
+  body: string,
+  association = 'OWNER',
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    action: 'created',
+    installation: { id: 999 },
+    repository: { owner: { login: 'acme' }, name: 'widget' },
+    issue: {
+      number: 42,
+      pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/42' },
+    },
+    comment: {
+      body,
+      user: { login: 'octocat' },
+      author_association: association,
+    },
+    ...overrides,
+  };
+}
+
+async function sendWebhook(
+  app: ReturnType<typeof createApp>,
+  event: string,
+  payload: unknown,
+  env: ReturnType<typeof getMockEnv>,
+) {
+  const body = JSON.stringify(payload);
+  const signature = await signPayload(body, WEBHOOK_SECRET);
+  return app.request(
+    '/webhook/github',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': event,
+      },
+      body,
+    },
+    env,
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('Webhook 503 — transient failure responses', () => {
+  let store: MemoryDataStore;
+  let github: FailableGitHubService;
+  let app: ReturnType<typeof createApp>;
+  let env: ReturnType<typeof getMockEnv>;
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    github = new FailableGitHubService();
+    app = createApp(store, github);
+    env = getMockEnv();
+  });
+
+  // ── pull_request handler ───────────────────────────────────
+
+  describe('pull_request handler', () => {
+    it('returns 503 when installation token fetch fails', async () => {
+      github.tokenError = new Error('GitHub API timeout');
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(503);
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('returns 503 when .review.toml has a parse error', async () => {
+      github.parseError = true;
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(503);
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('returns 503 when store.createTaskIfNotExists throws', async () => {
+      // Make the store throw on write
+      const originalCreate = store.createTaskIfNotExists.bind(store);
+      store.createTaskIfNotExists = async () => {
+        void originalCreate;
+        throw new Error('D1 write failure');
+      };
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 200 when action is not in trigger.on (intentional skip)', async () => {
+      const payload = makePRPayload({ action: 'closed' });
+      const res = await sendWebhook(app, 'pull_request', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 when PR is a draft (intentional skip)', async () => {
+      const payload = makePRPayload({
+        pull_request: {
+          number: 42,
+          html_url: 'https://github.com/acme/widget/pull/42',
+          diff_url: 'https://github.com/acme/widget/pull/42.diff',
+          base: { ref: 'main' },
+          head: { ref: 'feat/test' },
+          draft: true,
+          labels: [],
+        },
+      });
+      const res = await sendWebhook(app, 'pull_request', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 when no installation is present (intentional skip)', async () => {
+      const payload = makePRPayload({ installation: undefined });
+      const res = await sendWebhook(app, 'pull_request', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 on successful task creation', async () => {
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+  });
+
+  // ── issue_comment handler ──────────────────────────────────
+
+  describe('issue_comment handler', () => {
+    it('returns 503 when installation token fetch fails', async () => {
+      github.tokenError = new Error('GitHub API timeout');
+      const payload = makeCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 503 when PR details fetch fails', async () => {
+      github.fetchPrResult = null;
+      const payload = makeCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 503 when .review.toml has a parse error', async () => {
+      github.parseError = true;
+      const payload = makeCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 503 when store.createTaskIfNotExists throws', async () => {
+      store.createTaskIfNotExists = async () => {
+        throw new Error('D1 write failure');
+      };
+      const payload = makeCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(503);
+    });
+
+    it('returns 200 when comment is not a trigger command (intentional skip)', async () => {
+      const payload = makeCommentPayload('just a regular comment');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 when comment is not on a PR (intentional skip)', async () => {
+      const payload = makeCommentPayload('/opencara review', 'OWNER', {
+        issue: { number: 42 }, // no pull_request field
+      });
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 when author is not trusted (intentional skip)', async () => {
+      const payload = makeCommentPayload('/opencara review', 'NONE');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 when no installation is present (intentional skip)', async () => {
+      const payload = makeCommentPayload('/opencara review', 'OWNER', {
+        installation: undefined,
+      });
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 on successful task creation', async () => {
+      const payload = makeCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+  });
+});

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -244,7 +244,7 @@ async function handlePullRequest(
     logger.error('Failed to get installation token', {
       error: err instanceof Error ? err.message : String(err),
     });
-    return new Response('OK', { status: 200 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const baseRef = pull_request.base.ref;
@@ -258,7 +258,7 @@ async function handlePullRequest(
 
   if (parseError) {
     logger.info('Aborting due to .review.toml parse error', { prNumber });
-    return new Response('OK', { status: 200 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   if (!config.trigger.on.includes(action)) {
@@ -280,20 +280,30 @@ async function handlePullRequest(
     return new Response('OK', { status: 200 });
   }
 
-  await createTaskForPR(
-    store,
-    installation.id,
-    owner,
-    repo,
-    prNumber,
-    pull_request.html_url,
-    pull_request.diff_url,
-    pull_request.base.ref,
-    headRef,
-    config,
-    repository.private ?? false,
-    logger,
-  );
+  try {
+    await createTaskForPR(
+      store,
+      installation.id,
+      owner,
+      repo,
+      prNumber,
+      pull_request.html_url,
+      pull_request.diff_url,
+      pull_request.base.ref,
+      headRef,
+      config,
+      repository.private ?? false,
+      logger,
+    );
+  } catch (err) {
+    logger.error('Failed to create task for PR', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      prNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
 
   return new Response('OK', { status: 200 });
 }
@@ -326,13 +336,13 @@ async function handleIssueComment(
     logger.error('Failed to get installation token', {
       error: err instanceof Error ? err.message : String(err),
     });
-    return new Response('OK', { status: 200 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const pr = await github.fetchPrDetails(owner, repo, prNumber, token);
   if (!pr) {
     logger.error('Failed to fetch PR details', { owner, repo, prNumber });
-    return new Response('OK', { status: 200 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const { config, parseError } = await github.loadReviewConfig(
@@ -349,7 +359,7 @@ async function handleIssueComment(
       repo,
       prNumber,
     });
-    return new Response('OK', { status: 200 });
+    return new Response('Service Unavailable', { status: 503 });
   }
 
   const triggerCommand = config.trigger.comment;
@@ -374,20 +384,30 @@ async function handleIssueComment(
     prNumber,
   });
 
-  await createTaskForPR(
-    store,
-    installation.id,
-    owner,
-    repo,
-    prNumber,
-    pr.html_url,
-    pr.diff_url,
-    pr.base.ref,
-    pr.head.ref,
-    config,
-    repository.private ?? false,
-    logger,
-  );
+  try {
+    await createTaskForPR(
+      store,
+      installation.id,
+      owner,
+      repo,
+      prNumber,
+      pr.html_url,
+      pr.diff_url,
+      pr.base.ref,
+      pr.head.ref,
+      config,
+      repository.private ?? false,
+      logger,
+    );
+  } catch (err) {
+    logger.error('Failed to create task for PR', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      prNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
 
   return new Response('OK', { status: 200 });
 }


### PR DESCRIPTION
Part of #483

## Summary
- Transient failures (installation token fetch, config parse error, PR details fetch, D1 store write) now return **503 Service Unavailable** instead of 200, enabling GitHub webhook retries
- Intentional skips (draft PRs, action not in trigger list, no installation, untrusted author) continue to return **200 OK**
- Wrapped `createTaskForPR` calls in try/catch to handle store write failures gracefully
- Added 16 new tests covering all 503 and 200 paths for both `pull_request` and `issue_comment` handlers
- Updated 5 existing tests in `coverage-gaps.test.ts` to expect 503 for transient failures

## Test plan
- All 1536 tests pass
- Build, lint, typecheck all clean
- New test file: `packages/server/src/__tests__/webhook-503.test.ts`