### PR TITLE
[cli-dev] Remove backward-compat aliases for repo filter modes

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -780,42 +780,6 @@ mode = "private"
       expect(config.agents![0].repos!.list).toBeUndefined();
     });
 
-    it('accepts deprecated mode "all" as alias for "public" with warning', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(`
-[[agents]]
-model = "claude-opus-4-6"
-tool = "claude"
-[agents.repos]
-mode = "all"
-`);
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const config = loadConfig();
-      expect(config.agents![0].repos).toEqual({ mode: 'public' });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"all" is deprecated, use "public" instead'),
-      );
-      warnSpy.mockRestore();
-    });
-
-    it('accepts deprecated mode "own" as alias for "private" with warning', () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-      vi.mocked(fs.readFileSync).mockReturnValue(`
-[[agents]]
-model = "claude-opus-4-6"
-tool = "claude"
-[agents.repos]
-mode = "own"
-`);
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const config = loadConfig();
-      expect(config.agents![0].repos).toEqual({ mode: 'private' });
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"own" is deprecated, use "private" instead'),
-      );
-      warnSpy.mockRestore();
-    });
-
     it('saveConfig persists repos field on agents', () => {
       saveConfig({
         platformUrl: DEFAULT_PLATFORM_URL,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -54,12 +54,6 @@ export const DEFAULT_MAX_CONSECUTIVE_ERRORS = 10;
 const VALID_REPO_MODES: RepoFilterMode[] = ['public', 'private', 'whitelist', 'blacklist'];
 const REPO_PATTERN = /^[^/]+\/[^/]+$/;
 
-/** Backward-compatible aliases for renamed repo filter modes. */
-const REPO_MODE_ALIASES: Record<string, RepoFilterMode> = {
-  all: 'public',
-  own: 'private',
-};
-
 export class RepoConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -93,17 +87,10 @@ function parseRepoConfig(
   }
 
   const reposObj = raw as Record<string, unknown>;
-  let mode = reposObj.mode;
+  const mode = reposObj.mode;
 
   if (mode === undefined) {
     throw new RepoConfigError(`agents[${index}].${field}.mode is required`);
-  }
-  if (typeof mode === 'string' && Object.hasOwn(REPO_MODE_ALIASES, mode)) {
-    const resolved = REPO_MODE_ALIASES[mode];
-    console.warn(
-      `⚠ Config warning: agents[${index}].${field}.mode "${mode}" is deprecated, use "${resolved}" instead`,
-    );
-    mode = resolved;
   }
   if (typeof mode !== 'string' || !VALID_REPO_MODES.includes(mode as RepoFilterMode)) {
     throw new RepoConfigError(


### PR DESCRIPTION
Part of #557

## Summary
- Remove `REPO_MODE_ALIASES` map and alias resolution logic from config parser
- Remove 2 alias tests from config.test.ts
- The all→public and own→private rename is intentional and final per team lead directive — no backward compatibility needed

This reverts the alias portion of PR #559 while keeping the test assertion fix (error message now correctly lists `public, private` instead of `all, own`).

## Test plan
- [x] All 119 config tests pass
- [x] Invalid modes still throw `RepoConfigError` with correct message
- [x] No leftover "all"/"own" references in non-test source code
- [x] Build, lint, format, typecheck all pass