### PR TITLE
[cli-dev] Change dedup index entry format to NUMBER(LABELS): DESCRIPTION

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -1571,7 +1571,7 @@ describe('Agent Coverage Tests', () => {
       mockedExecuteTool.mockResolvedValueOnce({
         stdout: JSON.stringify({
           duplicates: [],
-          index_entry: '- #42 [bug] — Test issue',
+          index_entry: '- 42(bug): Test issue',
         }),
         stderr: '',
         exitCode: 0,

--- a/packages/cli/src/__tests__/dedup-init.test.ts
+++ b/packages/cli/src/__tests__/dedup-init.test.ts
@@ -46,12 +46,12 @@ describe('formatEntry', () => {
       title: 'Fix login bug',
       labels: [{ name: 'bug' }, { name: 'critical' }],
     });
-    expect(formatEntry(item)).toBe('- #42 [bug] [critical] — Fix login bug');
+    expect(formatEntry(item)).toBe('- 42(bug, critical): Fix login bug');
   });
 
   it('formats item without labels', () => {
     const item = makeItem({ number: 10, title: 'Add feature' });
-    expect(formatEntry(item)).toBe('- #10 — Add feature');
+    expect(formatEntry(item)).toBe('- 10(): Add feature');
   });
 
   it('formats compact entry (archived)', () => {
@@ -60,7 +60,7 @@ describe('formatEntry', () => {
       title: 'Fix login bug',
       labels: [{ name: 'bug' }],
     });
-    expect(formatEntry(item, true)).toBe('- #42 — Fix login bug');
+    expect(formatEntry(item, true)).toBe('- 42(): Fix login bug');
   });
 });
 
@@ -150,6 +150,29 @@ Not a list item #99`;
     const numbers = parseExistingNumbers(body);
     expect(numbers).toEqual(new Set([5]));
   });
+
+  it('parses numbers from new format entries', () => {
+    const body = `<!-- opencara-dedup-index:open -->
+## Open Items
+
+- 1(bug): Fix
+- 42(): Add feature
+- 100(feat, ui): Dashboard`;
+
+    const numbers = parseExistingNumbers(body);
+    expect(numbers).toEqual(new Set([1, 42, 100]));
+  });
+
+  it('parses numbers from mixed old and new format entries', () => {
+    const body = `<!-- opencara-dedup-index:open -->
+## Open Items
+
+- #1 [bug] — Fix
+- 42(cli): Add feature`;
+
+    const numbers = parseExistingNumbers(body);
+    expect(numbers).toEqual(new Set([1, 42]));
+  });
 });
 
 // ── buildCommentBody ─────────────────────────────────────────
@@ -166,8 +189,8 @@ describe('buildCommentBody', () => {
     const body = buildCommentBody(marker, header, items, null);
     expect(body).toContain(marker);
     expect(body).toContain('## Open Items');
-    expect(body).toContain('- #1 — First');
-    expect(body).toContain('- #2 — Second');
+    expect(body).toContain('- 1(): First');
+    expect(body).toContain('- 2(): Second');
   });
 
   it('merges without duplicates', () => {
@@ -179,17 +202,17 @@ describe('buildCommentBody', () => {
     const body = buildCommentBody(marker, header, items, existingBody);
     // Should contain #1 from existing and add #3
     expect(body).toContain('- #1 — First');
-    expect(body).toContain('- #3 — Third');
+    expect(body).toContain('- 3(): Third');
     // Should NOT have duplicate #1
-    const count1 = (body.match(/- #1/g) || []).length;
+    const count1 = (body.match(/- #?1[\s(]/g) || []).length;
     expect(count1).toBe(1);
   });
 
   it('uses compact format for archived', () => {
     const items = [makeItem({ number: 1, title: 'Item', labels: [{ name: 'bug' }] })];
     const body = buildCommentBody(marker, header, items, null, true);
-    expect(body).toContain('- #1 — Item');
-    expect(body).not.toContain('[bug]');
+    expect(body).toContain('- 1(): Item');
+    expect(body).not.toContain('bug');
   });
 });
 
@@ -358,11 +381,11 @@ describe('initIndex', () => {
     expect(result.newEntries).toBe(3);
     expect(createdComments).toHaveLength(3);
     expect(createdComments[0]).toContain('Open Items');
-    expect(createdComments[0]).toContain('- #1 — Open PR');
+    expect(createdComments[0]).toContain('- 1(): Open PR');
     expect(createdComments[1]).toContain('Recently Closed');
-    expect(createdComments[1]).toContain('- #2 — Recent PR');
+    expect(createdComments[1]).toContain('- 2(): Recent PR');
     expect(createdComments[2]).toContain('Archived');
-    expect(createdComments[2]).toContain('- #3 — Old PR');
+    expect(createdComments[2]).toContain('- 3(): Old PR');
   });
 
   it('merges with existing entries', async () => {
@@ -411,8 +434,8 @@ describe('initIndex', () => {
     const openUpdate = updatedBodies.find((u) => u.id === 100);
     expect(openUpdate).toBeDefined();
     expect(openUpdate!.body).toContain('- #1 — Existing PR');
-    expect(openUpdate!.body).toContain('- #4 — New PR');
-    const count1 = (openUpdate!.body.match(/- #1/g) || []).length;
+    expect(openUpdate!.body).toContain('- 4(): New PR');
+    const count1 = (openUpdate!.body.match(/- #?1[\s(]/g) || []).length;
     expect(count1).toBe(1);
   });
 

--- a/packages/cli/src/__tests__/dedup.test.ts
+++ b/packages/cli/src/__tests__/dedup.test.ts
@@ -107,7 +107,7 @@ describe('buildDedupPrompt', () => {
 
   it('specifies index_entry format', () => {
     const prompt = buildDedupPrompt(baseTask);
-    expect(prompt).toContain('- #<number> [label1] [label2]');
+    expect(prompt).toContain('- <number>(<label1>, <label2>, ...): <short description>');
   });
 
   it('injects custom prompt as Repo-Specific Instructions', () => {

--- a/packages/cli/src/commands/dedup.ts
+++ b/packages/cli/src/commands/dedup.ts
@@ -228,16 +228,15 @@ async function updateIssueComment(
 
 /**
  * Format a single item as an index entry line.
- * Full format: `- #<number> [label1] [label2] — <title>`
- * Compact format (archived): `- #<number> — <title>`
+ * Full format: `- <number>(<label1>, <label2>): <title>`
+ * Compact format (archived): `- <number>(): <title>`
  */
 export function formatEntry(item: GitHubItem, compact: boolean = false): string {
   if (compact) {
-    return `- #${item.number} — ${item.title}`;
+    return `- ${item.number}(): ${item.title}`;
   }
-  const labels = item.labels.map((l) => `[${l.name}]`).join(' ');
-  const labelPart = labels ? ` ${labels}` : '';
-  return `- #${item.number}${labelPart} — ${item.title}`;
+  const labels = item.labels.map((l) => l.name).join(', ');
+  return `- ${item.number}(${labels}): ${item.title}`;
 }
 
 // ── Categorization ───────────────────────────────────────────
@@ -271,10 +270,12 @@ export function categorizeItems(
 
 // ── Comment Body Building ────────────────────────────────────
 
-/** Parse existing entries from a comment body. Returns the set of #numbers already present. */
+/** Parse existing entries from a comment body. Returns the set of numbers already present.
+ *  Supports both old format (`- #42 ...`) and new format (`- 42(...): ...`).
+ */
 export function parseExistingNumbers(body: string): Set<number> {
   const numbers = new Set<number>();
-  const regex = /^- #(\d+)/gm;
+  const regex = /^- #?(\d+)/gm;
   let match: RegExpExecArray | null;
   while ((match = regex.exec(body)) !== null) {
     numbers.add(parseInt(match[1], 10));

--- a/packages/cli/src/dedup.ts
+++ b/packages/cli/src/dedup.ts
@@ -57,7 +57,7 @@ You MUST output ONLY a valid JSON object matching this exact schema (no markdown
 
 - "duplicates": array of matches found (empty array if no duplicates)
 - "similarity": "exact" = identical intent/change, "high" = very similar with minor differences, "partial" = overlapping but distinct
-- "index_entry": a single line in the format: \`- #<number> [label1] [label2] — <short description>\``);
+- "index_entry": a single line in the format: \`- <number>(<label1>, <label2>, ...): <short description>\` where labels are inferred from GitHub labels, PR/issue title, body, and any available context`);
 
   if (task.customPrompt) {
     parts.push(`\n## Repo-Specific Instructions\n\n${task.customPrompt}`);


### PR DESCRIPTION
Part of #544

## Summary
- Changed index_entry format instruction in buildDedupPrompt to new format
- Updated formatEntry in dedup init command to produce entries in the new format
- Updated parseExistingNumbers for backward compatibility with both old and new formats
- Added tests for new and mixed format parsing

## Test plan
- All 1909 tests passing across 67 test files
- New tests verify parseExistingNumbers handles new and mixed format entries