### PR TITLE
[server-dev] Webhook refactor — separate task creation + issue event handler

### DIFF
--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -6,7 +6,7 @@
  * - index.ts: error handler and 404
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG, DEFAULT_OPENCARA_CONFIG } from '@opencara/shared';
 import type { GitHubService } from '../github/service.js';
 
 const originalFetch = globalThis.fetch;
@@ -480,7 +480,7 @@ describe('webhook.ts edge cases', () => {
   });
 
   it('PR event with .opencara.toml parse error returns 503', async () => {
-    // Inject a GitHubService that returns parseError: true from loadReviewConfig
+    // Inject a GitHubService that returns parseError: true from loadOpenCaraConfig
     const parseErrorGithub: GitHubService = {
       async getInstallationToken() {
         return 'ghs_test';
@@ -493,6 +493,9 @@ describe('webhook.ts edge cases', () => {
       },
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: true };
+      },
+      async loadOpenCaraConfig() {
+        return { config: DEFAULT_OPENCARA_CONFIG, parseError: true };
       },
       async updateIssue() {},
       async fetchIssueBody() {
@@ -541,6 +544,9 @@ describe('webhook.ts edge cases', () => {
       },
       async loadReviewConfig() {
         return { config: DEFAULT_REVIEW_CONFIG, parseError: true };
+      },
+      async loadOpenCaraConfig() {
+        return { config: DEFAULT_OPENCARA_CONFIG, parseError: true };
       },
       async updateIssue() {},
       async fetchIssueBody() {

--- a/packages/server/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/server/src/__tests__/e2e-scenarios.test.ts
@@ -148,79 +148,51 @@ describe('E2E Scenarios', () => {
   // ═══════════════════════════════════════════════════════════
 
   describe('B. Multi-Agent Lifecycle', () => {
-    it('2 reviewers → submit → synthesizer claims with reviews → submits → posted', async () => {
-      const taskId = await injectPR({ reviewCount: 3 });
+    it('2 reviewers each claim separate review tasks (new separate task model)', async () => {
+      // reviewCount=3 → creates 2 separate review tasks (3-1=2)
+      await injectPR({ reviewCount: 3 });
       const r1 = agent('reviewer-1');
       const r2 = agent('reviewer-2');
-      const synth = agent('synthesizer');
 
-      // Both reviewers poll — see review role
+      // Both reviewers poll — see 2 review tasks
       const r1Tasks = await r1.poll();
+      expect(r1Tasks).toHaveLength(2);
       expect(r1Tasks[0].role).toBe('review');
-      const r2Tasks = await r2.poll();
-      expect(r2Tasks[0].role).toBe('review');
+      expect(r1Tasks[1].role).toBe('review');
 
-      // Both claim review
-      const c1 = await r1.claim(taskId, 'review');
+      // Each reviewer claims a different task
+      const task1Id = r1Tasks[0].task_id;
+      const task2Id = r1Tasks[1].task_id;
+      expect(task1Id).not.toBe(task2Id);
+
+      const c1 = await r1.claim(task1Id, 'review');
       expect(c1.claimed).toBe(true);
-      const c2 = await r2.claim(taskId, 'review');
+      const c2 = await r2.claim(task2Id, 'review');
       expect(c2.claimed).toBe(true);
 
-      // Synthesizer polls — nothing yet (reviews not complete)
-      let synthTasks = await synth.poll();
-      expect(synthTasks).toHaveLength(0);
-
-      // Reviewer 1 submits
-      await r1.submitResult(
-        taskId,
+      // Each submits to their own task
+      const r1Result = await r1.submitResult(
+        task1Id,
         'review',
         'The implementation follows established patterns and conventions well.',
         'approve',
         500,
       );
+      expect(r1Result.status).toBe(200);
 
-      // Still no summary (only 1 of 2 reviews done)
-      synthTasks = await synth.poll();
-      expect(synthTasks).toHaveLength(0);
-
-      // Reviewer 2 submits
-      await r2.submitResult(
-        taskId,
+      const r2Result = await r2.submitResult(
+        task2Id,
         'review',
         'Error handling improvements needed throughout the modified code paths.',
         'request_changes',
         600,
       );
+      expect(r2Result.status).toBe(200);
 
-      // Summary now available
-      synthTasks = await synth.poll();
-      expect(synthTasks).toHaveLength(1);
-      expect(synthTasks[0].role).toBe('summary');
-
-      // Synthesizer claims — receives prior reviews
-      const synthClaim = await synth.claim(taskId, 'summary');
-      expect(synthClaim.claimed).toBe(true);
-      if (synthClaim.claimed) {
-        expect(synthClaim.reviews).toHaveLength(2);
-        const agents = synthClaim.reviews!.map((r) => r.agent_id).sort();
-        expect(agents).toEqual(['reviewer-1', 'reviewer-2']);
-      }
-
-      // Synthesizer submits
-      const result = await synth.submitResult(
-        taskId,
-        'summary',
-        VALID_SUMMARY_TEXT,
-        undefined,
-        900,
-      );
-      expect(result.status).toBe(200);
-
-      // Task and claims deleted after successful post
-      const finalTask = await store.getTask(taskId);
-      expect(finalTask).toBeNull();
-      const claims = await store.getClaims(taskId);
-      expect(claims).toHaveLength(0);
+      // Both tasks share the same group_id (separate from task IDs)
+      const allTasks = await store.listTasks();
+      const groupIds = new Set(allTasks.map((t) => t.group_id));
+      expect(groupIds.size).toBe(1);
     });
 
     it('third agent cannot claim review when all slots taken', async () => {
@@ -304,26 +276,26 @@ describe('E2E Scenarios', () => {
   // ═══════════════════════════════════════════════════════════
 
   describe('D. Error Recovery', () => {
-    it('claim → error → slot freed → new agent claims → completes', async () => {
-      const taskId = await injectPR({ reviewCount: 3 });
+    it('claim → error → task freed → new agent claims → completes', async () => {
+      // reviewCount=3 → 2 separate review tasks
+      const firstTaskId = await injectPR({ reviewCount: 3 });
       const crasher = agent('crasher');
       const replacement = agent('replacement');
 
-      // Agent crashes
-      await crasher.claim(taskId, 'review');
-      const errRes = await crasher.reportError(taskId, 'SIGSEGV');
+      // Agent crashes on first task
+      await crasher.claim(firstTaskId, 'review');
+      const errRes = await crasher.reportError(firstTaskId, 'SIGSEGV');
       expect(errRes.status).toBe(200);
 
-      // Slot freed
-      const task = await store.getTask(taskId);
-      expect(task?.review_claims).toBe(0);
-
-      // Replacement agent claims
+      // Replacement agent polls — sees both review tasks (freed one + unclaimed one)
       const tasks = await replacement.poll();
-      expect(tasks).toHaveLength(1);
-      expect(tasks[0].role).toBe('review');
+      expect(tasks).toHaveLength(2);
+      for (const t of tasks) {
+        expect(t.role).toBe('review');
+      }
 
-      const c = await replacement.claim(taskId, 'review');
+      // Replacement claims the freed task
+      const c = await replacement.claim(firstTaskId, 'review');
       expect(c.claimed).toBe(true);
     });
 
@@ -694,30 +666,32 @@ describe('E2E Scenarios', () => {
 
   describe('J. review_only Flag', () => {
     it('agent with review_only sees only review tasks, not summary', async () => {
-      // review_count=1 → only summary role
+      // review_count=1 → only summary role (1 task)
       await injectPR({ prNumber: 1, reviewCount: 1 });
-      // review_count=3 → review role
+      // review_count=3 → review role (2 tasks: 3-1=2)
       await injectPR({ prNumber: 2, reviewCount: 3 });
 
       const a = agent('review-only-agent');
 
-      // With review_only: should only see the review task
+      // With review_only: should only see the review tasks (2 tasks from PR#2)
       const reviewTasks = await a.poll({ reviewOnly: true });
-      expect(reviewTasks).toHaveLength(1);
-      expect(reviewTasks[0].pr_number).toBe(2);
-      expect(reviewTasks[0].role).toBe('review');
+      expect(reviewTasks).toHaveLength(2);
+      for (const t of reviewTasks) {
+        expect(t.pr_number).toBe(2);
+        expect(t.role).toBe('review');
+      }
     });
 
     it('agent without review_only sees both review and summary tasks', async () => {
-      await injectPR({ prNumber: 1, reviewCount: 1 }); // summary only
-      await injectPR({ prNumber: 2, reviewCount: 3 }); // review
+      await injectPR({ prNumber: 1, reviewCount: 1 }); // summary only (1 task)
+      await injectPR({ prNumber: 2, reviewCount: 3 }); // review (2 tasks: 3-1=2)
 
       const a = agent('any-agent');
       const tasks = await a.poll();
-      expect(tasks).toHaveLength(2);
+      expect(tasks).toHaveLength(3); // 1 summary + 2 review
 
       const roles = tasks.map((t) => t.role).sort();
-      expect(roles).toEqual(['review', 'summary']);
+      expect(roles).toEqual(['review', 'review', 'summary']);
     });
   });
 

--- a/packages/server/src/__tests__/helpers/github-mock.ts
+++ b/packages/server/src/__tests__/helpers/github-mock.ts
@@ -5,8 +5,8 @@
  * - MockGitHubService: Implements GitHubService interface with call tracking
  */
 import { vi } from 'vitest';
-import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
-import type { ReviewConfig } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG, DEFAULT_OPENCARA_CONFIG } from '@opencara/shared';
+import type { ReviewConfig, OpenCaraConfig } from '@opencara/shared';
 import type { GitHubService, PrDetails } from '../../github/service.js';
 
 export interface GitHubCall {
@@ -164,6 +164,23 @@ export class MockGitHubService implements GitHubService {
       args: { owner, repo, baseRef, prNumber, token },
     });
     return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
+  }
+
+  /** Override to return custom OpenCaraConfig in tests */
+  openCaraConfig: OpenCaraConfig = DEFAULT_OPENCARA_CONFIG;
+  openCaraConfigParseError = false;
+
+  async loadOpenCaraConfig(
+    owner: string,
+    repo: string,
+    ref: string,
+    token: string,
+  ): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    this.calls.push({
+      method: 'loadOpenCaraConfig',
+      args: { owner, repo, ref, token },
+    });
+    return { config: this.openCaraConfig, parseError: this.openCaraConfigParseError };
   }
 
   async updateIssue(

--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -880,10 +880,10 @@ describe('Integration: full E2E flows', () => {
         mockEnv,
       );
 
-      // The loadReviewConfig call should use base ref (main), not head ref (feat/malicious-config)
-      const configFetch = githubCalls.find((c) => c.method === 'loadReviewConfig');
+      // The loadOpenCaraConfig call should use base ref (main), not head ref (feat/malicious-config)
+      const configFetch = githubCalls.find((c) => c.method === 'loadOpenCaraConfig');
       expect(configFetch).toBeDefined();
-      expect(configFetch!.args.baseRef).toBe('main');
+      expect(configFetch!.args.ref).toBe('main');
     });
 
     it('invalid signature is rejected with 401', async () => {

--- a/packages/server/src/__tests__/webhook-503.test.ts
+++ b/packages/server/src/__tests__/webhook-503.test.ts
@@ -6,8 +6,8 @@
  * skips (draft PRs, action not in trigger list, no installation) return 200 OK.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
-import type { ReviewConfig } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG, DEFAULT_OPENCARA_CONFIG } from '@opencara/shared';
+import type { ReviewConfig, OpenCaraConfig } from '@opencara/shared';
 import type { GitHubService, PrDetails } from '../github/service.js';
 import { MemoryDataStore } from '../store/memory.js';
 import { createApp } from '../index.js';
@@ -48,6 +48,7 @@ class FailableGitHubService implements GitHubService {
   tokenError: Error | null = null;
   parseError = false;
   configOverride: ReviewConfig | null = null;
+  openCaraConfigOverride: OpenCaraConfig | null = null;
   fetchPrResult: PrDetails | null = {
     number: 1,
     html_url: 'https://github.com/acme/widget/pull/1',
@@ -89,6 +90,23 @@ class FailableGitHubService implements GitHubService {
     _token: string,
   ): Promise<{ config: ReviewConfig; parseError: boolean }> {
     return { config: this.configOverride ?? DEFAULT_REVIEW_CONFIG, parseError: this.parseError };
+  }
+
+  async loadOpenCaraConfig(
+    _owner: string,
+    _repo: string,
+    _ref: string,
+    _token: string,
+  ): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    if (this.openCaraConfigOverride) {
+      return { config: this.openCaraConfigOverride, parseError: this.parseError };
+    }
+    // Build from configOverride/default for backward compat
+    const review = this.configOverride ?? DEFAULT_REVIEW_CONFIG;
+    return {
+      config: { ...DEFAULT_OPENCARA_CONFIG, review },
+      parseError: this.parseError,
+    };
   }
 
   async updateIssue(): Promise<void> {}

--- a/packages/server/src/__tests__/webhook-refactor.test.ts
+++ b/packages/server/src/__tests__/webhook-refactor.test.ts
@@ -1,0 +1,824 @@
+/**
+ * Tests for webhook refactor — separate task creation + issue event handler.
+ *
+ * Covers:
+ * - PR webhook creates separate review tasks (not one multi-claim task)
+ * - Per-agent prompts assigned correctly from config
+ * - Dedup PR tasks alongside review tasks
+ * - Issue webhook creates triage + dedup tasks when enabled
+ * - Issue events with pull_request field are skipped
+ * - createTaskIfNotExists works for issue-based dedup
+ * - Group IDs generated and linked correctly
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_REVIEW_CONFIG,
+  DEFAULT_OPENCARA_CONFIG,
+  type OpenCaraConfig,
+  type ReviewConfig,
+  type ReviewSectionConfig,
+} from '@opencara/shared';
+import type { GitHubService, PrDetails } from '../github/service.js';
+import { MemoryDataStore } from '../store/memory.js';
+import { createApp } from '../index.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+import { createTaskGroup, createTaskForPR, MAX_PROMPT_LENGTH } from '../routes/webhook.js';
+import { Logger } from '../logger.js';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+function getMockEnv() {
+  return {
+    GITHUB_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: 'unused-in-mock',
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+/**
+ * Configurable mock GitHubService for webhook tests.
+ */
+class TestGitHubService implements GitHubService {
+  openCaraConfig: OpenCaraConfig = DEFAULT_OPENCARA_CONFIG;
+  openCaraConfigParseError = false;
+  reviewConfig: ReviewConfig = DEFAULT_REVIEW_CONFIG;
+  reviewConfigParseError = false;
+  fetchPrResult: PrDetails | null = {
+    number: 1,
+    html_url: 'https://github.com/acme/widget/pull/1',
+    diff_url: 'https://github.com/acme/widget/pull/1.diff',
+    base: { ref: 'main' },
+    head: { ref: 'feat/test' },
+    draft: false,
+    labels: [],
+  };
+
+  async getInstallationToken(_installationId: number): Promise<string> {
+    return 'ghs_mock_token';
+  }
+
+  async postPrComment(): Promise<string> {
+    return 'https://github.com/test/repo/pull/1#comment-mock';
+  }
+
+  async fetchPrDetails(): Promise<PrDetails | null> {
+    return this.fetchPrResult;
+  }
+
+  async loadReviewConfig(): Promise<{ config: ReviewConfig; parseError: boolean }> {
+    return { config: this.reviewConfig, parseError: this.reviewConfigParseError };
+  }
+
+  async loadOpenCaraConfig(): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    return { config: this.openCaraConfig, parseError: this.openCaraConfigParseError };
+  }
+
+  async updateIssue(): Promise<void> {}
+  async fetchIssueBody(): Promise<string | null> {
+    return null;
+  }
+  async createIssue(): Promise<number> {
+    return 0;
+  }
+}
+
+function makePRPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 999 },
+    repository: { owner: { login: 'acme' }, name: 'widget', default_branch: 'main' },
+    pull_request: {
+      number: 42,
+      html_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base: { ref: 'main' },
+      head: { ref: 'feat/test' },
+      draft: false,
+      labels: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeIssuePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 999 },
+    repository: { owner: { login: 'acme' }, name: 'widget', default_branch: 'main' },
+    issue: {
+      number: 10,
+      html_url: 'https://github.com/acme/widget/issues/10',
+      title: 'Bug: something is broken',
+      body: 'Steps to reproduce...',
+      user: { login: 'alice' },
+    },
+    ...overrides,
+  };
+}
+
+async function sendWebhook(
+  app: ReturnType<typeof createApp>,
+  event: string,
+  payload: unknown,
+  env: ReturnType<typeof getMockEnv>,
+) {
+  const body = JSON.stringify(payload);
+  const signature = await signPayload(body, WEBHOOK_SECRET);
+  return app.request(
+    '/webhook/github',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': event,
+      },
+      body,
+    },
+    env,
+  );
+}
+
+function makeReviewConfig(overrides: Partial<ReviewSectionConfig> = {}): ReviewSectionConfig {
+  return { ...DEFAULT_REVIEW_CONFIG, ...overrides };
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('Webhook refactor — separate task creation', () => {
+  let store: MemoryDataStore;
+  let github: TestGitHubService;
+  let app: ReturnType<typeof createApp>;
+  let env: ReturnType<typeof getMockEnv>;
+  let logger: Logger;
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    github = new TestGitHubService();
+    app = createApp(store, github);
+    env = getMockEnv();
+    logger = new Logger('test');
+  });
+
+  // ── createTaskGroup unit tests ──────────────────────────────
+
+  describe('createTaskGroup', () => {
+    const baseTask = {
+      owner: 'acme',
+      repo: 'widget',
+      pr_number: 42,
+      pr_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base_ref: 'main',
+      head_ref: 'feat/test',
+      review_count: 1,
+      timeout_at: Date.now() + 600_000,
+      status: 'pending' as const,
+      queue: 'summary' as const,
+      github_installation_id: 999,
+      private: false,
+      config: DEFAULT_REVIEW_CONFIG,
+      created_at: Date.now(),
+    };
+
+    it('creates 1 summary task when agentCount == 1', async () => {
+      const config = makeReviewConfig({ agentCount: 1 });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+
+      expect(groupId).not.toBeNull();
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].task_type).toBe('summary');
+      expect(tasks[0].feature).toBe('review');
+      expect(tasks[0].group_id).toBe(groupId);
+    });
+
+    it('creates (agentCount - 1) review tasks when agentCount > 1', async () => {
+      const config = makeReviewConfig({ agentCount: 3 });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+
+      expect(groupId).not.toBeNull();
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2); // 3 - 1 = 2
+      for (const task of tasks) {
+        expect(task.task_type).toBe('review');
+        expect(task.feature).toBe('review');
+        expect(task.group_id).toBe(groupId);
+      }
+    });
+
+    it('assigns per-agent prompts from config.agents', async () => {
+      const config = makeReviewConfig({
+        agentCount: 4,
+        prompt: 'Default prompt',
+        agents: [
+          { prompt: 'Agent 0 prompt' },
+          { prompt: 'Agent 1 prompt' },
+          // Agent 2 has no prompt override — falls back to default
+        ],
+      });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(groupId).not.toBeNull();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(3); // 4 - 1 = 3
+      // Sort by creation order (tasks are created sequentially)
+      tasks.sort((a, b) => a.created_at - b.created_at);
+      expect(tasks[0].prompt).toBe('Agent 0 prompt');
+      expect(tasks[1].prompt).toBe('Agent 1 prompt');
+      expect(tasks[2].prompt).toBe('Default prompt'); // falls back
+    });
+
+    it('returns null when prompt exceeds MAX_PROMPT_LENGTH', async () => {
+      const config = makeReviewConfig({ prompt: 'x'.repeat(MAX_PROMPT_LENGTH + 1) });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(groupId).toBeNull();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('returns null on duplicate (idempotency)', async () => {
+      const config = makeReviewConfig({ agentCount: 1 });
+      const first = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(first).not.toBeNull();
+
+      const second = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(second).toBeNull();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+
+    it('all tasks in group share the same group_id', async () => {
+      const config = makeReviewConfig({ agentCount: 5 });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(groupId).not.toBeNull();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(4); // 5 - 1 = 4
+      const groupIds = new Set(tasks.map((t) => t.group_id));
+      expect(groupIds.size).toBe(1);
+      expect(groupIds.has(groupId!)).toBe(true);
+    });
+
+    it('each task gets a unique ID', async () => {
+      const config = makeReviewConfig({ agentCount: 4 });
+      await createTaskGroup(store, 'review', config, baseTask, logger);
+
+      const tasks = await store.listTasks();
+      const ids = new Set(tasks.map((t) => t.id));
+      expect(ids.size).toBe(3); // All unique
+    });
+
+    it('creates dedup tasks with extra fields', async () => {
+      const dedupConfig = makeReviewConfig({ agentCount: 2, prompt: 'Check for duplicates' });
+      const groupId = await createTaskGroup(store, 'dedup_pr', dedupConfig, baseTask, logger, {
+        dedup_target: 'pr',
+        index_issue_number: 99,
+      });
+
+      expect(groupId).not.toBeNull();
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1); // 2 - 1 = 1
+      expect(tasks[0].feature).toBe('dedup_pr');
+      expect(tasks[0].dedup_target).toBe('pr');
+      expect(tasks[0].index_issue_number).toBe(99);
+    });
+  });
+
+  // ── createTaskForPR backward compat ─────────────────────────
+
+  describe('createTaskForPR (backward compat)', () => {
+    it('creates a task group for a PR', async () => {
+      const groupId = await createTaskForPR(
+        store,
+        999,
+        'acme',
+        'widget',
+        42,
+        'https://github.com/acme/widget/pull/42',
+        'https://github.com/acme/widget/pull/42.diff',
+        'main',
+        'feat/test',
+        DEFAULT_REVIEW_CONFIG,
+        false,
+        logger,
+      );
+
+      expect(groupId).not.toBeNull();
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+      expect(tasks[0].task_type).toBe('summary');
+    });
+
+    it('returns null on duplicate', async () => {
+      await createTaskForPR(
+        store,
+        999,
+        'acme',
+        'widget',
+        42,
+        'https://github.com/acme/widget/pull/42',
+        'https://github.com/acme/widget/pull/42.diff',
+        'main',
+        'feat/test',
+        DEFAULT_REVIEW_CONFIG,
+        false,
+        logger,
+      );
+
+      const second = await createTaskForPR(
+        store,
+        999,
+        'acme',
+        'widget',
+        42,
+        'https://github.com/acme/widget/pull/42',
+        'https://github.com/acme/widget/pull/42.diff',
+        'main',
+        'feat/test',
+        DEFAULT_REVIEW_CONFIG,
+        false,
+        logger,
+      );
+
+      expect(second).toBeNull();
+    });
+  });
+
+  // ── PR webhook with multi-agent ─────────────────────────────
+
+  describe('PR webhook — multi-agent task creation', () => {
+    it('creates separate review tasks for agentCount=3', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 3 }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2); // 3 - 1 = 2
+      for (const task of tasks) {
+        expect(task.task_type).toBe('review');
+        expect(task.feature).toBe('review');
+      }
+      // All share the same group_id
+      const groupIds = new Set(tasks.map((t) => t.group_id));
+      expect(groupIds.size).toBe(1);
+    });
+
+    it('creates 1 summary task for agentCount=1', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 1 }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].task_type).toBe('summary');
+    });
+
+    it('assigns per-agent prompts in PR webhook', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          agentCount: 3,
+          prompt: 'Default review prompt',
+          agents: [{ prompt: 'Security-focused review' }, { prompt: 'Performance review' }],
+        }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+      const prompts = tasks.map((t) => t.prompt).sort();
+      expect(prompts).toContain('Security-focused review');
+      expect(prompts).toContain('Performance review');
+    });
+  });
+
+  // ── PR webhook with dedup.prs ───────────────────────────────
+
+  describe('PR webhook — dedup PR tasks', () => {
+    it('creates dedup tasks alongside review tasks when dedup.prs.enabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 2 }),
+        dedup: {
+          prs: {
+            enabled: true,
+            prompt: 'Check for duplicate PRs',
+            agentCount: 1,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      // 1 review task (2 - 1) + 1 dedup task
+      expect(tasks).toHaveLength(2);
+
+      const reviewTasks = tasks.filter((t) => t.feature === 'review');
+      const dedupTasks = tasks.filter((t) => t.feature === 'dedup_pr');
+      expect(reviewTasks).toHaveLength(1);
+      expect(dedupTasks).toHaveLength(1);
+
+      // Different group IDs
+      expect(reviewTasks[0].group_id).not.toBe(dedupTasks[0].group_id);
+
+      // Dedup task properties
+      expect(dedupTasks[0].dedup_target).toBe('pr');
+      expect(dedupTasks[0].task_type).toBe('summary');
+    });
+
+    it('skips dedup tasks when dedup.prs.enabled is false', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 1 }),
+        dedup: {
+          prs: {
+            enabled: false,
+            prompt: 'Check for duplicate PRs',
+            agentCount: 1,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+    });
+
+    it('sets index_issue_number on dedup tasks when configured', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 1 }),
+        dedup: {
+          prs: {
+            enabled: true,
+            prompt: 'Check for duplicate PRs',
+            agentCount: 1,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+            indexIssue: 42,
+          },
+        },
+      };
+
+      await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      const tasks = await store.listTasks();
+      const dedupTask = tasks.find((t) => t.feature === 'dedup_pr');
+      expect(dedupTask).toBeDefined();
+      expect(dedupTask!.index_issue_number).toBe(42);
+    });
+  });
+
+  // ── Issue webhook handler ───────────────────────────────────
+
+  describe('Issue webhook — handleIssueEvent', () => {
+    it('skips when issue has pull_request field (is a PR)', async () => {
+      const payload = makeIssuePayload({
+        issue: {
+          number: 10,
+          html_url: 'https://github.com/acme/widget/issues/10',
+          title: 'Bug',
+          body: 'Body',
+          user: { login: 'alice' },
+          pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/10' },
+        },
+      });
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('skips when action is not opened/edited', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this issue',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'],
+        },
+      };
+
+      const payload = makeIssuePayload({ action: 'closed' });
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('skips when no installation is present', async () => {
+      const payload = makeIssuePayload({ installation: undefined });
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('skips when no issue features are enabled', async () => {
+      github.openCaraConfig = { version: 1 }; // no triage, no dedup
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('creates triage task when triage.enabled and action in triage.triggers', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this issue',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+      expect(tasks[0].task_type).toBe('summary');
+      expect(tasks[0].issue_number).toBe(10);
+      expect(tasks[0].issue_title).toBe('Bug: something is broken');
+      expect(tasks[0].issue_body).toBe('Steps to reproduce...');
+      expect(tasks[0].issue_author).toBe('alice');
+      expect(tasks[0].pr_number).toBe(0); // Not a PR
+    });
+
+    it('creates dedup issue task when dedup.issues.enabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        dedup: {
+          issues: {
+            enabled: true,
+            prompt: 'Check for duplicate issues',
+            agentCount: 1,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+            indexIssue: 5,
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('dedup_issue');
+      expect(tasks[0].dedup_target).toBe('issue');
+      expect(tasks[0].index_issue_number).toBe(5);
+      expect(tasks[0].issue_number).toBe(10);
+    });
+
+    it('creates both triage and dedup tasks when both enabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this issue',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'],
+        },
+        dedup: {
+          issues: {
+            enabled: true,
+            prompt: 'Check for duplicates',
+            agentCount: 1,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+
+      const triageTask = tasks.find((t) => t.feature === 'triage');
+      const dedupTask = tasks.find((t) => t.feature === 'dedup_issue');
+      expect(triageTask).toBeDefined();
+      expect(dedupTask).toBeDefined();
+
+      // Different group IDs
+      expect(triageTask!.group_id).not.toBe(dedupTask!.group_id);
+    });
+
+    it('does not create triage task when action not in triggers', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this issue',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'], // only 'opened'
+        },
+      };
+
+      const payload = makeIssuePayload({ action: 'edited' });
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('creates triage task for edited action when in triggers', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this issue',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened', 'edited'],
+        },
+      };
+
+      const payload = makeIssuePayload({ action: 'edited' });
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+    });
+
+    it('handles issue with null body', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'],
+        },
+      };
+
+      const payload = makeIssuePayload({
+        issue: {
+          number: 10,
+          html_url: 'https://github.com/acme/widget/issues/10',
+          title: 'No body issue',
+          body: null,
+          user: { login: 'alice' },
+        },
+      });
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].issue_body).toBeUndefined();
+    });
+
+    it('returns 503 when config parse fails', async () => {
+      github.openCaraConfigParseError = true;
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          enabled: true,
+          prompt: 'Triage this',
+          agentCount: 1,
+          timeout: '10m',
+          preferredModels: [],
+          preferredTools: [],
+          defaultMode: 'comment',
+          autoLabel: false,
+          triggers: ['opened'],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── Multi-agent dedup issue tasks ───────────────────────────
+
+  describe('Issue webhook — multi-agent dedup', () => {
+    it('creates multiple dedup tasks when agentCount > 1', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        dedup: {
+          issues: {
+            enabled: true,
+            prompt: 'Check for duplicates',
+            agentCount: 3,
+            timeout: '10m',
+            preferredModels: [],
+            preferredTools: [],
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssuePayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2); // 3 - 1 = 2
+      for (const task of tasks) {
+        expect(task.feature).toBe('dedup_issue');
+        expect(task.task_type).toBe('review');
+      }
+    });
+  });
+
+  // ── Group queries ───────────────────────────────────────────
+
+  describe('Group ID queries', () => {
+    it('getTasksByGroup returns all tasks in a group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({ agentCount: 4 }),
+      };
+
+      await sendWebhook(app, 'pull_request', makePRPayload(), env);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(3); // 4 - 1 = 3
+
+      const groupId = tasks[0].group_id;
+      const groupTasks = await store.getTasksByGroup(groupId);
+      expect(groupTasks).toHaveLength(3);
+    });
+  });
+});

--- a/packages/server/src/github/service.ts
+++ b/packages/server/src/github/service.ts
@@ -7,10 +7,11 @@ import { postPrComment } from './reviews.js';
 import {
   fetchPrDetails,
   loadReviewConfig as loadReviewConfigImpl,
+  loadOpenCaraConfig as loadOpenCaraConfigImpl,
   type PrDetails,
 } from './config.js';
-import type { ReviewConfig } from '@opencara/shared';
-import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import type { ReviewConfig, OpenCaraConfig } from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG, DEFAULT_OPENCARA_CONFIG } from '@opencara/shared';
 
 export type { PrDetails } from './config.js';
 
@@ -43,6 +44,12 @@ export interface GitHubService {
     prNumber: number,
     token: string,
   ): Promise<{ config: ReviewConfig; parseError: boolean }>;
+  loadOpenCaraConfig(
+    owner: string,
+    repo: string,
+    ref: string,
+    token: string,
+  ): Promise<{ config: OpenCaraConfig; parseError: boolean }>;
 
   // Issue management
   updateIssue(
@@ -115,6 +122,16 @@ export class RealGitHubService implements GitHubService {
     token: string,
   ): Promise<{ config: ReviewConfig; parseError: boolean }> {
     return loadReviewConfigImpl(owner, repo, baseRef, prNumber, token, this.logger);
+  }
+
+  async loadOpenCaraConfig(
+    owner: string,
+    repo: string,
+    ref: string,
+    token: string,
+  ): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    // Note: prNumber=0 is a dummy — loadOpenCaraConfig doesn't post PR comments for issue events
+    return loadOpenCaraConfigImpl(owner, repo, ref, 0, token, this.logger);
   }
 
   async updateIssue(
@@ -234,6 +251,11 @@ export class NoOpGitHubService implements GitHubService {
   async loadReviewConfig(): Promise<{ config: ReviewConfig; parseError: boolean }> {
     this.logger.info('Dev mode — using default review config');
     return { config: DEFAULT_REVIEW_CONFIG, parseError: false };
+  }
+
+  async loadOpenCaraConfig(): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    this.logger.info('Dev mode — using default opencara config');
+    return { config: DEFAULT_OPENCARA_CONFIG, parseError: false };
   }
 
   async updateIssue(

--- a/packages/server/src/routes/test.ts
+++ b/packages/server/src/routes/test.ts
@@ -47,7 +47,7 @@ export function testRoutes() {
       ? { ...DEFAULT_REVIEW_CONFIG, ...body.config }
       : DEFAULT_REVIEW_CONFIG;
 
-    const taskId = await createTaskForPR(
+    const groupId = await createTaskForPR(
       store,
       installationId,
       owner,
@@ -62,11 +62,15 @@ export function testRoutes() {
       logger,
     );
 
-    if (!taskId) {
+    if (!groupId) {
       return c.json({ created: false, reason: 'Active task already exists for this PR' }, 200);
     }
 
-    return c.json({ created: true, task_id: taskId }, 201);
+    // Look up tasks in the group and return the first task's ID for backward compat
+    const groupTasks = await store.getTasksByGroup(groupId);
+    const firstTaskId = groupTasks.length > 0 ? groupTasks[0].id : groupId;
+
+    return c.json({ created: true, task_id: firstTaskId, group_id: groupId }, 201);
   });
 
   /**

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -1,5 +1,13 @@
 import { Hono } from 'hono';
-import type { ReviewConfig } from '@opencara/shared';
+import type {
+  ReviewConfig,
+  OpenCaraConfig,
+  FeatureConfig,
+  Feature,
+  TaskRole,
+  ReviewTask,
+} from '@opencara/shared';
+import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
@@ -16,7 +24,12 @@ export const MAX_PROMPT_LENGTH = 10_000;
 interface PullRequestPayload {
   action: string;
   installation?: { id: number };
-  repository: { owner: { login: string }; name: string; private?: boolean };
+  repository: {
+    owner: { login: string };
+    name: string;
+    default_branch?: string;
+    private?: boolean;
+  };
   pull_request: {
     number: number;
     html_url: string;
@@ -31,7 +44,12 @@ interface PullRequestPayload {
 interface IssueCommentPayload {
   action: string;
   installation?: { id: number };
-  repository: { owner: { login: string }; name: string; private?: boolean };
+  repository: {
+    owner: { login: string };
+    name: string;
+    default_branch?: string;
+    private?: boolean;
+  };
   issue: {
     number: number;
     pull_request?: { url: string };
@@ -40,6 +58,25 @@ interface IssueCommentPayload {
     body: string;
     user: { login: string };
     author_association: string;
+  };
+}
+
+interface IssuePayload {
+  action: string;
+  installation?: { id: number };
+  repository: {
+    owner: { login: string };
+    name: string;
+    default_branch?: string;
+    private?: boolean;
+  };
+  issue: {
+    number: number;
+    html_url: string;
+    title: string;
+    body: string | null;
+    user: { login: string };
+    pull_request?: { url: string };
   };
 }
 
@@ -86,12 +123,147 @@ function hexToBytes(hex: string): Uint8Array | null {
   return bytes;
 }
 
+// ── Task Group Creation ──────────────────────────────────────────
+
 /**
- * Create a task in the store for a PR. No diff fetching, no agent selection —
- * agents will poll and fetch diffs themselves.
+ * Get per-agent prompt for a given slot index.
+ * Task i → agents[i].prompt ?? feature.prompt
+ */
+function getAgentPrompt(feature: FeatureConfig, index: number): string {
+  return feature.agents?.[index]?.prompt ?? feature.prompt;
+}
+
+/**
+ * Get per-agent task_type: if agentCount > 1, worker tasks are 'review';
+ * if agentCount == 1, the single task is 'summary'.
+ */
+function getTaskRole(agentCount: number): TaskRole {
+  return agentCount > 1 ? 'review' : 'summary';
+}
+
+/**
+ * Build a base ReviewTask template with common fields. Caller fills in
+ * task-specific fields (id, prompt, task_type, feature, group_id).
+ */
+function buildBaseTask(
+  installationId: number,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  prUrl: string,
+  diffUrl: string,
+  baseRef: string,
+  headRef: string,
+  config: ReviewConfig,
+  isPrivate: boolean,
+  timeoutMs: number,
+): Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> {
+  const agentCount = config.agentCount;
+  return {
+    owner,
+    repo,
+    pr_number: prNumber,
+    pr_url: prUrl,
+    diff_url: diffUrl,
+    base_ref: baseRef,
+    head_ref: headRef,
+    review_count: agentCount,
+    timeout_at: Date.now() + timeoutMs,
+    status: 'pending',
+    queue: agentCount > 1 ? 'review' : 'summary',
+    github_installation_id: installationId,
+    private: isPrivate,
+    config,
+    created_at: Date.now(),
+  };
+}
+
+/**
+ * Create a group of tasks for a feature pipeline.
  *
- * Returns null if an active (pending/reviewing) task already exists for this PR
- * (idempotency guard against webhook redeliveries and rapid PR events).
+ * Uses createTaskIfNotExists for the first task (idempotency guard), then
+ * createTask for remaining tasks. Returns the group_id if the group was
+ * created, or null if a duplicate exists.
+ *
+ * When `skipDedup` is true, all tasks are created with createTask (no dedup check).
+ * Use this for secondary groups in the same webhook event (e.g., dedup group alongside
+ * review group) where the primary group already guards against duplicate webhooks.
+ */
+export async function createTaskGroup(
+  store: DataStore,
+  feature: Feature,
+  featureConfig: FeatureConfig,
+  baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'>,
+  logger: Logger,
+  extraFields?: Partial<ReviewTask>,
+  skipDedup?: boolean,
+): Promise<string | null> {
+  const agentCount = featureConfig.agentCount;
+  const taskCount = agentCount > 1 ? agentCount - 1 : 1;
+  const role = getTaskRole(agentCount);
+  const groupId = crypto.randomUUID();
+  const timeoutMs = parseTimeoutMs(featureConfig.timeout);
+
+  for (let i = 0; i < taskCount; i++) {
+    const taskId = crypto.randomUUID();
+    const prompt = getAgentPrompt(featureConfig, i);
+
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      logger.warn('Prompt exceeds MAX_PROMPT_LENGTH — skipping task group creation', {
+        feature,
+        promptLength: prompt.length,
+        maxLength: MAX_PROMPT_LENGTH,
+        slotIndex: i,
+      });
+      return null;
+    }
+
+    const task: ReviewTask = {
+      ...baseTask,
+      id: taskId,
+      prompt,
+      task_type: role,
+      feature,
+      group_id: groupId,
+      timeout_at: Date.now() + timeoutMs,
+      ...extraFields,
+    };
+
+    if (i === 0 && !skipDedup) {
+      // First task: atomic create-if-not-exists for idempotency
+      const created = await store.createTaskIfNotExists(task);
+      if (!created) {
+        logger.info('Task group already exists — skipping', {
+          feature,
+          owner: baseTask.owner,
+          repo: baseTask.repo,
+          prNumber: baseTask.pr_number,
+        });
+        return null;
+      }
+    } else {
+      await store.createTask(task);
+    }
+  }
+
+  logger.info('Task group created', {
+    groupId,
+    feature,
+    taskCount,
+    role,
+    owner: baseTask.owner,
+    repo: baseTask.repo,
+    prNumber: baseTask.pr_number,
+  });
+  return groupId;
+}
+
+/**
+ * Create review task group for a PR.
+ * Returns the group_id if created, null if duplicate.
+ *
+ * @deprecated Use createTaskGroup directly — kept for backward compatibility
+ * with existing tests.
  */
 export async function createTaskForPR(
   store: DataStore,
@@ -107,55 +279,166 @@ export async function createTaskForPR(
   isPrivate: boolean,
   logger: Logger,
 ): Promise<string | null> {
-  if (config.prompt.length > MAX_PROMPT_LENGTH) {
-    logger.warn('Prompt exceeds MAX_PROMPT_LENGTH — skipping task creation', {
-      owner,
-      repo,
-      prNumber,
-      promptLength: config.prompt.length,
-      maxLength: MAX_PROMPT_LENGTH,
-    });
-    return null;
-  }
-
-  const taskId = crypto.randomUUID();
   const timeoutMs = parseTimeoutMs(config.timeout);
-  const reviewCount = config.agentCount;
-
-  // Atomic create-if-not-exists: prevents duplicate tasks from concurrent webhook deliveries.
-  // The store checks for an existing active (pending/reviewing) task for this PR and inserts
-  // the new task in a single atomic operation — no read-then-write race window.
-  const created = await store.createTaskIfNotExists({
-    id: taskId,
+  const baseTask = buildBaseTask(
+    installationId,
     owner,
     repo,
-    pr_number: prNumber,
-    pr_url: prUrl,
-    diff_url: diffUrl,
-    base_ref: baseRef,
-    head_ref: headRef,
-    review_count: reviewCount,
-    prompt: config.prompt,
-    timeout_at: Date.now() + timeoutMs,
+    prNumber,
+    prUrl,
+    diffUrl,
+    baseRef,
+    headRef,
+    config,
+    isPrivate,
+    timeoutMs,
+  );
+  return createTaskGroup(store, 'review', config, baseTask, logger);
+}
+
+/**
+ * Create all task groups for a PR event: review + optional dedup.prs.
+ */
+async function createPrTaskGroups(
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  prUrl: string,
+  diffUrl: string,
+  baseRef: string,
+  headRef: string,
+  fullConfig: OpenCaraConfig,
+  isPrivate: boolean,
+  logger: Logger,
+): Promise<void> {
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+  const timeoutMs = parseTimeoutMs(reviewConfig.timeout);
+  const baseTask = buildBaseTask(
+    installationId,
+    owner,
+    repo,
+    prNumber,
+    prUrl,
+    diffUrl,
+    baseRef,
+    headRef,
+    reviewConfig,
+    isPrivate,
+    timeoutMs,
+  );
+
+  // Review task group (primary — uses createTaskIfNotExists for idempotency)
+  const reviewGroupId = await createTaskGroup(store, 'review', reviewConfig, baseTask, logger);
+
+  // Only create secondary groups if the primary group was created
+  // (if it returned null, a duplicate webhook already created the groups)
+  if (reviewGroupId === null) return;
+
+  // Dedup PR task group (secondary — skipDedup since review group already guards)
+  if (fullConfig.dedup?.prs?.enabled) {
+    const dedupConfig = fullConfig.dedup.prs;
+    await createTaskGroup(
+      store,
+      'dedup_pr',
+      dedupConfig,
+      baseTask,
+      logger,
+      {
+        dedup_target: 'pr',
+        ...(dedupConfig.indexIssue !== undefined
+          ? { index_issue_number: dedupConfig.indexIssue }
+          : {}),
+      },
+      true, // skipDedup — review group is the idempotency guard
+    );
+  }
+}
+
+/**
+ * Create task groups for an issue event: triage + dedup.issues.
+ */
+async function createIssueTaskGroups(
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  issue: IssuePayload['issue'],
+  fullConfig: OpenCaraConfig,
+  reviewConfig: ReviewConfig,
+  isPrivate: boolean,
+  action: string,
+  logger: Logger,
+): Promise<void> {
+  // Base task template for issue tasks (pr_number = 0, no diff)
+  const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+    owner,
+    repo,
+    pr_number: 0,
+    pr_url: '',
+    diff_url: '',
+    base_ref: '',
+    head_ref: '',
+    review_count: 1,
+    timeout_at: Date.now() + 10 * 60 * 1000,
     status: 'pending',
-    queue: reviewCount > 1 ? 'review' : 'summary',
-    task_type: 'review',
-    feature: 'review',
-    group_id: taskId,
+    queue: 'summary',
     github_installation_id: installationId,
     private: isPrivate,
-    config,
+    config: reviewConfig,
     created_at: Date.now(),
-  });
+  };
 
-  if (!created) {
-    logger.info('Task already exists for PR — skipping', { owner, repo, prNumber });
-    return null;
+  const issueFields: Partial<ReviewTask> = {
+    issue_number: issue.number,
+    issue_url: issue.html_url,
+    issue_title: issue.title,
+    issue_body: issue.body ?? undefined,
+    issue_author: issue.user.login,
+  };
+
+  // Create issue task groups. The first group uses createTaskIfNotExists
+  // for idempotency; subsequent groups skip dedup (the primary guards).
+  let primaryCreated = false;
+
+  // Triage task group
+  if (fullConfig.triage?.enabled && fullConfig.triage.triggers.includes(action)) {
+    const groupId = await createTaskGroup(
+      store,
+      'triage',
+      fullConfig.triage,
+      baseTask,
+      logger,
+      issueFields,
+      primaryCreated, // false on first call → uses createTaskIfNotExists
+    );
+    if (groupId !== null) primaryCreated = true;
+    else return; // Duplicate webhook — skip all remaining groups
   }
 
-  logger.info('Task created', { taskId, owner, repo, prNumber });
-  return taskId;
+  // Dedup issue task group
+  if (fullConfig.dedup?.issues?.enabled) {
+    const dedupIssueConfig = fullConfig.dedup.issues;
+    await createTaskGroup(
+      store,
+      'dedup_issue',
+      dedupIssueConfig,
+      baseTask,
+      logger,
+      {
+        ...issueFields,
+        dedup_target: 'issue',
+        ...(dedupIssueConfig.indexIssue !== undefined
+          ? { index_issue_number: dedupIssueConfig.indexIssue }
+          : {}),
+      },
+      primaryCreated, // true if triage group was created → skip dedup
+    );
+  }
 }
+
+// ── Webhook Routes ───────────────────────────────────────────────
 
 export function webhookRoutes() {
   const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
@@ -191,6 +474,8 @@ export function webhookRoutes() {
           action,
           logger,
         );
+      case 'issues':
+        return handleIssueEvent(github, store, payload as unknown as IssuePayload, action, logger);
       case 'issue_comment':
         if (action === 'created') {
           return handleIssueComment(
@@ -251,11 +536,10 @@ async function handlePullRequest(
   }
 
   const baseRef = pull_request.base.ref;
-  const { config, parseError } = await github.loadReviewConfig(
+  const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
     owner,
     repo,
     baseRef,
-    prNumber,
     token,
   );
 
@@ -264,16 +548,18 @@ async function handlePullRequest(
     return new Response('Service Unavailable', { status: 503 });
   }
 
-  if (!config.trigger.on.includes(action)) {
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+
+  if (!reviewConfig.trigger.on.includes(action)) {
     logger.info('Action not in trigger.on — skipping', {
       prNumber,
       action,
-      triggerOn: config.trigger.on,
+      triggerOn: reviewConfig.trigger.on,
     });
     return new Response('OK', { status: 200 });
   }
 
-  const skipReason = shouldSkipReview(config, {
+  const skipReason = shouldSkipReview(reviewConfig, {
     draft: pull_request.draft,
     labels: pull_request.labels,
     headRef,
@@ -284,7 +570,7 @@ async function handlePullRequest(
   }
 
   try {
-    await createTaskForPR(
+    await createPrTaskGroups(
       store,
       installation.id,
       owner,
@@ -294,16 +580,120 @@ async function handlePullRequest(
       pull_request.diff_url,
       pull_request.base.ref,
       headRef,
-      config,
+      fullConfig,
       repository.private ?? false,
       logger,
     );
   } catch (err) {
-    logger.error('Failed to create task for PR', {
+    logger.error('Failed to create task groups for PR', {
       error: err instanceof Error ? err.message : String(err),
       owner,
       repo,
       prNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+/**
+ * Handle GitHub `issues` webhook event.
+ * Creates triage and/or dedup task groups for new or edited issues.
+ */
+export async function handleIssueEvent(
+  github: GitHubService,
+  store: DataStore,
+  payload: IssuePayload,
+  action: string,
+  logger: Logger,
+): Promise<Response> {
+  const { installation, repository, issue } = payload;
+
+  if (!installation) {
+    logger.info('Issue event without installation — skipping');
+    return new Response('OK', { status: 200 });
+  }
+
+  // Skip issue events for pull requests (GitHub sends issues events for PRs too)
+  if (issue.pull_request) {
+    logger.info('Issue event is a PR — skipping', { issueNumber: issue.number });
+    return new Response('OK', { status: 200 });
+  }
+
+  if (action !== 'opened' && action !== 'edited') {
+    logger.info('Issue action not handled — skipping', { action, issueNumber: issue.number });
+    return new Response('OK', { status: 200 });
+  }
+
+  const owner = repository.owner.login;
+  const repo = repository.name;
+  const defaultBranch = repository.default_branch ?? 'main';
+
+  logger.info('Webhook received', {
+    event: 'issues',
+    owner,
+    repo,
+    issueNumber: issue.number,
+    action,
+  });
+
+  let token: string;
+  try {
+    token = await github.getInstallationToken(installation.id);
+  } catch (err) {
+    logger.error('Failed to get installation token', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
+    owner,
+    repo,
+    defaultBranch,
+    token,
+  );
+
+  if (parseError) {
+    logger.info('Aborting due to .opencara.toml parse error', {
+      issueNumber: issue.number,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+
+  // Check if any feature is enabled for issues
+  const triageEnabled = fullConfig.triage?.enabled && fullConfig.triage.triggers.includes(action);
+  const dedupIssuesEnabled = fullConfig.dedup?.issues?.enabled;
+
+  if (!triageEnabled && !dedupIssuesEnabled) {
+    logger.info('No issue features enabled — skipping', {
+      issueNumber: issue.number,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  try {
+    await createIssueTaskGroups(
+      store,
+      installation.id,
+      owner,
+      repo,
+      issue,
+      fullConfig,
+      reviewConfig,
+      repository.private ?? false,
+      action,
+      logger,
+    );
+  } catch (err) {
+    logger.error('Failed to create task groups for issue', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      issueNumber: issue.number,
     });
     return new Response('Service Unavailable', { status: 503 });
   }


### PR DESCRIPTION
Part of #505

## Summary
- Refactored `createTaskForPR` to create separate review tasks with `group_id` (1 task = 1 claim slot)
- `agentCount > 1` creates `(agentCount - 1)` review tasks; `agentCount == 1` creates 1 summary task
- Per-agent prompt assignment from `config.agents[i]?.prompt ?? config.prompt`
- New `createTaskGroup` helper for any feature pipeline (review, dedup, triage)
- `handlePullRequest` now uses `loadOpenCaraConfig` for full config access (dedup.prs support)
- Creates dedup PR task group alongside review group when `dedup.prs.enabled`
- New `handleIssueEvent` handler for `issues` webhook (triage + dedup tasks)
- Added `loadOpenCaraConfig` to `GitHubService` interface and all implementations
- Updated e2e tests for new separate task model
- 29 new webhook refactor tests

## Test plan
- All 1733 tests pass (63 files)
- Build, lint, typecheck, format all pass
- New `webhook-refactor.test.ts` covers: separate task creation, per-agent prompts, dedup PR/issue tasks, triage tasks, issue event guards, group ID linking
- Updated existing e2e tests for new multi-agent model