### PR TITLE
[server-dev] Drop unique index blocking multi-task groups, scope dedup by feature (#523)

### DIFF
--- a/packages/server/migrations/0014_multi_task_unique.sql
+++ b/packages/server/migrations/0014_multi_task_unique.sql
@@ -1,0 +1,6 @@
+-- Drop the old unique index that only allows 1 active task per PR.
+-- The M19 multi-task group model creates multiple active tasks per PR
+-- (one per agent slot), so this constraint must be removed.
+-- Application-layer dedup in createTaskIfNotExists (INSERT...WHERE NOT EXISTS)
+-- still prevents duplicate webhook-triggered groups.
+DROP INDEX IF EXISTS idx_tasks_active_pr;

--- a/packages/server/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/server/src/__tests__/sqlite-adapter.test.ts
@@ -408,34 +408,82 @@ describe('SqliteD1Adapter', () => {
       expect(created).toBe(true);
     });
 
-    it('partial unique index prevents duplicate active tasks at DB level', async () => {
+    it('createTaskIfNotExists returns false for same PR and feature', async () => {
       await store.createTask(
-        makeTask({ id: 'first', owner: 'org', repo: 'repo', pr_number: 10, status: 'pending' }),
+        makeTask({
+          id: 'first',
+          owner: 'org',
+          repo: 'repo',
+          pr_number: 10,
+          status: 'pending',
+          feature: 'review',
+        }),
       );
 
-      await expect(
-        store.createTask(
-          makeTask({
-            id: 'second',
-            owner: 'org',
-            repo: 'repo',
-            pr_number: 10,
-            status: 'pending',
-          }),
-        ),
-      ).rejects.toThrow(/UNIQUE constraint failed/);
-    });
-
-    it('createTaskIfNotExists returns false on constraint violation', async () => {
-      // Directly insert a pending task
-      await store.createTask(
-        makeTask({ id: 'first', owner: 'org', repo: 'repo', pr_number: 10, status: 'pending' }),
-      );
-
-      // createTaskIfNotExists should return false (caught by WHERE NOT EXISTS)
-      const task = makeTask({ id: 'dup', owner: 'org', repo: 'repo', pr_number: 10 });
+      const task = makeTask({
+        id: 'dup',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 10,
+        feature: 'review',
+      });
       const created = await store.createTaskIfNotExists(task);
       expect(created).toBe(false);
+    });
+
+    it('createTaskIfNotExists succeeds for same PR but different feature', async () => {
+      await store.createTask(
+        makeTask({
+          id: 'review-1',
+          owner: 'org',
+          repo: 'repo',
+          pr_number: 10,
+          status: 'pending',
+          feature: 'review',
+        }),
+      );
+
+      const task = makeTask({
+        id: 'dedup-1',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 10,
+        feature: 'dedup_pr',
+      });
+      const created = await store.createTaskIfNotExists(task);
+      expect(created).toBe(true);
+      expect(await store.getTask('dedup-1')).not.toBeNull();
+    });
+
+    it('allows multiple active tasks for same PR after index removal', async () => {
+      // With idx_tasks_active_pr dropped, multiple active tasks per PR are allowed
+      // (needed for multi-task groups)
+      await store.createTask(
+        makeTask({
+          id: 'first',
+          owner: 'org',
+          repo: 'repo',
+          pr_number: 10,
+          status: 'pending',
+          feature: 'review',
+        }),
+      );
+
+      // Second task for same PR should succeed (no unique index blocking it)
+      await store.createTask(
+        makeTask({
+          id: 'second',
+          owner: 'org',
+          repo: 'repo',
+          pr_number: 10,
+          status: 'pending',
+          feature: 'review',
+          group_id: 'same-group',
+        }),
+      );
+
+      expect(await store.getTask('first')).not.toBeNull();
+      expect(await store.getTask('second')).not.toBeNull();
     });
   });
 

--- a/packages/server/src/__tests__/store-memory.test.ts
+++ b/packages/server/src/__tests__/store-memory.test.ts
@@ -198,6 +198,38 @@ describe('MemoryDataStore', () => {
       const created = await store.createTaskIfNotExists(task);
       expect(created).toBe(true);
     });
+
+    it('createTaskIfNotExists succeeds for same PR but different feature', async () => {
+      await store.createTask(
+        makeTask({ id: 'review-1', owner: 'org', repo: 'repo', pr_number: 10, feature: 'review' }),
+      );
+      const task = makeTask({
+        id: 'dedup-1',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 10,
+        feature: 'dedup_pr',
+      });
+      const created = await store.createTaskIfNotExists(task);
+      expect(created).toBe(true);
+      expect(await store.getTask('dedup-1')).not.toBeNull();
+    });
+
+    it('createTaskIfNotExists returns false for same PR and same feature', async () => {
+      await store.createTask(
+        makeTask({ id: 'review-1', owner: 'org', repo: 'repo', pr_number: 10, feature: 'review' }),
+      );
+      const task = makeTask({
+        id: 'review-dup',
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 10,
+        feature: 'review',
+      });
+      const created = await store.createTaskIfNotExists(task);
+      expect(created).toBe(false);
+      expect(await store.getTask('review-dup')).toBeNull();
+    });
   });
 
   // ── Claims ─────────────────────────────────────────────────

--- a/packages/server/src/__tests__/webhook-refactor.test.ts
+++ b/packages/server/src/__tests__/webhook-refactor.test.ts
@@ -270,6 +270,76 @@ describe('Webhook refactor — separate task creation', () => {
       expect(tasks).toHaveLength(1);
     });
 
+    it('creates multiple review tasks that all appear in poll', async () => {
+      const config = makeReviewConfig({ agentCount: 3 });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(groupId).not.toBeNull();
+
+      // Both tasks should be pending and listable
+      const pending = await store.listTasks({ status: ['pending'] });
+      expect(pending).toHaveLength(2);
+      for (const task of pending) {
+        expect(task.group_id).toBe(groupId);
+        expect(task.status).toBe('pending');
+        expect(task.feature).toBe('review');
+      }
+    });
+
+    it('different agents can claim different tasks without conflict', async () => {
+      const config = makeReviewConfig({ agentCount: 3 });
+      const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(groupId).not.toBeNull();
+
+      const tasks = await store.listTasks({ status: ['pending'] });
+      expect(tasks).toHaveLength(2);
+
+      // Agent 1 claims first task
+      const claimed1 = await store.claimTask(tasks[0].id);
+      expect(claimed1).toBe(true);
+
+      // Agent 2 claims second task — no conflict
+      const claimed2 = await store.claimTask(tasks[1].id);
+      expect(claimed2).toBe(true);
+
+      // Both tasks are now reviewing
+      const reviewing = await store.listTasks({ status: ['reviewing'] });
+      expect(reviewing).toHaveLength(2);
+    });
+
+    it('allows different feature groups for the same PR', async () => {
+      const reviewConfig = makeReviewConfig({ agentCount: 2 });
+      const dedupConfig = makeReviewConfig({ agentCount: 2, prompt: 'Check for duplicates' });
+
+      // Review group for the PR
+      const reviewGroupId = await createTaskGroup(store, 'review', reviewConfig, baseTask, logger);
+      expect(reviewGroupId).not.toBeNull();
+
+      // Dedup group for the same PR — different feature, should succeed
+      const dedupGroupId = await createTaskGroup(store, 'dedup_pr', dedupConfig, baseTask, logger);
+      expect(dedupGroupId).not.toBeNull();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2); // 1 review + 1 dedup
+      const features = new Set(tasks.map((t) => t.feature));
+      expect(features).toEqual(new Set(['review', 'dedup_pr']));
+    });
+
+    it('duplicate review group for same PR is rejected', async () => {
+      const config = makeReviewConfig({ agentCount: 3 });
+
+      // First group succeeds
+      const first = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(first).not.toBeNull();
+
+      // Second review group for same PR is rejected (idempotency)
+      const second = await createTaskGroup(store, 'review', config, baseTask, logger);
+      expect(second).toBeNull();
+
+      // Still only 2 tasks (from the first group)
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+    });
+
     it('all tasks in group share the same group_id', async () => {
       const config = makeReviewConfig({ agentCount: 5 });
       const groupId = await createTaskGroup(store, 'review', config, baseTask, logger);

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -245,7 +245,7 @@ export class D1DataStore implements DataStore {
           dedup_target, index_issue_number)
         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         WHERE NOT EXISTS (
-          SELECT 1 FROM tasks WHERE owner = ? AND repo = ? AND pr_number = ? AND status IN (?, ?)
+          SELECT 1 FROM tasks WHERE owner = ? AND repo = ? AND pr_number = ? AND feature = ? AND status IN (?, ?)
         )`,
         )
         .bind(
@@ -285,6 +285,7 @@ export class D1DataStore implements DataStore {
           task.owner,
           task.repo,
           task.pr_number,
+          task.feature,
           'pending',
           'reviewing',
         )

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -10,8 +10,10 @@ export interface DataStore {
   createTask(task: ReviewTask): Promise<void>;
   /**
    * Atomically create a task only if no active (pending/reviewing) task exists
-   * for the same PR. Returns true if the task was created, false if a duplicate exists.
-   * This prevents race conditions from concurrent webhook deliveries.
+   * for the same PR and feature. Returns true if the task was created, false if
+   * a duplicate exists. This prevents race conditions from concurrent webhook
+   * deliveries while allowing multiple task groups for different features on
+   * the same PR.
    */
   createTaskIfNotExists(task: ReviewTask): Promise<boolean>;
   getTask(id: string): Promise<ReviewTask | null>;

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -33,6 +33,7 @@ export class MemoryDataStore implements DataStore {
         existing.owner === task.owner &&
         existing.repo === task.repo &&
         existing.pr_number === task.pr_number &&
+        existing.feature === task.feature &&
         (existing.status === 'pending' || existing.status === 'reviewing')
       ) {
         return false;


### PR DESCRIPTION
Part of #523

## Summary
- New migration `0014_multi_task_unique.sql` drops `idx_tasks_active_pr` unique index that enforced at most 1 active task per PR — this blocked multi-task group creation
- `createTaskIfNotExists` in both D1 and Memory stores now includes `feature` in the dedup check, allowing different feature groups (review, dedup_pr, triage) to coexist on the same PR while still preventing duplicate webhook-triggered groups
- Updated interface docstring to reflect the new feature-scoped dedup behavior

## Test plan
- Added test: `createTaskGroup` with `agentCount=3` creates 2 review tasks that all appear in poll
- Added test: different agents can claim different tasks without CLAIM_CONFLICT
- Added test: different feature groups for the same PR are allowed
- Added test: duplicate review group for same PR is still rejected (idempotency preserved)
- Added test: `createTaskIfNotExists` succeeds for same PR but different feature (Memory + D1)
- Added test: `createTaskIfNotExists` returns false for same PR and same feature (Memory + D1)
- Added test: multiple active tasks for same PR allowed after index removal (D1)
- All 1803 existing tests pass, plus the new tests above
- Build, lint, format, typecheck all pass