### PR TITLE
[cli-dev] Fix CLI crash on issue tasks (pr_number=0)

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -1506,4 +1506,162 @@ describe('Agent Coverage Tests', () => {
       }
     });
   });
+
+  // ═══════════════════════════════════════════════════════════
+  // Issue-based tasks (pr_number=0) — skip diff fetch
+  // ═══════════════════════════════════════════════════════════
+
+  describe('Issue-based tasks (pr_number=0)', () => {
+    it('issue_triage task succeeds without diff fetch', async () => {
+      // Return triage JSON from the tool executor
+      mockedExecuteTool.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          category: 'bug',
+          module: 'cli',
+          priority: 'high',
+          size: 'S',
+          labels: ['bug', 'cli'],
+          summary: 'Test issue summary',
+          body: 'Test issue body',
+          comment: 'This is a bug in the CLI module.',
+        }),
+        stderr: '',
+        exitCode: 0,
+        tokensUsed: 200,
+        tokensParsed: true,
+        tokenDetail: { input: 0, output: 200, total: 200, parsed: true },
+      });
+
+      const taskId = await server.injectIssueTask({ taskType: 'issue_triage' });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const savedFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return savedFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('triage-agent');
+        await advanceTime(2000);
+
+        // Should have logged "Issue-based task" and NOT tried to fetch a diff
+        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Issue-based task'));
+
+        // Result should have been submitted
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.type).toBe('issue_triage');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+
+    it('issue_dedup task succeeds without diff fetch', async () => {
+      // Return dedup JSON from the tool executor
+      mockedExecuteTool.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          duplicates: [],
+          index_entry: '- #42 [bug] — Test issue',
+        }),
+        stderr: '',
+        exitCode: 0,
+        tokensUsed: 150,
+        tokensParsed: true,
+        tokenDetail: { input: 0, output: 150, total: 150, parsed: true },
+      });
+
+      const taskId = await server.injectIssueTask({ taskType: 'issue_dedup' });
+
+      let resultBody: Record<string, unknown> | null = null;
+      const savedFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          if (typeof init?.body === 'string') {
+            resultBody = JSON.parse(init.body);
+          }
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return savedFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('dedup-agent');
+        await advanceTime(2000);
+
+        // Should have logged "Issue-based task" and NOT tried to fetch a diff
+        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Issue-based task'));
+
+        // Result should have been submitted
+        expect(resultBody).not.toBeNull();
+        expect(resultBody!.type).toBe('issue_dedup');
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+
+    it('issue task does not attempt diff fetch (no diff URL failure)', async () => {
+      mockedExecuteTool.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          category: 'feature',
+          module: 'server',
+          priority: 'medium',
+          size: 'M',
+          labels: ['enhancement'],
+          summary: 'New feature',
+          body: 'Feature description',
+          comment: 'Feature request for server.',
+        }),
+        stderr: '',
+        exitCode: 0,
+        tokensUsed: 180,
+        tokensParsed: true,
+        tokenDetail: { input: 0, output: 180, total: 180, parsed: true },
+      });
+
+      const taskId = await server.injectIssueTask({ taskType: 'issue_triage' });
+
+      const savedFetch = globalThis.fetch;
+      const fetchCalls: string[] = [];
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        fetchCalls.push(url);
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return savedFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const agentPromise = startTestAgent('no-diff-agent');
+        await advanceTime(2000);
+
+        // No diff-related fetch calls should have been made
+        const diffCalls = fetchCalls.filter(
+          (u) => u.includes('.diff') || u.includes('application/vnd.github.v3.diff'),
+        );
+        expect(diffCalls).toHaveLength(0);
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(agentPromise, server);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    });
+  });
 });

--- a/packages/cli/src/__tests__/helpers/fake-server.ts
+++ b/packages/cli/src/__tests__/helpers/fake-server.ts
@@ -228,6 +228,54 @@ export class FakeServer {
     return body.task_id;
   }
 
+  /** Inject an issue-based task directly into the store (no test route for issue events). */
+  async injectIssueTask(opts?: {
+    owner?: string;
+    repo?: string;
+    issueNumber?: number;
+    issueTitle?: string;
+    issueBody?: string;
+    taskType?: 'issue_triage' | 'issue_dedup';
+    indexIssueNumber?: number;
+  }): Promise<string> {
+    const taskId = `issue-task-${Date.now()}`;
+    const groupId = `group-${Date.now()}`;
+    const taskType = opts?.taskType ?? 'issue_triage';
+    const feature = taskType === 'issue_dedup' ? 'dedup_issue' : 'triage';
+
+    const task: ReviewTask = {
+      id: taskId,
+      owner: opts?.owner ?? 'test-org',
+      repo: opts?.repo ?? 'test-repo',
+      pr_number: 0,
+      pr_url: '',
+      diff_url: '',
+      base_ref: '',
+      head_ref: '',
+      prompt: '',
+      timeout_at: Date.now() + 600_000,
+      status: 'pending',
+      github_installation_id: 1,
+      private: false,
+      config: DEFAULT_REVIEW_CONFIG,
+      created_at: Date.now(),
+      task_type: taskType,
+      feature,
+      group_id: groupId,
+      queue: 'review',
+      review_count: 1,
+      issue_number: opts?.issueNumber ?? 42,
+      issue_url: `https://github.com/${opts?.owner ?? 'test-org'}/${opts?.repo ?? 'test-repo'}/issues/${opts?.issueNumber ?? 42}`,
+      issue_title: opts?.issueTitle ?? 'Test issue title',
+      issue_body: opts?.issueBody ?? 'Test issue body content',
+      issue_author: 'test-user',
+      ...(opts?.indexIssueNumber != null ? { index_issue_number: opts.indexIssueNumber } : {}),
+    };
+
+    await this.store.createTask(task);
+    return taskId;
+  }
+
   /** Get a task from the store. */
   async getTask(id: string): Promise<ReviewTask | null> {
     return this.store.getTask(id);

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -495,8 +495,14 @@ async function handleTask(
   const { task_id, owner, repo, pr_number, diff_url, timeout_seconds, prompt, role } = task;
   const { log, logError, logWarn } = logger;
 
-  log(`${icons.success} Claimed task ${task_id} (${role}) — ${owner}/${repo}#${pr_number}`);
-  log(`  https://github.com/${owner}/${repo}/pull/${pr_number}`);
+  const isIssueTask = pr_number === 0;
+  if (isIssueTask) {
+    const issueRef = task.issue_number ? `issue #${task.issue_number}` : 'issue';
+    log(`${icons.success} Claimed task ${task_id} (${role}) — ${owner}/${repo} ${issueRef}`);
+  } else {
+    log(`${icons.success} Claimed task ${task_id} (${role}) — ${owner}/${repo}#${pr_number}`);
+    log(`  https://github.com/${owner}/${repo}/pull/${pr_number}`);
+  }
 
   // Claim the task (retry once — slot may be taken)
   // On failure, server returns structured error (e.g. CLAIM_CONFLICT, TASK_NOT_FOUND)
@@ -526,77 +532,83 @@ async function handleTask(
     return {};
   }
 
-  // Fetch diff — gh CLI first, fall back to HTTP
-  let diffContent: string;
-  try {
-    const result = await fetchDiff(diff_url, owner, repo, pr_number, {
-      githubToken: client.currentToken,
-      signal,
-      maxDiffSizeKb: reviewDeps.maxDiffSizeKb,
-    });
-    diffContent = result.diff;
-    log(`  Diff fetched via ${result.method} (${Math.round(diffContent.length / 1024)}KB)`);
-  } catch (err) {
-    logError(`  Failed to fetch diff for task ${task_id}: ${(err as Error).message}`);
-    await safeReject(
-      client,
-      task_id,
-      agentId,
-      `Cannot access diff: ${(err as Error).message}`,
-      logger,
-    );
-    return { diffFetchFailed: true };
-  }
-
-  // Clone/update codebase if configured, otherwise create a repo-scoped working directory
+  // Issue-based tasks (issue_triage, issue_dedup) have no diff, codebase, or PR context
+  let diffContent = '';
   let taskReviewDeps = reviewDeps;
   let taskCheckoutPath: string | null = null;
-  if (reviewDeps.codebaseDir) {
-    try {
-      const result = cloneOrUpdate(owner, repo, pr_number, reviewDeps.codebaseDir, task_id);
-      log(`  Codebase ${result.cloned ? 'cloned' : 'updated'}: ${result.localPath}`);
-      taskCheckoutPath = result.localPath;
-      // Pass the resolved local path as codebaseDir for this task
-      taskReviewDeps = { ...reviewDeps, codebaseDir: result.localPath };
-    } catch (err) {
-      logWarn(
-        `  Warning: codebase clone failed: ${(err as Error).message}. Continuing with diff-only review.`,
-      );
-      taskReviewDeps = { ...reviewDeps, codebaseDir: null };
-    }
-  } else {
-    // No codebase_dir configured — create a repo-scoped working directory
-    try {
-      validatePathSegment(owner, 'owner');
-      validatePathSegment(repo, 'repo');
-      validatePathSegment(task_id, 'task_id');
-      const repoScopedDir = path.join(CONFIG_DIR, 'repos', owner, repo, task_id);
-      fs.mkdirSync(repoScopedDir, { recursive: true });
-      taskCheckoutPath = repoScopedDir;
-      taskReviewDeps = { ...reviewDeps, codebaseDir: repoScopedDir };
-      log(`  Working directory: ${repoScopedDir}`);
-    } catch (err) {
-      logWarn(
-        `  Warning: failed to create working directory: ${(err as Error).message}. Continuing without scoped cwd.`,
-      );
-    }
-  }
-
-  // Fetch PR context (metadata, comments, reviews) — non-blocking on failure
   let contextBlock: string | undefined;
-  try {
-    const prContext = await fetchPRContext(owner, repo, pr_number, {
-      githubToken: client.currentToken,
-      signal,
-    });
-    if (hasContent(prContext)) {
-      contextBlock = formatPRContext(prContext, taskReviewDeps.codebaseDir);
-      log('  PR context fetched');
+
+  if (isIssueTask) {
+    log('  Issue-based task — skipping diff fetch');
+  } else {
+    // Fetch diff — gh CLI first, fall back to HTTP
+    try {
+      const result = await fetchDiff(diff_url, owner, repo, pr_number, {
+        githubToken: client.currentToken,
+        signal,
+        maxDiffSizeKb: reviewDeps.maxDiffSizeKb,
+      });
+      diffContent = result.diff;
+      log(`  Diff fetched via ${result.method} (${Math.round(diffContent.length / 1024)}KB)`);
+    } catch (err) {
+      logError(`  Failed to fetch diff for task ${task_id}: ${(err as Error).message}`);
+      await safeReject(
+        client,
+        task_id,
+        agentId,
+        `Cannot access diff: ${(err as Error).message}`,
+        logger,
+      );
+      return { diffFetchFailed: true };
     }
-  } catch (err) {
-    logWarn(
-      `  Warning: failed to fetch PR context: ${(err as Error).message}. Continuing without.`,
-    );
+
+    // Clone/update codebase if configured, otherwise create a repo-scoped working directory
+    if (reviewDeps.codebaseDir) {
+      try {
+        const result = cloneOrUpdate(owner, repo, pr_number, reviewDeps.codebaseDir, task_id);
+        log(`  Codebase ${result.cloned ? 'cloned' : 'updated'}: ${result.localPath}`);
+        taskCheckoutPath = result.localPath;
+        // Pass the resolved local path as codebaseDir for this task
+        taskReviewDeps = { ...reviewDeps, codebaseDir: result.localPath };
+      } catch (err) {
+        logWarn(
+          `  Warning: codebase clone failed: ${(err as Error).message}. Continuing with diff-only review.`,
+        );
+        taskReviewDeps = { ...reviewDeps, codebaseDir: null };
+      }
+    } else {
+      // No codebase_dir configured — create a repo-scoped working directory
+      try {
+        validatePathSegment(owner, 'owner');
+        validatePathSegment(repo, 'repo');
+        validatePathSegment(task_id, 'task_id');
+        const repoScopedDir = path.join(CONFIG_DIR, 'repos', owner, repo, task_id);
+        fs.mkdirSync(repoScopedDir, { recursive: true });
+        taskCheckoutPath = repoScopedDir;
+        taskReviewDeps = { ...reviewDeps, codebaseDir: repoScopedDir };
+        log(`  Working directory: ${repoScopedDir}`);
+      } catch (err) {
+        logWarn(
+          `  Warning: failed to create working directory: ${(err as Error).message}. Continuing without scoped cwd.`,
+        );
+      }
+    }
+
+    // Fetch PR context (metadata, comments, reviews) — non-blocking on failure
+    try {
+      const prContext = await fetchPRContext(owner, repo, pr_number, {
+        githubToken: client.currentToken,
+        signal,
+      });
+      if (hasContent(prContext)) {
+        contextBlock = formatPRContext(prContext, taskReviewDeps.codebaseDir);
+        log('  PR context fetched');
+      }
+    } catch (err) {
+      logWarn(
+        `  Warning: failed to fetch PR context: ${(err as Error).message}. Continuing without.`,
+      );
+    }
   }
 
   // Check repo prompt for suspicious patterns (prompt injection attempts)


### PR DESCRIPTION
Part of #541

## Summary
- Skip diff fetching, codebase cloning, and PR context fetching for issue-based tasks (pr_number=0)
- Issue tasks (issue_triage, issue_dedup) operate on issue title/body, not code diffs — attempting to fetch a diff crashes with "Failed to parse URL from .diff"
- Add `injectIssueTask` helper to FakeServer for testing issue-based task flows

## Test plan
- [x] New test: issue_triage task succeeds without diff fetch
- [x] New test: issue_dedup task succeeds without diff fetch
- [x] New test: issue task does not attempt diff-related fetch calls
- [x] All 1877 existing tests pass
- [x] Build, lint, typecheck, format all pass