### PR TITLE
[cli-dev] Add backward-compatible aliases for renamed repo filter modes

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -789,12 +789,13 @@ tool = "claude"
 [agents.repos]
 mode = "all"
 `);
-      const warnSpy = vi.spyOn(console, 'warn');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const config = loadConfig();
       expect(config.agents![0].repos).toEqual({ mode: 'public' });
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('"all" is deprecated, use "public" instead'),
       );
+      warnSpy.mockRestore();
     });
 
     it('accepts deprecated mode "own" as alias for "private" with warning', () => {
@@ -806,12 +807,13 @@ tool = "claude"
 [agents.repos]
 mode = "own"
 `);
-      const warnSpy = vi.spyOn(console, 'warn');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const config = loadConfig();
       expect(config.agents![0].repos).toEqual({ mode: 'private' });
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('"own" is deprecated, use "private" instead'),
       );
+      warnSpy.mockRestore();
     });
 
     it('saveConfig persists repos field on agents', () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -98,7 +98,7 @@ function parseRepoConfig(
   if (mode === undefined) {
     throw new RepoConfigError(`agents[${index}].${field}.mode is required`);
   }
-  if (typeof mode === 'string' && mode in REPO_MODE_ALIASES) {
+  if (typeof mode === 'string' && Object.hasOwn(REPO_MODE_ALIASES, mode)) {
     const resolved = REPO_MODE_ALIASES[mode];
     console.warn(
       `⚠ Config warning: agents[${index}].${field}.mode "${mode}" is deprecated, use "${resolved}" instead`,


### PR DESCRIPTION
Part of #557

## Summary
- Add `REPO_MODE_ALIASES` map (`all→public`, `own→private`) in the config parser, following the existing `TOOL_ALIASES` pattern
- Deprecated mode names are accepted with a console warning instead of crashing
- Fix test that expected old mode names in the error message
- Add 2 new tests verifying alias resolution and deprecation warnings

## Test plan
- [x] `mode = "all"` parses as `mode: "public"` with deprecation warning
- [x] `mode = "own"` parses as `mode: "private"` with deprecation warning
- [x] Invalid modes still throw `RepoConfigError`
- [x] All 121 config tests pass
- [x] Build, lint, format, typecheck all pass