### PR TITLE
[architect] Remove anonymous agent mode from codebase

### DIFF
--- a/docs/QA-PLAN.md
+++ b/docs/QA-PLAN.md
@@ -361,7 +361,7 @@ pnpm opencara agent --help
    - `RefreshTokenRequest`, `RefreshTokenResponse` exported
    - `AUTH_REQUIRED`, `AUTH_TOKEN_EXPIRED`, `AUTH_TOKEN_REVOKED` in `ErrorCode` union
    - `github_username` field absent from `PollRequest` and `ClaimRequest` types
-   - `allow_anonymous` in `.review.toml` produces deprecation warning, not parse error
+   - `allow_anonymous` in `.review.toml` is silently ignored, not a parse error
 3. Verify type-safety across packages: `pnpm run typecheck`
 
 **Expected**: All new types exported. Removed fields cause no compile errors. Deprecation handled gracefully.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,7 +215,6 @@ skip = ["draft"] # Skip conditions: "draft", label names, branch names
 
 # Reviewer access control (all agents authenticated via GitHub OAuth)
 [reviewer]
-# Note: allow_anonymous is deprecated and ignored.
 
 [[reviewer.whitelist]]
 github = "trusted-contributor"

--- a/docs/product.md
+++ b/docs/product.md
@@ -72,10 +72,8 @@ on = ["opened", "synchronize"]  # PR events that trigger review
 comment = "/opencara review"    # Manual trigger (both /opencara and @opencara work)
 skip = ["draft"]                # Skip conditions: "draft", "label:<name>", "branch:<pattern>"
 
-# Reviewer access control (enforced server-side)
+# Reviewer access control (enforced server-side, all agents authenticated via GitHub OAuth)
 [reviewer]
-# Note: allow_anonymous is deprecated and ignored — all agents are now
-# authenticated via GitHub OAuth. This field is accepted but has no effect.
 
 [[reviewer.whitelist]]
 github = "trusted-contributor"  # Only these users can review

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -875,21 +875,6 @@ github_token = "ghp_agent1"
     });
   });
 
-  describe('loadConfig ignores anonymous_agents', () => {
-    it('does not include anonymousAgents in config', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(`
-[[anonymous_agents]]
-agent_id = "a1b2c3d4"
-api_key = "cr_abc123"
-model = "claude-sonnet-4-6"
-tool = "claude"
-`);
-      const config = loadConfig();
-      expect(config).not.toHaveProperty('anonymousAgents');
-    });
-  });
-
   describe('codebase_dir config', () => {
     it('parses global codebase_dir', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);

--- a/packages/server/src/__tests__/routes-config.test.ts
+++ b/packages/server/src/__tests__/routes-config.test.ts
@@ -150,7 +150,6 @@ describe('POST /api/config/validate', () => {
       'preferred_tools = ["claude"]',
       '',
       '[reviewer]',
-      'allow_anonymous = false',
     ].join('\n');
     const res = await postValidate(app, { toml });
     expect(res.status).toBe(200);

--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -22,7 +22,6 @@ preferred_models = ["claude-opus-4-6", "glm-5"]
 preferred_tools = ["claude-code", "codex"]
 
 [reviewer]
-allow_anonymous = false
 
 [[reviewer.whitelist]]
 agent = "abc-123"
@@ -152,29 +151,11 @@ describe('parseReviewConfig', () => {
     expect(result.agents.preferredTools).toEqual(['claude-code', 'codex']);
   });
 
-  it('logs deprecation warning when allow_anonymous is present', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('silently ignores allow_anonymous field in reviewer section', () => {
     const result = parseReviewConfig(
       'version = 1\nprompt = "test"\n[reviewer]\nallow_anonymous = false',
     ) as ReviewConfig;
     expect('error' in result).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Deprecated: "reviewer.allow_anonymous" is ignored'),
-    );
-    warnSpy.mockRestore();
-  });
-
-  it('does not log deprecation warning when allow_anonymous is absent', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    parseReviewConfig(MINIMAL_CONFIG);
-    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('allow_anonymous'));
-    warnSpy.mockRestore();
-  });
-
-  it('does not include allowAnonymous in parsed config', () => {
-    const result = parseReviewConfig(
-      'version = 1\nprompt = "test"\n[reviewer]\nallow_anonymous = false',
-    ) as ReviewConfig;
     expect('allowAnonymous' in result.reviewer).toBe(false);
   });
 });

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -212,13 +212,6 @@ export function parseReviewConfig(toml: string): ParseResult {
   const agentsRaw = isObject(raw.agents) ? raw.agents : {};
   const reviewerRaw = isObject(raw.reviewer) ? raw.reviewer : {};
 
-  // Deprecation warning: allow_anonymous is ignored with OAuth authentication
-  if (reviewerRaw.allow_anonymous !== undefined) {
-    console.warn(
-      'Deprecated: "reviewer.allow_anonymous" is ignored. All agents are now authenticated via OAuth.',
-    );
-  }
-
   const config: ReviewConfig = {
     version: raw.version,
     prompt: raw.prompt,


### PR DESCRIPTION
Part of #500

## Summary
- Remove `allow_anonymous` deprecation warning from shared review-config parser (field is still silently ignored for backward compatibility)
- Remove `anonymous_agents` test section from CLI config tests
- Remove `allow_anonymous` from server routes-config test fixture
- Clean up doc references in architecture.md, product.md, and QA-PLAN.md
- Keep one test verifying `allow_anonymous` field is silently ignored (not a parse error)

## Test plan
- All 1585 tests pass across 60 test files
- `pnpm build && pnpm test && pnpm lint && pnpm run format:check && pnpm run typecheck` all pass
- No remaining `allow_anonymous` or `anonymous_agents` references in `.ts` source files (only the backward-compat test)
- `.review.toml` files with `allow_anonymous` are still parsed without error (silently ignored)