### PR TITLE
[cli-dev] CLI command to initialize dedup index by scanning existing PRs/issues

### DIFF
--- a/packages/cli/src/__tests__/dedup-init.test.ts
+++ b/packages/cli/src/__tests__/dedup-init.test.ts
@@ -1,0 +1,684 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StoredAuth } from '../auth.js';
+import {
+  formatEntry,
+  categorizeItems,
+  parseExistingNumbers,
+  buildCommentBody,
+  fetchRepoFile,
+  fetchAllPRs,
+  fetchAllIssues,
+  initIndex,
+  runDedupInit,
+} from '../commands/dedup.js';
+import type { GitHubItem } from '../commands/dedup.js';
+
+// ── Test Helpers ─────────────────────────────────────────────
+
+function makeItem(overrides: Partial<GitHubItem> = {}): GitHubItem {
+  return {
+    number: 1,
+    title: 'Test item',
+    state: 'open',
+    labels: [],
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+function makePR(overrides: Partial<GitHubItem> = {}): GitHubItem {
+  return makeItem({ merged_at: null, ...overrides });
+}
+
+const validAuth: StoredAuth = {
+  access_token: 'ghp_test123',
+  expires_at: Date.now() + 3600_000,
+  github_username: 'testuser',
+  github_user_id: 12345,
+};
+
+// ── formatEntry ──────────────────────────────────────────────
+
+describe('formatEntry', () => {
+  it('formats item with labels', () => {
+    const item = makeItem({
+      number: 42,
+      title: 'Fix login bug',
+      labels: [{ name: 'bug' }, { name: 'critical' }],
+    });
+    expect(formatEntry(item)).toBe('- #42 [bug] [critical] — Fix login bug');
+  });
+
+  it('formats item without labels', () => {
+    const item = makeItem({ number: 10, title: 'Add feature' });
+    expect(formatEntry(item)).toBe('- #10 — Add feature');
+  });
+
+  it('formats compact entry (archived)', () => {
+    const item = makeItem({
+      number: 42,
+      title: 'Fix login bug',
+      labels: [{ name: 'bug' }],
+    });
+    expect(formatEntry(item, true)).toBe('- #42 — Fix login bug');
+  });
+});
+
+// ── categorizeItems ──────────────────────────────────────────
+
+describe('categorizeItems', () => {
+  const now = new Date('2026-03-26T12:00:00Z').getTime();
+  const tenDaysAgo = new Date('2026-03-16T12:00:00Z').toISOString();
+  const sixtyDaysAgo = new Date('2026-01-25T12:00:00Z').toISOString();
+
+  it('categorizes open items', () => {
+    const items = [makeItem({ number: 1, state: 'open' })];
+    const result = categorizeItems(items, 30, now);
+    expect(result.open).toHaveLength(1);
+    expect(result.recentlyClosed).toHaveLength(0);
+    expect(result.archived).toHaveLength(0);
+  });
+
+  it('categorizes recently closed items', () => {
+    const items = [makeItem({ number: 2, state: 'closed', closed_at: tenDaysAgo })];
+    const result = categorizeItems(items, 30, now);
+    expect(result.open).toHaveLength(0);
+    expect(result.recentlyClosed).toHaveLength(1);
+    expect(result.archived).toHaveLength(0);
+  });
+
+  it('categorizes archived items', () => {
+    const items = [makeItem({ number: 3, state: 'closed', closed_at: sixtyDaysAgo })];
+    const result = categorizeItems(items, 30, now);
+    expect(result.open).toHaveLength(0);
+    expect(result.recentlyClosed).toHaveLength(0);
+    expect(result.archived).toHaveLength(1);
+  });
+
+  it('handles mixed items', () => {
+    const items = [
+      makeItem({ number: 1, state: 'open' }),
+      makeItem({ number: 2, state: 'closed', closed_at: tenDaysAgo }),
+      makeItem({ number: 3, state: 'closed', closed_at: sixtyDaysAgo }),
+    ];
+    const result = categorizeItems(items, 30, now);
+    expect(result.open).toHaveLength(1);
+    expect(result.recentlyClosed).toHaveLength(1);
+    expect(result.archived).toHaveLength(1);
+  });
+
+  it('respects custom recentDays window', () => {
+    // With 5-day window, the 10-day-old item should be archived
+    const items = [makeItem({ number: 2, state: 'closed', closed_at: tenDaysAgo })];
+    const result = categorizeItems(items, 5, now);
+    expect(result.recentlyClosed).toHaveLength(0);
+    expect(result.archived).toHaveLength(1);
+  });
+
+  it('treats closed items with null closed_at as archived', () => {
+    const items = [makeItem({ number: 4, state: 'closed', closed_at: null })];
+    const result = categorizeItems(items, 30, now);
+    expect(result.archived).toHaveLength(1);
+  });
+});
+
+// ── parseExistingNumbers ─────────────────────────────────────
+
+describe('parseExistingNumbers', () => {
+  it('parses numbers from entry lines', () => {
+    const body = `<!-- opencara-dedup-index:open -->
+## Open Items
+
+- #1 [bug] — Fix
+- #42 — Add feature
+- #100 [feat] [ui] — Dashboard`;
+
+    const numbers = parseExistingNumbers(body);
+    expect(numbers).toEqual(new Set([1, 42, 100]));
+  });
+
+  it('returns empty set for empty body', () => {
+    const numbers = parseExistingNumbers('<!-- marker -->\n## Header\n');
+    expect(numbers).toEqual(new Set());
+  });
+
+  it('ignores non-entry lines', () => {
+    const body = `## Open Items
+Some description text
+- #5 — Item
+Not a list item #99`;
+    const numbers = parseExistingNumbers(body);
+    expect(numbers).toEqual(new Set([5]));
+  });
+});
+
+// ── buildCommentBody ─────────────────────────────────────────
+
+describe('buildCommentBody', () => {
+  const marker = '<!-- opencara-dedup-index:open -->';
+  const header = 'Open Items';
+
+  it('creates new comment when no existing body', () => {
+    const items = [
+      makeItem({ number: 1, title: 'First' }),
+      makeItem({ number: 2, title: 'Second' }),
+    ];
+    const body = buildCommentBody(marker, header, items, null);
+    expect(body).toContain(marker);
+    expect(body).toContain('## Open Items');
+    expect(body).toContain('- #1 — First');
+    expect(body).toContain('- #2 — Second');
+  });
+
+  it('merges without duplicates', () => {
+    const existingBody = `${marker}\n## Open Items\n\n- #1 — First`;
+    const items = [
+      makeItem({ number: 1, title: 'First' }),
+      makeItem({ number: 3, title: 'Third' }),
+    ];
+    const body = buildCommentBody(marker, header, items, existingBody);
+    // Should contain #1 from existing and add #3
+    expect(body).toContain('- #1 — First');
+    expect(body).toContain('- #3 — Third');
+    // Should NOT have duplicate #1
+    const count1 = (body.match(/- #1/g) || []).length;
+    expect(count1).toBe(1);
+  });
+
+  it('uses compact format for archived', () => {
+    const items = [makeItem({ number: 1, title: 'Item', labels: [{ name: 'bug' }] })];
+    const body = buildCommentBody(marker, header, items, null, true);
+    expect(body).toContain('- #1 — Item');
+    expect(body).not.toContain('[bug]');
+  });
+});
+
+// ── fetchRepoFile ────────────────────────────────────────────
+
+describe('fetchRepoFile', () => {
+  it('returns file content on success', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('version = 1', { status: 200 })) as unknown as typeof fetch;
+
+    const content = await fetchRepoFile('owner', 'repo', '.opencara.toml', 'token', mockFetch);
+    expect(content).toBe('version = 1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/owner/repo/contents/.opencara.toml',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+        }),
+      }),
+    );
+  });
+
+  it('returns null on 404', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Not Found', { status: 404 })) as unknown as typeof fetch;
+
+    const content = await fetchRepoFile('owner', 'repo', 'missing', 'token', mockFetch);
+    expect(content).toBeNull();
+  });
+
+  it('throws on other errors', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Server Error', { status: 500 })) as unknown as typeof fetch;
+
+    await expect(fetchRepoFile('owner', 'repo', 'file', 'token', mockFetch)).rejects.toThrow(
+      'GitHub API error: 500',
+    );
+  });
+});
+
+// ── fetchAllPRs ──────────────────────────────────────────────
+
+describe('fetchAllPRs', () => {
+  it('fetches single page of PRs', async () => {
+    const prs = [makePR({ number: 1, title: 'PR 1' })];
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(prs), { status: 200 }),
+      ) as unknown as typeof fetch;
+
+    const result = await fetchAllPRs('owner', 'repo', 'token', mockFetch);
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+
+  it('paginates multiple pages', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makePR({ number: i + 1 }));
+    const page2 = [makePR({ number: 101 })];
+
+    let callCount = 0;
+    const mockFetch = vi.fn(async () => {
+      callCount++;
+      const data = callCount === 1 ? page1 : page2;
+      return new Response(JSON.stringify(data), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchAllPRs('owner', 'repo', 'token', mockFetch);
+    expect(result).toHaveLength(101);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on API error', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Error', { status: 403 })) as unknown as typeof fetch;
+
+    await expect(fetchAllPRs('owner', 'repo', 'token', mockFetch)).rejects.toThrow(
+      'GitHub API error: 403',
+    );
+  });
+});
+
+// ── fetchAllIssues ───────────────────────────────────────────
+
+describe('fetchAllIssues', () => {
+  it('filters out PRs from issues endpoint', async () => {
+    const items = [
+      makeItem({ number: 1, title: 'Issue 1' }),
+      makeItem({ number: 2, title: 'PR 1', pull_request: { url: '...' } }),
+    ];
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(items), { status: 200 }),
+      ) as unknown as typeof fetch;
+
+    const result = await fetchAllIssues('owner', 'repo', 'token', mockFetch);
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+});
+
+// ── initIndex ────────────────────────────────────────────────
+
+describe('initIndex', () => {
+  const baseOpts = {
+    owner: 'acme',
+    repo: 'widgets',
+    indexIssue: 53,
+    kind: 'prs' as const,
+    recentDays: 30,
+    dryRun: false,
+    token: 'ghp_test',
+    log: vi.fn(),
+  };
+
+  it('initializes empty index from scratch', async () => {
+    const prs = [
+      makePR({ number: 1, title: 'Open PR', state: 'open' }),
+      makePR({
+        number: 2,
+        title: 'Recent PR',
+        state: 'closed',
+        closed_at: new Date(Date.now() - 5 * 86400_000).toISOString(),
+      }),
+      makePR({
+        number: 3,
+        title: 'Old PR',
+        state: 'closed',
+        closed_at: new Date(Date.now() - 60 * 86400_000).toISOString(),
+      }),
+    ];
+
+    let callCount = 0;
+    const createdComments: string[] = [];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (
+        url.includes(`/issues/${baseOpts.indexIssue}/comments`) &&
+        (!init || init.method !== 'POST')
+      ) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.includes(`/issues/${baseOpts.indexIssue}/comments`) && init?.method === 'POST') {
+        callCount++;
+        const body = JSON.parse(init.body as string) as { body: string };
+        createdComments.push(body.body);
+        return new Response(JSON.stringify({ id: callCount }), { status: 201 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await initIndex({ ...baseOpts, fetchFn: mockFetch });
+    expect(result.openCount).toBe(1);
+    expect(result.recentCount).toBe(1);
+    expect(result.archivedCount).toBe(1);
+    expect(result.newEntries).toBe(3);
+    expect(createdComments).toHaveLength(3);
+    expect(createdComments[0]).toContain('Open Items');
+    expect(createdComments[0]).toContain('- #1 — Open PR');
+    expect(createdComments[1]).toContain('Recently Closed');
+    expect(createdComments[1]).toContain('- #2 — Recent PR');
+    expect(createdComments[2]).toContain('Archived');
+    expect(createdComments[2]).toContain('- #3 — Old PR');
+  });
+
+  it('merges with existing entries', async () => {
+    const prs = [
+      makePR({ number: 1, title: 'Existing PR', state: 'open' }),
+      makePR({ number: 4, title: 'New PR', state: 'open' }),
+    ];
+
+    const existingComments = [
+      {
+        id: 100,
+        body: '<!-- opencara-dedup-index:open -->\n## Open Items\n\n- #1 — Existing PR',
+      },
+      { id: 101, body: '<!-- opencara-dedup-index:recent -->\n## Recently Closed Items\n' },
+      { id: 102, body: '<!-- opencara-dedup-index:archived -->\n## Archived Items\n' },
+    ];
+
+    const updatedBodies: Array<{ id: number; body: string }> = [];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (
+        url.includes(`/issues/${baseOpts.indexIssue}/comments`) &&
+        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
+      ) {
+        return new Response(JSON.stringify(existingComments), { status: 200 });
+      }
+      if (url.includes('/issues/comments/') && init?.method === 'PATCH') {
+        const idMatch = url.match(/comments\/(\d+)/);
+        const body = JSON.parse(init.body as string) as { body: string };
+        updatedBodies.push({ id: parseInt(idMatch![1], 10), body: body.body });
+        return new Response('{}', { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await initIndex({ ...baseOpts, fetchFn: mockFetch });
+    expect(result.openCount).toBe(2);
+    expect(result.newEntries).toBe(1); // Only #4 is new
+
+    // Verify the open comment was updated with #4 but #1 not duplicated
+    const openUpdate = updatedBodies.find((u) => u.id === 100);
+    expect(openUpdate).toBeDefined();
+    expect(openUpdate!.body).toContain('- #1 — Existing PR');
+    expect(openUpdate!.body).toContain('- #4 — New PR');
+    const count1 = (openUpdate!.body.match(/- #1/g) || []).length;
+    expect(count1).toBe(1);
+  });
+
+  it('dry run does not call GitHub write APIs', async () => {
+    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (init?.method === 'POST' || init?.method === 'PATCH') {
+        throw new Error('Should not write in dry run mode');
+      }
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (url.includes('/comments')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await initIndex({ ...baseOpts, dryRun: true, fetchFn: mockFetch });
+    expect(result.openCount).toBe(1);
+    expect(result.newEntries).toBe(1);
+  });
+
+  it('works for issues kind', async () => {
+    const issues = [makeItem({ number: 10, title: 'Bug report', state: 'open' })];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes('/issues?state=all')) {
+        return new Response(JSON.stringify(issues), { status: 200 });
+      }
+      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const result = await initIndex({
+      ...baseOpts,
+      kind: 'issues',
+      fetchFn: mockFetch,
+    });
+    expect(result.openCount).toBe(1);
+  });
+});
+
+// ── runDedupInit ─────────────────────────────────────────────
+
+describe('runDedupInit', () => {
+  let log: ReturnType<typeof vi.fn>;
+  let logError: ReturnType<typeof vi.fn>;
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    log = vi.fn();
+    logError = vi.fn();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  it('requires authentication', async () => {
+    await runDedupInit({ repo: 'owner/repo' }, { log, logError, loadAuthFn: () => null });
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rejects expired auth', async () => {
+    const expiredAuth = { ...validAuth, expires_at: Date.now() - 1000 };
+    await runDedupInit({ repo: 'owner/repo' }, { log, logError, loadAuthFn: () => expiredAuth });
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('Not authenticated'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('requires --repo flag', async () => {
+    await runDedupInit({}, { log, logError, loadAuthFn: () => validAuth });
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('--repo is required'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('validates repo format', async () => {
+    await runDedupInit({ repo: 'invalid' }, { log, logError, loadAuthFn: () => validAuth });
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('Invalid repo format'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('errors when .opencara.toml not found', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Not Found', { status: 404 })) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'owner/repo' },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('No .opencara.toml'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('errors when no dedup config in .opencara.toml', async () => {
+    const toml = 'version = 1\n\n[review]\nprompt = "Review this"';
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(toml, { status: 200 })) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'owner/repo' },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('No dedup index issues'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('errors when --all not set and only issues index configured', async () => {
+    const toml = `version = 1
+[dedup.issues]
+index_issue = 10
+`;
+    const mockFetch = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('contents/')) {
+        return new Response(toml, { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'owner/repo' },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('No PR dedup index configured'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('validates --days flag', async () => {
+    await runDedupInit(
+      { repo: 'owner/repo', days: 'abc' },
+      { log, logError, loadAuthFn: () => validAuth },
+    );
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('--days must be a positive'));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('runs successfully with PR dedup config', async () => {
+    const toml = `version = 1
+[dedup.prs]
+index_issue = 53
+`;
+    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes('contents/')) {
+        return new Response(toml, { status: 200 });
+      }
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (
+        url.includes('/comments') &&
+        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
+      ) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'acme/widgets' },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(process.exitCode).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Initializing prs'));
+  });
+
+  it('runs both indexes with --all', async () => {
+    const toml = `version = 1
+[dedup.prs]
+index_issue = 53
+
+[dedup.issues]
+index_issue = 54
+`;
+    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
+    const issues = [makeItem({ number: 10, title: 'Issue 1', state: 'open' })];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes('contents/')) {
+        return new Response(toml, { status: 200 });
+      }
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (url.includes('/issues?state=all')) {
+        return new Response(JSON.stringify(issues), { status: 200 });
+      }
+      if (
+        url.includes('/comments') &&
+        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
+      ) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'acme/widgets', all: true },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(process.exitCode).toBeUndefined();
+    // Should have logs for both prs and issues
+    const logCalls = log.mock.calls.map((c: string[]) => c[0]);
+    expect(logCalls.some((c: string) => c.includes('prs'))).toBe(true);
+    expect(logCalls.some((c: string) => c.includes('issues'))).toBe(true);
+  });
+
+  it('supports dry run mode', async () => {
+    const toml = `version = 1
+[dedup.prs]
+index_issue = 53
+`;
+    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
+
+    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+      if (init?.method === 'POST' || init?.method === 'PATCH') {
+        throw new Error('Should not write in dry run');
+      }
+      if (url.includes('contents/')) {
+        return new Response(toml, { status: 200 });
+      }
+      if (url.includes('/pulls?')) {
+        return new Response(JSON.stringify(prs), { status: 200 });
+      }
+      if (url.includes('/comments')) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response('Not Found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await runDedupInit(
+      { repo: 'acme/widgets', dryRun: true },
+      { log, logError, loadAuthFn: () => validAuth, fetchFn: mockFetch },
+    );
+    expect(process.exitCode).toBeUndefined();
+    const logCalls = log.mock.calls.map((c: string[]) => c[0]);
+    expect(logCalls.some((c: string) => c.includes('Dry run'))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/dedup.ts
+++ b/packages/cli/src/commands/dedup.ts
@@ -1,0 +1,570 @@
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { parseOpenCaraConfig } from '@opencara/shared';
+import type { OpenCaraConfig } from '@opencara/shared';
+import { loadAuth } from '../auth.js';
+import { icons } from '../logger.js';
+
+// ── Constants ────────────────────────────────────────────────
+
+/** Default window for "recently closed" items (in days). */
+const DEFAULT_RECENT_DAYS = 30;
+
+/** Per-page limit for GitHub API pagination. */
+const PER_PAGE = 100;
+
+/** Comment markers — must match server's dedup-index.ts. */
+const OPEN_MARKER = '<!-- opencara-dedup-index:open -->';
+const RECENT_MARKER = '<!-- opencara-dedup-index:recent -->';
+const ARCHIVED_MARKER = '<!-- opencara-dedup-index:archived -->';
+
+// ── Types ────────────────────────────────────────────────────
+
+/** A PR or issue item from the GitHub API. */
+export interface GitHubItem {
+  number: number;
+  title: string;
+  state: string; // 'open' | 'closed'
+  labels: Array<{ name: string }>;
+  closed_at: string | null;
+  merged_at?: string | null; // PRs only
+  pull_request?: unknown; // present on issues endpoint if item is a PR
+}
+
+/** Parsed index comment structure. */
+interface IndexComments {
+  open: { id: number; body: string } | null;
+  recent: { id: number; body: string } | null;
+  archived: { id: number; body: string } | null;
+}
+
+/** Categorized items ready for index population. */
+export interface CategorizedItems {
+  open: GitHubItem[];
+  recentlyClosed: GitHubItem[];
+  archived: GitHubItem[];
+}
+
+/** Dependencies for dedup init — allows injection for testing. */
+export interface DedupInitDeps {
+  fetchFn?: typeof fetch;
+  log?: (msg: string) => void;
+  logError?: (msg: string) => void;
+  loadAuthFn?: typeof loadAuth;
+}
+
+// ── GitHub API Helpers ───────────────────────────────────────
+
+/**
+ * Fetch a file from a GitHub repo via the Contents API.
+ * Returns the decoded text content, or null if not found.
+ */
+export async function fetchRepoFile(
+  owner: string,
+  repo: string,
+  path: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<string | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  const res = await fetchFn(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.raw+json',
+    },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching ${path}`);
+  return res.text();
+}
+
+/**
+ * Fetch all PRs from a repo using pagination.
+ * Returns items sorted by number.
+ */
+export async function fetchAllPRs(
+  owner: string,
+  repo: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+  log?: (msg: string) => void,
+): Promise<GitHubItem[]> {
+  const items: GitHubItem[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/pulls?state=all&per_page=${PER_PAGE}&page=${page}&sort=created&direction=desc`;
+    const res = await fetchFn(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching PRs page ${page}`);
+
+    const batch = (await res.json()) as GitHubItem[];
+    items.push(...batch);
+
+    if (log) log(`  Fetched ${items.length} PRs...`);
+
+    if (batch.length < PER_PAGE) break;
+    page++;
+  }
+
+  return items;
+}
+
+/**
+ * Fetch all issues from a repo using pagination (excludes PRs).
+ * The GitHub Issues API returns both issues and PRs — items with
+ * `pull_request` field are filtered out.
+ */
+export async function fetchAllIssues(
+  owner: string,
+  repo: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+  log?: (msg: string) => void,
+): Promise<GitHubItem[]> {
+  const items: GitHubItem[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/issues?state=all&per_page=${PER_PAGE}&page=${page}&sort=created&direction=desc`;
+    const res = await fetchFn(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching issues page ${page}`);
+
+    const batch = (await res.json()) as GitHubItem[];
+    // Filter out PRs (they appear in issues endpoint with pull_request field)
+    const issuesOnly = batch.filter((item) => !item.pull_request);
+    items.push(...issuesOnly);
+
+    if (log) log(`  Fetched ${items.length} issues...`);
+
+    if (batch.length < PER_PAGE) break;
+    page++;
+  }
+
+  return items;
+}
+
+/**
+ * Fetch comments on an issue.
+ */
+async function fetchIssueComments(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<Array<{ id: number; body: string }>> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`;
+  const res = await fetchFn(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching comments`);
+  return (await res.json()) as Array<{ id: number; body: string }>;
+}
+
+/**
+ * Create a comment on an issue. Returns the comment ID.
+ */
+async function createIssueComment(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<number> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
+  const res = await fetchFn(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body }),
+  });
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status} creating comment`);
+  const data = (await res.json()) as { id: number };
+  return data.id;
+}
+
+/**
+ * Update a comment on an issue.
+ */
+async function updateIssueComment(
+  owner: string,
+  repo: string,
+  commentId: number,
+  body: string,
+  token: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<void> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`;
+  const res = await fetchFn(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body }),
+  });
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status} updating comment`);
+}
+
+// ── Index Entry Formatting ───────────────────────────────────
+
+/**
+ * Format a single item as an index entry line.
+ * Full format: `- #<number> [label1] [label2] — <title>`
+ * Compact format (archived): `- #<number> — <title>`
+ */
+export function formatEntry(item: GitHubItem, compact: boolean = false): string {
+  if (compact) {
+    return `- #${item.number} — ${item.title}`;
+  }
+  const labels = item.labels.map((l) => `[${l.name}]`).join(' ');
+  const labelPart = labels ? ` ${labels}` : '';
+  return `- #${item.number}${labelPart} — ${item.title}`;
+}
+
+// ── Categorization ───────────────────────────────────────────
+
+/**
+ * Categorize items into open, recently closed, and archived buckets.
+ */
+export function categorizeItems(
+  items: GitHubItem[],
+  recentDays: number = DEFAULT_RECENT_DAYS,
+  nowMs: number = Date.now(),
+): CategorizedItems {
+  const cutoff = nowMs - recentDays * 24 * 60 * 60 * 1000;
+
+  const open: GitHubItem[] = [];
+  const recentlyClosed: GitHubItem[] = [];
+  const archived: GitHubItem[] = [];
+
+  for (const item of items) {
+    if (item.state === 'open') {
+      open.push(item);
+    } else if (item.closed_at && new Date(item.closed_at).getTime() >= cutoff) {
+      recentlyClosed.push(item);
+    } else {
+      archived.push(item);
+    }
+  }
+
+  return { open, recentlyClosed, archived };
+}
+
+// ── Comment Body Building ────────────────────────────────────
+
+/** Parse existing entries from a comment body. Returns the set of #numbers already present. */
+export function parseExistingNumbers(body: string): Set<number> {
+  const numbers = new Set<number>();
+  const regex = /^- #(\d+)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(body)) !== null) {
+    numbers.add(parseInt(match[1], 10));
+  }
+  return numbers;
+}
+
+/** Build comment body for a section, merging with existing entries. */
+export function buildCommentBody(
+  marker: string,
+  header: string,
+  items: GitHubItem[],
+  existingBody: string | null,
+  compact: boolean = false,
+): string {
+  const existingNumbers = existingBody ? parseExistingNumbers(existingBody) : new Set<number>();
+  const newItems = items.filter((item) => !existingNumbers.has(item.number));
+
+  // Preserve existing entries and append new ones
+  let body = existingBody ?? `${marker}\n## ${header}\n`;
+  for (const item of newItems) {
+    body += `\n${formatEntry(item, compact)}`;
+  }
+
+  return body;
+}
+
+// ── Find Index Comments ──────────────────────────────────────
+
+function findIndexComments(comments: Array<{ id: number; body: string }>): IndexComments {
+  let open: { id: number; body: string } | null = null;
+  let recent: { id: number; body: string } | null = null;
+  let archived: { id: number; body: string } | null = null;
+
+  for (const c of comments) {
+    if (c.body.includes(OPEN_MARKER)) open = c;
+    else if (c.body.includes(RECENT_MARKER)) recent = c;
+    else if (c.body.includes(ARCHIVED_MARKER)) archived = c;
+  }
+
+  return { open, recent, archived };
+}
+
+// ── Core Init Logic ──────────────────────────────────────────
+
+export interface InitIndexOptions {
+  owner: string;
+  repo: string;
+  indexIssue: number;
+  kind: 'prs' | 'issues';
+  recentDays: number;
+  dryRun: boolean;
+  token: string;
+  fetchFn?: typeof fetch;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Initialize a dedup index by scanning existing items and populating
+ * the 3 structured comments on the index issue.
+ */
+export async function initIndex(opts: InitIndexOptions): Promise<{
+  openCount: number;
+  recentCount: number;
+  archivedCount: number;
+  newEntries: number;
+}> {
+  const { owner, repo, indexIssue, kind, recentDays, dryRun, token } = opts;
+  const fetchFn = opts.fetchFn ?? fetch;
+  const log = opts.log ?? (() => {});
+
+  // 1. Fetch all items
+  log(`Scanning ${kind}...`);
+  const items =
+    kind === 'prs'
+      ? await fetchAllPRs(owner, repo, token, fetchFn, log)
+      : await fetchAllIssues(owner, repo, token, fetchFn, log);
+
+  log(`${icons.info} Found ${items.length} ${kind}.`);
+
+  // 2. Categorize
+  const { open, recentlyClosed, archived } = categorizeItems(items, recentDays);
+
+  log(
+    `  ${open.length} open, ${recentlyClosed.length} recently closed, ${archived.length} archived`,
+  );
+
+  // 3. Fetch existing comments on the index issue
+  const comments = await fetchIssueComments(owner, repo, indexIssue, token, fetchFn);
+  const found = findIndexComments(comments);
+
+  // 4. Build updated comment bodies (merging without duplicates)
+  const openBody = buildCommentBody(OPEN_MARKER, 'Open Items', open, found.open?.body ?? null);
+  const recentBody = buildCommentBody(
+    RECENT_MARKER,
+    'Recently Closed Items',
+    recentlyClosed,
+    found.recent?.body ?? null,
+  );
+  const archivedBody = buildCommentBody(
+    ARCHIVED_MARKER,
+    'Archived Items',
+    archived,
+    found.archived?.body ?? null,
+    true, // compact format
+  );
+
+  // Count new entries
+  const existingOpen = found.open ? parseExistingNumbers(found.open.body) : new Set<number>();
+  const existingRecent = found.recent ? parseExistingNumbers(found.recent.body) : new Set<number>();
+  const existingArchived = found.archived
+    ? parseExistingNumbers(found.archived.body)
+    : new Set<number>();
+
+  const newOpen = open.filter((i) => !existingOpen.has(i.number)).length;
+  const newRecent = recentlyClosed.filter((i) => !existingRecent.has(i.number)).length;
+  const newArchived = archived.filter((i) => !existingArchived.has(i.number)).length;
+  const newEntries = newOpen + newRecent + newArchived;
+
+  if (dryRun) {
+    log(`\n${icons.info} Dry run — would update index issue #${indexIssue}:`);
+    log(`  Open Items: ${open.length} entries (${newOpen} new)`);
+    log(`  Recently Closed: ${recentlyClosed.length} entries (${newRecent} new)`);
+    log(`  Archived: ${archived.length} entries (${newArchived} new)`);
+    return {
+      openCount: open.length,
+      recentCount: recentlyClosed.length,
+      archivedCount: archived.length,
+      newEntries,
+    };
+  }
+
+  // 5. Create or update comments
+  log(`Populating index issue #${indexIssue}...`);
+
+  if (found.open) {
+    await updateIssueComment(owner, repo, found.open.id, openBody, token, fetchFn);
+  } else {
+    await createIssueComment(owner, repo, indexIssue, openBody, token, fetchFn);
+  }
+
+  if (found.recent) {
+    await updateIssueComment(owner, repo, found.recent.id, recentBody, token, fetchFn);
+  } else {
+    await createIssueComment(owner, repo, indexIssue, recentBody, token, fetchFn);
+  }
+
+  if (found.archived) {
+    await updateIssueComment(owner, repo, found.archived.id, archivedBody, token, fetchFn);
+  } else {
+    await createIssueComment(owner, repo, indexIssue, archivedBody, token, fetchFn);
+  }
+
+  log(
+    `${icons.success} Index populated: ${open.length} open, ${recentlyClosed.length} recent, ${archived.length} archived (${newEntries} new entries)`,
+  );
+
+  return {
+    openCount: open.length,
+    recentCount: recentlyClosed.length,
+    archivedCount: archived.length,
+    newEntries,
+  };
+}
+
+// ── CLI Command ──────────────────────────────────────────────
+
+/** Run `opencara dedup init` with injectable dependencies. */
+export async function runDedupInit(
+  options: { repo?: string; all?: boolean; dryRun?: boolean; days?: string },
+  deps: DedupInitDeps = {},
+): Promise<void> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const log = deps.log ?? console.log;
+  const logError = deps.logError ?? console.error;
+  const loadAuthFn = deps.loadAuthFn ?? loadAuth;
+
+  // 1. Require authentication
+  const auth = loadAuthFn();
+  if (!auth || auth.expires_at <= Date.now()) {
+    logError(`${icons.error} Not authenticated. Run: ${pc.cyan('opencara auth login')}`);
+    process.exitCode = 1;
+    return;
+  }
+  const token = auth.access_token;
+
+  // 2. Parse --repo flag
+  if (!options.repo) {
+    logError(`${icons.error} --repo is required. Usage: opencara dedup init --repo owner/repo`);
+    process.exitCode = 1;
+    return;
+  }
+  const [owner, repo] = options.repo.split('/');
+  if (!owner || !repo) {
+    logError(`${icons.error} Invalid repo format. Expected: owner/repo`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const recentDays = options.days ? parseInt(options.days, 10) : DEFAULT_RECENT_DAYS;
+  if (isNaN(recentDays) || recentDays <= 0) {
+    logError(`${icons.error} --days must be a positive number`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // 3. Fetch .opencara.toml from the repo
+  log(`Fetching .opencara.toml from ${options.repo}...`);
+  const tomlContent = await fetchRepoFile(owner, repo, '.opencara.toml', token, fetchFn);
+  if (!tomlContent) {
+    logError(`${icons.error} No .opencara.toml found in ${options.repo}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const parsed = parseOpenCaraConfig(tomlContent);
+  if ('error' in parsed) {
+    logError(`${icons.error} Failed to parse .opencara.toml: ${parsed.error}`);
+    process.exitCode = 1;
+    return;
+  }
+  const config = parsed as OpenCaraConfig;
+
+  // 4. Determine which indexes to initialize
+  const targets: Array<{ kind: 'prs' | 'issues'; indexIssue: number }> = [];
+
+  if (config.dedup?.prs?.indexIssue) {
+    targets.push({ kind: 'prs', indexIssue: config.dedup.prs.indexIssue });
+  }
+  if (config.dedup?.issues?.indexIssue) {
+    targets.push({ kind: 'issues', indexIssue: config.dedup.issues.indexIssue });
+  }
+
+  if (targets.length === 0) {
+    logError(
+      `${icons.error} No dedup index issues configured in .opencara.toml. Add [dedup.prs] or [dedup.issues] with index_issue.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // If --all is not set, only initialize PR index (default)
+  const filteredTargets = options.all
+    ? targets
+    : targets.filter((t) => t.kind === 'prs').slice(0, 1);
+
+  if (filteredTargets.length === 0) {
+    // --all not set and no PR index configured
+    if (targets.some((t) => t.kind === 'issues')) {
+      logError(
+        `${icons.error} No PR dedup index configured. Use --all to initialize issue index, or add [dedup.prs] with index_issue.`,
+      );
+    } else {
+      logError(`${icons.error} No dedup index issues configured in .opencara.toml.`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // 5. Initialize each target
+  for (const target of filteredTargets) {
+    log(`\n${pc.bold(`Initializing ${target.kind} dedup index (issue #${target.indexIssue})...`)}`);
+    await initIndex({
+      owner,
+      repo,
+      indexIssue: target.indexIssue,
+      kind: target.kind,
+      recentDays,
+      dryRun: options.dryRun ?? false,
+      token,
+      fetchFn,
+      log,
+    });
+  }
+}
+
+/** Create the `dedup` command group. */
+export function dedupCommand(): Command {
+  const dedup = new Command('dedup').description('Dedup index management');
+
+  dedup
+    .command('init')
+    .description('Scan existing PRs/issues and populate dedup index')
+    .requiredOption('--repo <owner/repo>', 'Target repository (e.g., OpenCara/OpenCara)')
+    .option('--all', 'Initialize both PR and issue dedup indexes')
+    .option('--dry-run', 'Show what would be done without making changes')
+    .option('--days <number>', 'Recently closed window in days (default: 30)', '30')
+    .action(async (options: { repo: string; all?: boolean; dryRun?: boolean; days?: string }) => {
+      await runDedupInit(options);
+    });
+
+  return dedup;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import { agentCommand, startAgentRouter } from './commands/agent.js';
 import { authCommand } from './commands/auth.js';
+import { dedupCommand } from './commands/dedup.js';
 import { statusCommand } from './commands/status.js';
 
 declare const __CLI_VERSION__: string;
@@ -14,6 +15,7 @@ const program = new Command()
 
 program.addCommand(agentCommand);
 program.addCommand(authCommand());
+program.addCommand(dedupCommand());
 program.addCommand(statusCommand);
 
 // Default: run agent start in router mode when no subcommand is given


### PR DESCRIPTION
Part of #530

## Summary
- New `opencara dedup init` CLI command that bootstraps the dedup index by scanning all existing PRs/issues in a repo
- Reads `.opencara.toml` from the target repo to find `dedup.prs.index_issue` and/or `dedup.issues.index_issue`
- Fetches all PRs/issues via GitHub API with pagination, categorizes into open/recently-closed/archived
- Creates or updates the 3 structured comments (matching server's dedup-index.ts format) on the index issue
- Supports `--repo`, `--all`, `--dry-run`, and `--days` flags
- Merges without duplicating when index already has entries
- 37 new tests covering formatting, categorization, pagination, merging, dry-run, and error cases

## Test plan
- Unit tests for `formatEntry`, `categorizeItems`, `parseExistingNumbers`, `buildCommentBody`
- Tests for GitHub API helpers: `fetchRepoFile`, `fetchAllPRs`, `fetchAllIssues` with pagination
- Integration tests for `initIndex`: empty index, merge with existing, dry run, issues kind
- CLI tests for `runDedupInit`: auth validation, repo format, config parsing, dry run, --all flag
- All 1854 tests pass (37 new)