### PR TITLE
[server-dev] Serialize dedup tasks per repo — only one claimable at a time

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -466,6 +466,163 @@ describe('Task Routes', () => {
     });
   });
 
+  // ── Dedup serialization ──────────────────────────────────
+
+  describe('dedup serialization', () => {
+    it('returns only the oldest pending dedup task per repo', async () => {
+      const now = Date.now();
+      await store.createTask(
+        makeTask({
+          id: 'dedup-old',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-old',
+          created_at: now - 10_000,
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'dedup-new',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-new',
+          created_at: now,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['pr_dedup'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('dedup-old');
+    });
+
+    it('returns no dedup task if one is already claimed for that repo', async () => {
+      // Create a claimed (reviewing) dedup task
+      await store.createTask(
+        makeTask({
+          id: 'dedup-claimed',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-claimed',
+        }),
+      );
+      await request('POST', '/api/tasks/dedup-claimed/claim', {
+        agent_id: 'agent-other',
+        role: 'pr_dedup',
+      });
+
+      // Create a pending dedup task for the same repo
+      await store.createTask(
+        makeTask({
+          id: 'dedup-pending',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-pending',
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['pr_dedup'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(0);
+    });
+
+    it('does not serialize review/summary/triage tasks per repo', async () => {
+      // Two review tasks for the same repo should both be returned
+      await store.createTask(
+        makeTask({
+          id: 'review-1',
+          task_type: 'review',
+          feature: 'review',
+          group_id: 'grp-r1',
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'review-2',
+          task_type: 'review',
+          feature: 'review',
+          group_id: 'grp-r2',
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['review'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('does not block dedup tasks across different repos', async () => {
+      const now = Date.now();
+      await store.createTask(
+        makeTask({
+          id: 'dedup-repo-a',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-a',
+          owner: 'org',
+          repo: 'repo-a',
+          created_at: now,
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'dedup-repo-b',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-b',
+          owner: 'org',
+          repo: 'repo-b',
+          created_at: now,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['pr_dedup'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('serializes issue_dedup tasks per repo the same as pr_dedup', async () => {
+      const now = Date.now();
+      await store.createTask(
+        makeTask({
+          id: 'issue-dedup-old',
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-id-old',
+          created_at: now - 5_000,
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'issue-dedup-new',
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-id-new',
+          created_at: now,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['issue_dedup'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('issue-dedup-old');
+    });
+  });
+
   // ── Claim ────────────────────────────────────────────────
 
   describe('POST /api/tasks/:taskId/claim', () => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -11,7 +11,7 @@ import type {
   DedupReport,
   TriageReport,
 } from '@opencara/shared';
-import { isRepoAllowed, isEntityMatch } from '@opencara/shared';
+import { isRepoAllowed, isEntityMatch, isDedupRole } from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
@@ -589,6 +589,26 @@ export function taskRoutes() {
     const tasks = await store.listTasks({ status: ['pending'] });
     const tasksById = new Map(tasks.map((t) => [t.id, t]));
 
+    // ── Dedup serialization: build blocked-repo set and oldest-per-repo map ──
+    // Query reviewing (claimed) tasks to find repos with in-progress dedup work
+    const reviewingTasks = await store.listTasks({ status: ['reviewing'] });
+    const dedupBlockedRepos = new Set<string>();
+    for (const t of reviewingTasks) {
+      if (isDedupRole(t.task_type)) {
+        dedupBlockedRepos.add(`${t.owner}/${t.repo}`);
+      }
+    }
+    // Track the oldest pending dedup task per repo (only return one per repo)
+    const oldestDedupPerRepo = new Map<string, ReviewTask>();
+    for (const t of tasks) {
+      if (!isDedupRole(t.task_type)) continue;
+      const repoKey = `${t.owner}/${t.repo}`;
+      const existing = oldestDedupPerRepo.get(repoKey);
+      if (!existing || t.created_at < existing.created_at) {
+        oldestDedupPerRepo.set(repoKey, t);
+      }
+    }
+
     // First pass: filter tasks by non-claim criteria, collecting candidate claim IDs
     const candidates: PollCandidate[] = [];
 
@@ -644,6 +664,14 @@ export function taskRoutes() {
       const existing = existingClaims.get(claimId);
       if (existing && !isClaimFailed(existing)) {
         continue;
+      }
+
+      // Dedup serialization: skip if repo has a claimed dedup task or this isn't the oldest
+      if (isDedupRole(task.task_type)) {
+        const repoKey = `${task.owner}/${task.repo}`;
+        if (dedupBlockedRepos.has(repoKey)) continue;
+        const oldest = oldestDedupPerRepo.get(repoKey);
+        if (oldest && oldest.id !== task.id) continue;
       }
 
       const remainingMs = task.timeout_at - Date.now();


### PR DESCRIPTION
Part of #531

## Summary
- Poll endpoint now enforces per-repo dedup serialization at the filtering level
- At most one dedup task per repo returned in poll (oldest pending wins)
- No dedup task returned if another for the same repo is already claimed (status=reviewing)
- Review, summary, and triage tasks are unaffected — no serialization applied
- No DB schema change needed — pure filtering logic in the poll handler

## Test plan
- [x] Two pending dedup tasks for same repo → poll returns only the oldest
- [x] One claimed dedup task for repo → poll returns no dedup tasks for that repo
- [x] Review tasks for same repo are not serialized
- [x] Different repos are not affected by each other's dedup tasks
- [x] issue_dedup serialized the same as pr_dedup
- [x] All existing tests pass (1859 tests)
- [x] Build, lint, format, typecheck all pass