### PR TITLE
[server-dev] Add preferred_models support for summarizer config

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -2148,6 +2148,208 @@ describe('Task Routes', () => {
     });
   });
 
+  // ── Preferred summarizer models (#555) ──────────────────
+
+  describe('preferred summarizer models (#555)', () => {
+    function makeModelPreferredConfig(preferredModels: string[]) {
+      return {
+        ...DEFAULT_REVIEW_CONFIG,
+        summarizer: {
+          ...DEFAULT_REVIEW_CONFIG.summarizer,
+          preferredModels,
+        },
+      };
+    }
+
+    describe('poll — model preference during grace period', () => {
+      it('agent with matching model gets summary immediately', async () => {
+        await store.createTask(
+          makeTask({
+            config: makeModelPreferredConfig(['claude-opus-4-6', 'gpt-5.4']),
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-a',
+          model: 'claude-opus-4-6',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(1);
+        expect(body.tasks[0].role).toBe('summary');
+      });
+
+      it('agent without matching model is held during grace period', async () => {
+        await store.createTask(
+          makeTask({
+            config: makeModelPreferredConfig(['claude-opus-4-6']),
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-a',
+          model: 'gpt-4o',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(0);
+      });
+
+      it('agent without model is held during grace period', async () => {
+        await store.createTask(
+          makeTask({
+            config: makeModelPreferredConfig(['claude-opus-4-6']),
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-a',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(0);
+      });
+
+      it('non-matching agent gets summary after grace period expires', async () => {
+        await store.createTask(
+          makeTask({
+            config: makeModelPreferredConfig(['claude-opus-4-6']),
+            created_at: Date.now() - PREFERRED_SYNTH_GRACE_PERIOD_MS - 1000,
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-a',
+          model: 'gpt-4o',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(1);
+        expect(body.tasks[0].role).toBe('summary');
+      });
+    });
+
+    describe('combined entity and model preferences', () => {
+      it('entity-preferred agent gets summary even without matching model', async () => {
+        await store.createTask(
+          makeTask({
+            config: {
+              ...DEFAULT_REVIEW_CONFIG,
+              summarizer: {
+                ...DEFAULT_REVIEW_CONFIG.summarizer,
+                preferred: [{ agent: 'agent-preferred' }],
+                preferredModels: ['claude-opus-4-6'],
+              },
+            },
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-preferred',
+          model: 'gpt-4o',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(1);
+      });
+
+      it('model-preferred agent gets summary even without entity match', async () => {
+        await store.createTask(
+          makeTask({
+            config: {
+              ...DEFAULT_REVIEW_CONFIG,
+              summarizer: {
+                ...DEFAULT_REVIEW_CONFIG.summarizer,
+                preferred: [{ agent: 'agent-preferred' }],
+                preferredModels: ['claude-opus-4-6'],
+              },
+            },
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-other',
+          model: 'claude-opus-4-6',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(1);
+      });
+
+      it('agent matching neither entity nor model is held during grace period', async () => {
+        await store.createTask(
+          makeTask({
+            config: {
+              ...DEFAULT_REVIEW_CONFIG,
+              summarizer: {
+                ...DEFAULT_REVIEW_CONFIG.summarizer,
+                preferred: [{ agent: 'agent-preferred' }],
+                preferredModels: ['claude-opus-4-6'],
+              },
+            },
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/poll', {
+          agent_id: 'agent-other',
+          model: 'gpt-4o',
+        });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(0);
+      });
+    });
+
+    describe('claim — model preference during grace period', () => {
+      it('model-preferred agent can claim summary during grace period', async () => {
+        await store.createTask(
+          makeTask({
+            task_type: 'summary',
+            queue: 'summary',
+            config: makeModelPreferredConfig(['claude-opus-4-6']),
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/task-1/claim', {
+          agent_id: 'agent-a',
+          role: 'summary',
+          model: 'claude-opus-4-6',
+        });
+        const body = await res.json();
+        expect(body.claimed).toBe(true);
+      });
+
+      it('non-matching model agent cannot claim during grace period', async () => {
+        await store.createTask(
+          makeTask({
+            task_type: 'summary',
+            queue: 'summary',
+            config: makeModelPreferredConfig(['claude-opus-4-6']),
+            created_at: Date.now(),
+          }),
+        );
+
+        const res = await request('POST', '/api/tasks/task-1/claim', {
+          agent_id: 'agent-a',
+          role: 'summary',
+          model: 'gpt-4o',
+        });
+        expect(res.status).toBe(409);
+      });
+    });
+
+    describe('backward compatibility', () => {
+      it('summary is available immediately when no preferredModels set', async () => {
+        await store.createTask(makeTask());
+
+        const res = await request('POST', '/api/tasks/poll', { agent_id: 'any-agent' });
+        const body = await res.json();
+        expect(body.tasks).toHaveLength(1);
+        expect(body.tasks[0].role).toBe('summary');
+      });
+    });
+  });
+
   // ── Preferred review models/tools (#355) ───────────────
 
   describe('preferred review models/tools (#355)', () => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -88,13 +88,21 @@ function isWorkerVisibleToAgent(task: ReviewTask, model?: string, tool?: string)
 /**
  * Check if a summary task is visible to the given agent, considering
  * the preferred synthesizer grace period.
+ * Checks both entity-based preferences and model-based preferences.
  */
-function isSummaryVisibleToAgent(task: ReviewTask, agentId: string): boolean {
-  const preferred = task.config?.summarizer?.preferred ?? [];
-  if (preferred.length === 0) return true;
+function isSummaryVisibleToAgent(task: ReviewTask, agentId: string, model?: string): boolean {
+  const summarizer = task.config?.summarizer;
+  const preferred = summarizer?.preferred ?? [];
+  const preferredModels = summarizer?.preferredModels ?? [];
 
-  const isPreferred = preferred.some((p) => isEntityMatch(p, agentId));
-  if (isPreferred) return true;
+  // No preferences at all — visible to everyone
+  if (preferred.length === 0 && preferredModels.length === 0) return true;
+
+  // Check entity-based preference
+  if (preferred.length > 0 && preferred.some((p) => isEntityMatch(p, agentId))) return true;
+
+  // Check model-based preference
+  if (preferredModels.length > 0 && model && preferredModels.includes(model)) return true;
 
   // Non-preferred agent: check if grace period has elapsed since task creation
   return Date.now() - task.created_at >= PREFERRED_SYNTH_GRACE_PERIOD_MS;
@@ -637,7 +645,7 @@ export function taskRoutes() {
 
       // Grace period visibility checks
       if (isSummaryTask(task)) {
-        if (!isSummaryVisibleToAgent(task, agent_id)) continue;
+        if (!isSummaryVisibleToAgent(task, agent_id, body.model)) continue;
         // Repo filter for summary agents
         if (synthesize_repos) {
           if (!isRepoAllowed(synthesize_repos, task.owner, task.repo)) continue;
@@ -803,7 +811,7 @@ export function taskRoutes() {
     }
 
     // Grace period check for summary tasks
-    if (isSummaryTask(task) && !isSummaryVisibleToAgent(task, agent_id)) {
+    if (isSummaryTask(task) && !isSummaryVisibleToAgent(task, agent_id, model)) {
       return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
     }
 

--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -724,6 +724,83 @@ describe('summarizer shorthand parsing', () => {
   });
 });
 
+// ── Summarizer preferred_models parsing ──
+
+describe('summarizer.preferred_models parsing', () => {
+  it('parses preferred_models in full object form (legacy)', () => {
+    const config = parseReviewConfig(
+      'version = 1\nprompt = "test"\n[summarizer]\npreferred_models = ["claude-opus-4-6", "gpt-5.4"]',
+    ) as ReviewConfig;
+    expect(config.summarizer.preferredModels).toEqual(['claude-opus-4-6', 'gpt-5.4']);
+  });
+
+  it('parses preferred_models alongside "only" string', () => {
+    const config = parseReviewConfig(
+      'version = 1\nprompt = "test"\n[summarizer]\nonly = "alice"\npreferred_models = ["claude-opus-4-6"]',
+    ) as ReviewConfig;
+    expect(config.summarizer.whitelist).toEqual([{ github: 'alice' }]);
+    expect(config.summarizer.preferredModels).toEqual(['claude-opus-4-6']);
+  });
+
+  it('parses preferred_models alongside "only" list', () => {
+    const config = parseReviewConfig(
+      'version = 1\nprompt = "test"\n[summarizer]\nonly = ["alice", "bob"]\npreferred_models = ["gpt-5.4"]',
+    ) as ReviewConfig;
+    expect(config.summarizer.whitelist).toEqual([{ github: 'alice' }, { github: 'bob' }]);
+    expect(config.summarizer.preferredModels).toEqual(['gpt-5.4']);
+  });
+
+  it('defaults to empty array when preferred_models is not set', () => {
+    const config = parseReviewConfig(MINIMAL_LEGACY_CONFIG) as ReviewConfig;
+    expect(config.summarizer.preferredModels).toEqual([]);
+  });
+
+  it('defaults to empty array for string shorthand (no object)', () => {
+    const config = parseReviewConfig(
+      'version = 1\nprompt = "test"\nsummarizer = "alice"',
+    ) as ReviewConfig;
+    expect(config.summarizer.preferredModels).toEqual([]);
+  });
+
+  it('filters non-string entries from preferred_models', () => {
+    const config = parseReviewConfig(
+      'version = 1\nprompt = "test"\n[summarizer]\npreferred_models = ["claude-opus-4-6", 123, "gpt-5.4"]',
+    ) as ReviewConfig;
+    expect(config.summarizer.preferredModels).toEqual(['claude-opus-4-6', 'gpt-5.4']);
+  });
+
+  it('parses preferred_models in new format [review.summarizer]', () => {
+    const toml = `
+version = 1
+[review]
+prompt = "Review this"
+[review.summarizer]
+only = "quabug"
+preferred_models = ["claude-opus-4-6", "gpt-5.4"]
+`;
+    const result = parseOpenCaraConfig(toml) as OpenCaraConfig;
+    expect(result.review!.summarizer.whitelist).toEqual([{ github: 'quabug' }]);
+    expect(result.review!.summarizer.preferredModels).toEqual(['claude-opus-4-6', 'gpt-5.4']);
+  });
+
+  it('parses preferred_models alongside entity preferences in new format', () => {
+    const toml = `
+version = 1
+[review]
+prompt = "Review this"
+preferred_models = ["claude-opus-4-6"]
+[review.summarizer]
+preferred_models = ["gpt-5.4"]
+[[review.summarizer.preferred]]
+github = "alice"
+`;
+    const result = parseOpenCaraConfig(toml) as OpenCaraConfig;
+    expect(result.review!.preferredModels).toEqual(['claude-opus-4-6']);
+    expect(result.review!.summarizer.preferred).toEqual([{ github: 'alice' }]);
+    expect(result.review!.summarizer.preferredModels).toEqual(['gpt-5.4']);
+  });
+});
+
 describe('isEntityMatch', () => {
   it('matches by agent ID', () => {
     expect(isEntityMatch({ agent: 'agent-abc' }, 'agent-abc')).toBe(true);

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -30,7 +30,12 @@ export interface FeatureConfig {
 export interface ReviewSectionConfig extends FeatureConfig {
   trigger: TriggerConfig;
   reviewer: { whitelist: EntityEntry[]; blacklist: EntityEntry[] };
-  summarizer: { whitelist: EntityEntry[]; blacklist: EntityEntry[]; preferred: EntityEntry[] };
+  summarizer: {
+    whitelist: EntityEntry[];
+    blacklist: EntityEntry[];
+    preferred: EntityEntry[];
+    preferredModels: string[];
+  };
 }
 
 /** Dedup target config for PRs */
@@ -175,7 +180,7 @@ export const DEFAULT_REVIEW_SECTION: ReviewSectionConfig = {
   ...DEFAULT_FEATURE_CONFIG,
   trigger: DEFAULT_TRIGGER,
   reviewer: { whitelist: [], blacklist: [] },
-  summarizer: { whitelist: [], blacklist: [], preferred: [] },
+  summarizer: { whitelist: [], blacklist: [], preferred: [], preferredModels: [] },
 };
 
 /** @deprecated Use DEFAULT_REVIEW_SECTION instead */
@@ -207,6 +212,7 @@ function parseSummarizerSection(raw: unknown): ReviewSectionConfig['summarizer']
     whitelist: [],
     blacklist: [],
     preferred: [],
+    preferredModels: [],
   };
 
   // String shorthand: "alice" → preferred with github username
@@ -216,18 +222,21 @@ function parseSummarizerSection(raw: unknown): ReviewSectionConfig['summarizer']
 
   if (!isObject(raw)) return defaults;
 
+  // Parse preferred_models from any object form
+  const preferredModels = parseStringArray(raw.preferred_models);
+
   // Object with "only" key — whitelist-only mode
   if (raw.only !== undefined) {
     if (typeof raw.only === 'string') {
-      return { ...defaults, whitelist: [toGithubEntity(raw.only)] };
+      return { ...defaults, whitelist: [toGithubEntity(raw.only)], preferredModels };
     }
     if (Array.isArray(raw.only)) {
       const entries = raw.only
         .filter((v: unknown) => typeof v === 'string')
         .map((v: unknown) => toGithubEntity(v as string));
-      return { ...defaults, whitelist: entries };
+      return { ...defaults, whitelist: entries, preferredModels };
     }
-    return defaults;
+    return { ...defaults, preferredModels };
   }
 
   // Full object (existing behavior)
@@ -235,6 +244,7 @@ function parseSummarizerSection(raw: unknown): ReviewSectionConfig['summarizer']
     whitelist: parseEntityList(raw.whitelist),
     blacklist: parseEntityList(raw.blacklist),
     preferred: parseEntityList(raw.preferred),
+    preferredModels,
   };
 }
 


### PR DESCRIPTION
Part of #555

## Summary
- Added `preferredModels: string[]` field to `ReviewSectionConfig.summarizer` type
- Updated `parseSummarizerSection()` to parse `preferred_models` from TOML across all summarizer forms (full object, "only" shorthand, string shorthand)
- Updated `isSummaryVisibleToAgent()` to check model-based preferences alongside entity-based preferences during the grace period
- Updated both poll and claim call sites to pass the agent's model

## Test plan
- Shared parser tests: preferred_models parsing in full object, "only" shorthand, string shorthand, new format, combined with entity preferences, non-string filtering
- Server poll tests: model-matching visibility, grace period hold, grace period expiry, combined entity+model preferences
- Server claim tests: model-preferred claim during grace period, non-matching model rejection
- Backward compatibility: configs without summarizer.preferred_models work unchanged