### PR TITLE
[architect] Add network timeouts to all outbound fetch calls

### DIFF
--- a/packages/cli/src/__tests__/http.test.ts
+++ b/packages/cli/src/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ApiClient, HttpError, UpgradeRequiredError } from '../http.js';
+import { ApiClient, HttpError, UpgradeRequiredError, API_TIMEOUT_MS } from '../http.js';
 
 describe('ApiClient', () => {
   const originalFetch = globalThis.fetch;
@@ -457,6 +457,60 @@ describe('ApiClient', () => {
       // Only one refresh attempt
       expect(onTokenRefresh).toHaveBeenCalledOnce();
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('timeout', () => {
+    it('passes AbortController signal to fetch calls', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const client = new ApiClient('https://api.test.com');
+      await client.get('/test');
+
+      const calledInit = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(calledInit.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('uses default timeout of API_TIMEOUT_MS', () => {
+      expect(API_TIMEOUT_MS).toBe(30_000);
+    });
+
+    it('accepts custom timeoutMs', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const client = new ApiClient('https://api.test.com', { timeoutMs: 5000 });
+      await client.get('/test');
+
+      const calledInit = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(calledInit.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('throws on timeout (AbortError propagated from fetch)', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'));
+
+      const client = new ApiClient('https://api.test.com', { timeoutMs: 1 });
+      await expect(client.get('/test')).rejects.toThrow('aborted');
+    });
+
+    it('passes AbortController signal to POST fetch calls', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: '1' }),
+      });
+
+      const client = new ApiClient('https://api.test.com');
+      await client.post('/test', { data: 1 });
+
+      const calledInit = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(calledInit.signal).toBeInstanceOf(AbortSignal);
     });
   });
 });

--- a/packages/cli/src/__tests__/pr-context.test.ts
+++ b/packages/cli/src/__tests__/pr-context.test.ts
@@ -221,7 +221,7 @@ describe('fetchPRContext', () => {
     expect(ctx.comments[0].author).toBe('unknown');
   });
 
-  it('passes signal to fetch calls', async () => {
+  it('passes signal to fetch calls (internal controller forwards parent abort)', async () => {
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
       json: () =>
@@ -239,10 +239,42 @@ describe('fetchPRContext', () => {
     const controller = new AbortController();
     await fetchPRContext('owner', 'repo', 1, { signal: controller.signal });
 
+    // Each fetch call receives an AbortSignal (from the internal timeout controller)
     for (const call of fetchSpy.mock.calls) {
       const init = call[1] as RequestInit;
-      expect(init.signal).toBe(controller.signal);
+      expect(init.signal).toBeInstanceOf(AbortSignal);
     }
+  });
+
+  it('aborts fetch when parent signal is aborted', async () => {
+    const controller = new AbortController();
+    // Abort immediately — all fetches should fail
+    controller.abort();
+
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            title: 'T',
+            body: null,
+            user: null,
+            labels: [],
+            base: { ref: 'main' },
+            head: { ref: 'test' },
+          }),
+      });
+    });
+    globalThis.fetch = fetchSpy;
+
+    const ctx = await fetchPRContext('owner', 'repo', 1, { signal: controller.signal });
+
+    // All sub-fetches degrade gracefully on abort
+    expect(ctx.metadata).toBeNull();
+    expect(ctx.comments).toEqual([]);
   });
 });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -151,6 +151,9 @@ export function computeRoles(agent: LocalAgentConfig): ClaimRole[] {
 /** Diff fetch method identifier for logging. */
 type DiffMethod = 'gh' | 'http';
 
+/** Default timeout for diff fetch via HTTP (60 seconds — diffs can be large). */
+const DIFF_FETCH_TIMEOUT_MS = 60_000;
+
 /**
  * Fetch diff via HTTP with streaming size guard.
  */
@@ -162,7 +165,26 @@ async function fetchDiffHttp(
 ): Promise<string> {
   const maxBytes = maxDiffSizeKb ? maxDiffSizeKb * 1024 : Infinity;
 
-  const response = await fetch(url, { headers, signal });
+  // Per-call timeout, combined with optional caller signal (e.g., shutdown)
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DIFF_FETCH_TIMEOUT_MS);
+  const onParentAbort = () => controller.abort();
+  if (signal?.aborted) {
+    controller.abort();
+  } else {
+    signal?.addEventListener('abort', onParentAbort);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { headers, signal: controller.signal });
+  } catch (err) {
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', onParentAbort);
+    throw err;
+  }
+  clearTimeout(timer);
+  signal?.removeEventListener('abort', onParentAbort);
   if (!response.ok) {
     const hint =
       response.status === 404

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -27,12 +27,16 @@ export class UpgradeRequiredError extends Error {
 /** Callback invoked when the server returns AUTH_TOKEN_EXPIRED. Returns a fresh token. */
 export type TokenRefreshFn = () => Promise<string>;
 
+/** Default timeout for platform API calls (30 seconds). */
+export const API_TIMEOUT_MS = 30_000;
+
 export class ApiClient {
   private readonly debug: boolean;
   private authToken: string | null;
   private readonly cliVersion: string | null;
   private readonly versionOverride: string | null;
   private readonly onTokenRefresh: TokenRefreshFn | null;
+  private readonly timeoutMs: number;
 
   constructor(
     private readonly baseUrl: string,
@@ -44,6 +48,8 @@ export class ApiClient {
           cliVersion?: string;
           versionOverride?: string | null;
           onTokenRefresh?: TokenRefreshFn;
+          /** Per-request timeout in milliseconds. Defaults to API_TIMEOUT_MS (30s). */
+          timeoutMs?: number;
         },
   ) {
     if (typeof debugOrOptions === 'object' && debugOrOptions !== null) {
@@ -52,12 +58,14 @@ export class ApiClient {
       this.cliVersion = debugOrOptions.cliVersion ?? null;
       this.versionOverride = debugOrOptions.versionOverride ?? null;
       this.onTokenRefresh = debugOrOptions.onTokenRefresh ?? null;
+      this.timeoutMs = debugOrOptions.timeoutMs ?? API_TIMEOUT_MS;
     } else {
       this.debug = debugOrOptions ?? process.env.OPENCARA_DEBUG === '1';
       this.authToken = null;
       this.cliVersion = null;
       this.versionOverride = null;
       this.onTokenRefresh = null;
+      this.timeoutMs = API_TIMEOUT_MS;
     }
   }
 
@@ -110,9 +118,20 @@ export class ApiClient {
     return { message, errorCode, minimumVersion };
   }
 
+  /** Fetch with AbortController-based timeout. Clears the timer on completion. */
+  private async timedFetch(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   async get<T>(path: string): Promise<T> {
     this.log(`GET ${path}`);
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.timedFetch(`${this.baseUrl}${path}`, {
       method: 'GET',
       headers: this.headers(),
     });
@@ -121,7 +140,7 @@ export class ApiClient {
 
   async post<T>(path: string, body?: unknown): Promise<T> {
     this.log(`POST ${path}`);
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.timedFetch(`${this.baseUrl}${path}`, {
       method: 'POST',
       headers: this.headers(),
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -149,7 +168,7 @@ export class ApiClient {
         try {
           this.authToken = await this.onTokenRefresh();
           this.log('Token refreshed, retrying request');
-          const retryRes = await fetch(`${this.baseUrl}${path}`, {
+          const retryRes = await this.timedFetch(`${this.baseUrl}${path}`, {
             method,
             headers: this.headers(),
             body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/packages/cli/src/pr-context.ts
+++ b/packages/cli/src/pr-context.ts
@@ -45,6 +45,9 @@ export interface PRContext {
 
 // ── Fetching ──────────────────────────────────────────────────
 
+/** Default timeout for GitHub API calls in PR context (30 seconds). */
+const GITHUB_API_TIMEOUT_MS = 30_000;
+
 interface FetchDeps {
   githubToken?: string | null;
   signal?: AbortSignal;
@@ -57,11 +60,27 @@ async function githubGet<T>(url: string, deps: FetchDeps): Promise<T> {
   if (deps.githubToken) {
     headers['Authorization'] = `Bearer ${deps.githubToken}`;
   }
-  const response = await fetch(url, { headers, signal: deps.signal });
-  if (!response.ok) {
-    throw new Error(`GitHub API ${response.status}: ${response.statusText}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
+
+  // If the caller provides a signal (e.g., for graceful shutdown), abort on that too
+  const onParentAbort = () => controller.abort();
+  if (deps.signal?.aborted) {
+    controller.abort();
+  } else {
+    deps.signal?.addEventListener('abort', onParentAbort);
   }
-  return response.json() as Promise<T>;
+
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}: ${response.statusText}`);
+    }
+    return response.json() as Promise<T>;
+  } finally {
+    clearTimeout(timer);
+    deps.signal?.removeEventListener('abort', onParentAbort);
+  }
 }
 
 interface GitHubPR {

--- a/packages/server/src/__tests__/github-fetch.test.ts
+++ b/packages/server/src/__tests__/github-fetch.test.ts
@@ -241,10 +241,12 @@ describe('githubFetch', () => {
         const res = await githubFetch('https://api.github.com/test');
 
         expect(res.status).toBe(200);
-        expect(delays).toHaveLength(1);
+        // Filter out timeout timers (30000ms) — only check retry delay timers
+        const retryDelays = delays.filter((d) => d < 10_000);
+        expect(retryDelays).toHaveLength(1);
         // Base delay is 1000ms, with ±30% jitter → 700-1300
-        expect(delays[0]).toBeGreaterThanOrEqual(700);
-        expect(delays[0]).toBeLessThanOrEqual(1300);
+        expect(retryDelays[0]).toBeGreaterThanOrEqual(700);
+        expect(retryDelays[0]).toBeLessThanOrEqual(1300);
       } finally {
         vi.useFakeTimers();
       }
@@ -310,6 +312,51 @@ describe('githubFetch', () => {
 
       expect(res.status).toBe(200);
       expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // ── Timeout behavior ─────────────────────────────────────
+
+  describe('timeout', () => {
+    it('passes AbortController signal to each fetch attempt', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await fetchWithTimers('https://api.github.com/test');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('retries on timeout (abort error) like a network error', async () => {
+      fetchMock
+        .mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'))
+        .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+      const res = await fetchWithTimers('https://api.github.com/test');
+
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses custom timeoutMs when provided', async () => {
+      vi.useRealTimers();
+      try {
+        const delays: number[] = [];
+        const origSetTimeout = globalThis.setTimeout;
+        vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb: TimerHandler, ms?: number) => {
+          delays.push(ms ?? 0);
+          return origSetTimeout(cb, 0);
+        });
+
+        fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+        await githubFetch('https://api.github.com/test', { timeoutMs: 5000 });
+
+        // The first setTimeout should be the timeout timer with our custom value
+        expect(delays).toContain(5000);
+      } finally {
+        vi.useFakeTimers();
+      }
     });
   });
 

--- a/packages/server/src/github/fetch.ts
+++ b/packages/server/src/github/fetch.ts
@@ -3,9 +3,14 @@ const GITHUB_API_VERSION = '2022-11-28';
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 
+/** Default timeout for GitHub API calls (30 seconds). */
+export const GITHUB_FETCH_TIMEOUT_MS = 30_000;
+
 export interface GitHubFetchOptions extends RequestInit {
   token?: string;
   accept?: string;
+  /** Per-attempt timeout in milliseconds. Defaults to GITHUB_FETCH_TIMEOUT_MS (30s). */
+  timeoutMs?: number;
 }
 
 /**
@@ -18,7 +23,7 @@ export async function githubFetch(
   url: string,
   options: GitHubFetchOptions = {},
 ): Promise<Response> {
-  const { token, accept, ...fetchOptions } = options;
+  const { token, accept, timeoutMs = GITHUB_FETCH_TIMEOUT_MS, ...fetchOptions } = options;
 
   const headers: Record<string, string> = {
     'User-Agent': GITHUB_USER_AGENT,
@@ -33,8 +38,15 @@ export async function githubFetch(
   };
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await fetch(url, { ...fetchOptions, headers });
+      const response = await fetch(url, {
+        ...fetchOptions,
+        headers,
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
 
       if (response.ok) return response;
 
@@ -53,7 +65,8 @@ export async function githubFetch(
       // Non-retryable error or retries exhausted
       return response;
     } catch (err) {
-      // Network errors are transient — retry
+      clearTimeout(timer);
+      // Network errors and timeouts are transient — retry
       if (attempt < MAX_RETRIES) {
         const baseDelay = BASE_DELAY_MS * Math.pow(2, attempt);
         const delay = Math.round(baseDelay * (0.7 + Math.random() * 0.6));

--- a/packages/server/src/middleware/oauth.ts
+++ b/packages/server/src/middleware/oauth.ts
@@ -5,6 +5,9 @@ import type { Env, AppVariables } from '../types.js';
 /** Default cache TTL: 1 hour in milliseconds. */
 export const OAUTH_CACHE_TTL_MS = 60 * 60 * 1000;
 
+/** Timeout for GitHub token verification API calls (10 seconds). */
+const OAUTH_VERIFY_TIMEOUT_MS = 10_000;
+
 /**
  * Hash a token using SHA-256. Returns hex-encoded digest.
  * Uses the Web Crypto API available in Cloudflare Workers and Node 18+.
@@ -34,17 +37,25 @@ export async function verifyGitHubToken(
   { identity: VerifiedIdentity; valid: true } | { valid: false; reason: 'revoked' | 'expired' }
 > {
   const credentials = btoa(`${clientId}:${clientSecret}`);
-  const response = await fetch(`https://api.github.com/applications/${clientId}/token`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${credentials}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'OpenCara-Server',
-    },
-    body: JSON.stringify({ access_token: token }),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OAUTH_VERIFY_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`https://api.github.com/applications/${clientId}/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'OpenCara-Server',
+      },
+      body: JSON.stringify({ access_token: token }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
 
   if (response.status === 200) {
     const data = (await response.json()) as { user?: { id: number; login: string } };

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -12,12 +12,19 @@ import { rateLimitByIP } from '../middleware/rate-limit.js';
 const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code';
 const GITHUB_OAUTH_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 
-/** Safely fetch a URL, returning null on network errors. */
+/** Timeout for GitHub OAuth proxy calls (10 seconds). */
+const OAUTH_PROXY_TIMEOUT_MS = 10_000;
+
+/** Safely fetch a URL with timeout, returning null on network/timeout errors. */
 async function safeFetch(url: string, init: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OAUTH_PROXY_TIMEOUT_MS);
   try {
-    return await fetch(url, init);
+    return await fetch(url, { ...init, signal: controller.signal });
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
Part of #482

## Summary
- Add AbortController-based timeouts to all outbound `fetch` calls across both server and CLI packages
- Server: 30s for GitHub API calls (configurable), 10s for OAuth verification/proxy calls
- CLI: 30s for platform API calls (configurable), 30s for PR context API, 60s for diff fetches
- Timeouts are retried as transient errors in retry-capable functions; parent abort signals forwarded to internal controllers
- Updated existing tests and added new timeout-specific tests (1529 tests passing)

## Test plan
- [x] All 1529 tests pass
- [x] Lint, format, typecheck clean
- [x] github-fetch: timeout creates AbortController signal per attempt, retries on timeout, supports custom timeoutMs
- [x] ApiClient: passes AbortController signal to all fetch calls, supports custom timeoutMs
- [x] pr-context: internal timeout controller, parent abort signal forwarding verified
- [x] agent.ts fetchDiffHttp: per-call 60s timeout with parent signal forwarding