### PR TITLE
[server-dev] Add issue management methods to GitHubService

### DIFF
--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -455,6 +455,13 @@ describe('webhook.ts edge cases', () => {
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
       },
+      async updateIssue() {},
+      async fetchIssueBody() {
+        return null;
+      },
+      async createIssue() {
+        return 0;
+      },
     };
     const { app, mockEnv } = await setupApp(failingGithub);
     const res = await sendWebhook(app, mockEnv, 'pull_request', {
@@ -486,6 +493,13 @@ describe('webhook.ts edge cases', () => {
       },
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: true };
+      },
+      async updateIssue() {},
+      async fetchIssueBody() {
+        return null;
+      },
+      async createIssue() {
+        return 0;
       },
     };
     const { app, mockEnv } = await setupApp(parseErrorGithub);
@@ -527,6 +541,13 @@ describe('webhook.ts edge cases', () => {
       },
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: true };
+      },
+      async updateIssue() {},
+      async fetchIssueBody() {
+        return null;
+      },
+      async createIssue() {
+        return 0;
       },
     };
     const { app, store, mockEnv } = await setupApp(parseErrorGithub);
@@ -589,6 +610,13 @@ describe('webhook.ts edge cases', () => {
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
       },
+      async updateIssue() {},
+      async fetchIssueBody() {
+        return null;
+      },
+      async createIssue() {
+        return 0;
+      },
     };
     const { app, mockEnv } = await setupApp(failingGithub);
     const res = await sendWebhook(app, mockEnv, 'issue_comment', {
@@ -615,6 +643,13 @@ describe('webhook.ts edge cases', () => {
       },
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
+      },
+      async updateIssue() {},
+      async fetchIssueBody() {
+        return null;
+      },
+      async createIssue() {
+        return 0;
       },
     };
     const { app, mockEnv } = await setupApp(failingGithub);

--- a/packages/server/src/__tests__/github-service.test.ts
+++ b/packages/server/src/__tests__/github-service.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for GitHubService new issue management methods:
+ * - updateIssue
+ * - fetchIssueBody
+ * - createIssue
+ *
+ * Tests both RealGitHubService (with mocked fetch) and NoOpGitHubService.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { RealGitHubService, NoOpGitHubService } from '../github/service.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ── RealGitHubService ───────────────────────────────────────
+
+describe('RealGitHubService issue methods', () => {
+  function createService(): RealGitHubService {
+    return new RealGitHubService('app-id', 'private-key');
+  }
+
+  describe('updateIssue', () => {
+    it('sends PATCH request with updates', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      });
+
+      const svc = createService();
+      await svc.updateIssue('owner', 'repo', 42, { title: 'New Title', labels: ['bug'] }, 'token');
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.github.com/repos/owner/repo/issues/42');
+      expect(opts.method).toBe('PATCH');
+      expect(JSON.parse(opts.body as string)).toEqual({ title: 'New Title', labels: ['bug'] });
+    });
+
+    it('throws on non-ok response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      });
+
+      const svc = createService();
+      await expect(
+        svc.updateIssue('owner', 'repo', 42, { title: 'New Title' }, 'token'),
+      ).rejects.toThrow('Failed to update issue #42: 403 Forbidden');
+    });
+  });
+
+  describe('fetchIssueBody', () => {
+    it('returns issue body on success', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ body: 'Issue description here' }),
+      });
+
+      const svc = createService();
+      const result = await svc.fetchIssueBody('owner', 'repo', 10, 'token');
+      expect(result).toBe('Issue description here');
+
+      const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.github.com/repos/owner/repo/issues/10');
+    });
+
+    it('returns null on 404', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      const svc = createService();
+      const result = await svc.fetchIssueBody('owner', 'repo', 999, 'token');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when body is null', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ body: null }),
+      });
+
+      const svc = createService();
+      const result = await svc.fetchIssueBody('owner', 'repo', 10, 'token');
+      expect(result).toBeNull();
+    });
+
+    it('throws on non-404 error', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      });
+
+      const svc = createService();
+      await expect(svc.fetchIssueBody('owner', 'repo', 10, 'token')).rejects.toThrow(
+        'Failed to fetch issue #10: 403 Forbidden',
+      );
+    });
+  });
+
+  describe('createIssue', () => {
+    it('sends POST request and returns issue number', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve({ number: 123 }),
+      });
+
+      const svc = createService();
+      const result = await svc.createIssue(
+        'owner',
+        'repo',
+        { title: 'New Issue', body: 'Description', labels: ['enhancement'] },
+        'token',
+      );
+      expect(result).toBe(123);
+
+      const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe('https://api.github.com/repos/owner/repo/issues');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body as string)).toEqual({
+        title: 'New Issue',
+        body: 'Description',
+        labels: ['enhancement'],
+      });
+    });
+
+    it('throws on non-ok response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+      });
+
+      const svc = createService();
+      await expect(
+        svc.createIssue('owner', 'repo', { title: 'Bad', body: '' }, 'token'),
+      ).rejects.toThrow('Failed to create issue: 422 Unprocessable Entity');
+    });
+  });
+});
+
+// ── NoOpGitHubService ───────────────────────────────────────
+
+describe('NoOpGitHubService issue methods', () => {
+  it('updateIssue is a no-op', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const svc = new NoOpGitHubService();
+    await expect(
+      svc.updateIssue('owner', 'repo', 1, { title: 'test' }, 'token'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fetchIssueBody returns mock body', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const svc = new NoOpGitHubService();
+    const result = await svc.fetchIssueBody('owner', 'repo', 5, 'token');
+    expect(result).toBe('Mock issue body for #5');
+  });
+
+  it('createIssue returns 0', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const svc = new NoOpGitHubService();
+    const result = await svc.createIssue('owner', 'repo', { title: 'Test', body: 'Body' }, 'token');
+    expect(result).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/helpers/github-mock.ts
+++ b/packages/server/src/__tests__/helpers/github-mock.ts
@@ -166,6 +166,36 @@ export class MockGitHubService implements GitHubService {
     return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
   }
 
+  async updateIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    updates: { title?: string; body?: string; labels?: string[] },
+    token: string,
+  ): Promise<void> {
+    this.calls.push({ method: 'updateIssue', args: { owner, repo, number, updates, token } });
+  }
+
+  async fetchIssueBody(
+    owner: string,
+    repo: string,
+    number: number,
+    token: string,
+  ): Promise<string | null> {
+    this.calls.push({ method: 'fetchIssueBody', args: { owner, repo, number, token } });
+    return `Mock issue body for #${number}`;
+  }
+
+  async createIssue(
+    owner: string,
+    repo: string,
+    fields: { title: string; body: string; labels?: string[] },
+    token: string,
+  ): Promise<number> {
+    this.calls.push({ method: 'createIssue', args: { owner, repo, fields, token } });
+    return 42;
+  }
+
   /** Count postPrComment calls (convenience for assertions). */
   get commentCount(): number {
     return this.calls.filter((c) => c.method === 'postPrComment').length;

--- a/packages/server/src/__tests__/webhook-503.test.ts
+++ b/packages/server/src/__tests__/webhook-503.test.ts
@@ -90,6 +90,14 @@ class FailableGitHubService implements GitHubService {
   ): Promise<{ config: ReviewConfig; parseError: boolean }> {
     return { config: this.configOverride ?? DEFAULT_REVIEW_CONFIG, parseError: this.parseError };
   }
+
+  async updateIssue(): Promise<void> {}
+  async fetchIssueBody(): Promise<string | null> {
+    return null;
+  }
+  async createIssue(): Promise<number> {
+    return 0;
+  }
 }
 
 function makePRPayload(overrides: Record<string, unknown> = {}) {

--- a/packages/server/src/github/service.ts
+++ b/packages/server/src/github/service.ts
@@ -2,6 +2,7 @@ import type { Env } from '../types.js';
 import type { Logger } from '../logger.js';
 import { createLogger } from '../logger.js';
 import { getInstallationToken } from './app.js';
+import { githubFetch } from './fetch.js';
 import { postPrComment } from './reviews.js';
 import {
   fetchPrDetails,
@@ -42,6 +43,27 @@ export interface GitHubService {
     prNumber: number,
     token: string,
   ): Promise<{ config: ReviewConfig; parseError: boolean }>;
+
+  // Issue management
+  updateIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    updates: { title?: string; body?: string; labels?: string[] },
+    token: string,
+  ): Promise<void>;
+  fetchIssueBody(
+    owner: string,
+    repo: string,
+    number: number,
+    token: string,
+  ): Promise<string | null>;
+  createIssue(
+    owner: string,
+    repo: string,
+    fields: { title: string; body: string; labels?: string[] },
+    token: string,
+  ): Promise<number>;
 }
 
 /**
@@ -94,6 +116,74 @@ export class RealGitHubService implements GitHubService {
   ): Promise<{ config: ReviewConfig; parseError: boolean }> {
     return loadReviewConfigImpl(owner, repo, baseRef, prNumber, token, this.logger);
   }
+
+  async updateIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    updates: { title?: string; body?: string; labels?: string[] },
+    token: string,
+  ): Promise<void> {
+    const response = await githubFetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${number}`,
+      {
+        method: 'PATCH',
+        token,
+        body: JSON.stringify(updates),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to update issue #${number}: ${response.status} ${response.statusText}`,
+      );
+    }
+  }
+
+  async fetchIssueBody(
+    owner: string,
+    repo: string,
+    number: number,
+    token: string,
+  ): Promise<string | null> {
+    const response = await githubFetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${number}`,
+      { token },
+    );
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch issue #${number}: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as { body: string | null };
+    return data.body ?? null;
+  }
+
+  async createIssue(
+    owner: string,
+    repo: string,
+    fields: { title: string; body: string; labels?: string[] },
+    token: string,
+  ): Promise<number> {
+    const response = await githubFetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      token,
+      body: JSON.stringify(fields),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create issue: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as { number: number };
+    return data.number;
+  }
 }
 
 /**
@@ -144,5 +234,37 @@ export class NoOpGitHubService implements GitHubService {
   async loadReviewConfig(): Promise<{ config: ReviewConfig; parseError: boolean }> {
     this.logger.info('Dev mode — using default review config');
     return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
+  }
+
+  async updateIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    updates: { title?: string; body?: string; labels?: string[] },
+  ): Promise<void> {
+    this.logger.info('Dev mode — skipping issue update', {
+      owner,
+      repo,
+      number,
+      updates: Object.keys(updates),
+    });
+  }
+
+  async fetchIssueBody(owner: string, repo: string, number: number): Promise<string | null> {
+    this.logger.info('Dev mode — returning mock issue body', { owner, repo, number });
+    return `Mock issue body for #${number}`;
+  }
+
+  async createIssue(
+    owner: string,
+    repo: string,
+    fields: { title: string; body: string; labels?: string[] },
+  ): Promise<number> {
+    this.logger.info('Dev mode — skipping issue creation', {
+      owner,
+      repo,
+      title: fields.title,
+    });
+    return 0;
   }
 }


### PR DESCRIPTION
Part of #504

## Summary
- Added `updateIssue`, `fetchIssueBody`, `createIssue` to `GitHubService` interface
- Implemented in `RealGitHubService` using `githubFetch` with proper error handling (404 returns null for fetchIssueBody, throws on other errors)
- Implemented stubs in `NoOpGitHubService` and `MockGitHubService`
- Updated all inline `GitHubService` implementations in test files (webhook-503, coverage-gaps)
- Added 11 new tests covering all three methods for both Real and NoOp implementations

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (1616 tests, 61 test files)
- [x] `pnpm lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes