### PR TITLE
[cli-dev] Persistent repo cache with git worktrees

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -11,8 +11,6 @@
  * - handleTask codebase clone paths
  * - DiffTooLargeError / InputTooLargeError rejection paths
  */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
@@ -40,24 +38,27 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 // ── Mock repo-cache so git worktree operations don't need real git ──
-
-vi.mock('../repo-cache.js', () => ({
-  checkoutWorktree: vi.fn(
-    async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
-      const worktreePath = path.join(baseDir, owner, `${repo}-worktrees`, taskId);
-      const bareRepoPath = path.join(baseDir, owner, `${repo}.git`);
-      fs.mkdirSync(worktreePath, { recursive: true });
-      return { worktreePath, bareRepoPath, cloned: true };
-    },
-  ),
-  cleanupWorktree: vi.fn((_bareRepoPath: string, worktreePath: string) => {
-    try {
-      fs.rmSync(worktreePath, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
-  }),
-}));
+vi.mock('../repo-cache.js', async () => {
+  const _fs = await import('node:fs');
+  const _path = await import('node:path');
+  return {
+    checkoutWorktree: vi.fn(
+      async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
+        const worktreePath = _path.join(baseDir, owner, `${repo}-worktrees`, taskId);
+        const bareRepoPath = _path.join(baseDir, owner, `${repo}.git`);
+        _fs.mkdirSync(worktreePath, { recursive: true });
+        return { worktreePath, bareRepoPath, cloned: true };
+      },
+    ),
+    cleanupWorktree: vi.fn(async (_bareRepoPath: string, worktreePath: string) => {
+      try {
+        _fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }),
+  };
+});
 
 // ── Mock tool executor ───────────────────────────────────────
 

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { startAgent, computeRoles, type ConsumptionDeps } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
@@ -25,24 +23,27 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 // ── Mock repo-cache so git worktree operations don't need real git ──
-
-vi.mock('../repo-cache.js', () => ({
-  checkoutWorktree: vi.fn(
-    async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
-      const worktreePath = path.join(baseDir, owner, `${repo}-worktrees`, taskId);
-      const bareRepoPath = path.join(baseDir, owner, `${repo}.git`);
-      fs.mkdirSync(worktreePath, { recursive: true });
-      return { worktreePath, bareRepoPath, cloned: true };
-    },
-  ),
-  cleanupWorktree: vi.fn((_bareRepoPath: string, worktreePath: string) => {
-    try {
-      fs.rmSync(worktreePath, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
-  }),
-}));
+vi.mock('../repo-cache.js', async () => {
+  const _fs = await import('node:fs');
+  const _path = await import('node:path');
+  return {
+    checkoutWorktree: vi.fn(
+      async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
+        const worktreePath = _path.join(baseDir, owner, `${repo}-worktrees`, taskId);
+        const bareRepoPath = _path.join(baseDir, owner, `${repo}.git`);
+        _fs.mkdirSync(worktreePath, { recursive: true });
+        return { worktreePath, bareRepoPath, cloned: true };
+      },
+    ),
+    cleanupWorktree: vi.fn(async (_bareRepoPath: string, worktreePath: string) => {
+      try {
+        _fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }),
+  };
+});
 
 vi.mock('../tool-executor.js', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;

--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -7,8 +7,6 @@
  *
  * Mocks: tool-executor (no real AI calls), globalThis.fetch (routes to Hono app).
  */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
@@ -35,24 +33,27 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 // ── Mock repo-cache so git worktree operations don't need real git ──
-
-vi.mock('../repo-cache.js', () => ({
-  checkoutWorktree: vi.fn(
-    async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
-      const worktreePath = path.join(baseDir, owner, `${repo}-worktrees`, taskId);
-      const bareRepoPath = path.join(baseDir, owner, `${repo}.git`);
-      fs.mkdirSync(worktreePath, { recursive: true });
-      return { worktreePath, bareRepoPath, cloned: true };
-    },
-  ),
-  cleanupWorktree: vi.fn((_bareRepoPath: string, worktreePath: string) => {
-    try {
-      fs.rmSync(worktreePath, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
-  }),
-}));
+vi.mock('../repo-cache.js', async () => {
+  const _fs = await import('node:fs');
+  const _path = await import('node:path');
+  return {
+    checkoutWorktree: vi.fn(
+      async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
+        const worktreePath = _path.join(baseDir, owner, `${repo}-worktrees`, taskId);
+        const bareRepoPath = _path.join(baseDir, owner, `${repo}.git`);
+        _fs.mkdirSync(worktreePath, { recursive: true });
+        return { worktreePath, bareRepoPath, cloned: true };
+      },
+    ),
+    cleanupWorktree: vi.fn(async (_bareRepoPath: string, worktreePath: string) => {
+      try {
+        _fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }),
+  };
+});
 
 // ── Mock tool executor ───────────────────────────────────────
 

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -59,24 +59,27 @@ vi.mock('../tool-executor.js', () => ({
 const mockedExecuteTool = vi.mocked(executeTool);
 
 // ── Mock repo-cache so git worktree operations don't need real git ──
-
-vi.mock('../repo-cache.js', () => ({
-  checkoutWorktree: vi.fn(
-    async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
-      const worktreePath = path.join(baseDir, owner, `${repo}-worktrees`, taskId);
-      const bareRepoPath = path.join(baseDir, owner, `${repo}.git`);
-      fs.mkdirSync(worktreePath, { recursive: true });
-      return { worktreePath, bareRepoPath, cloned: true };
-    },
-  ),
-  cleanupWorktree: vi.fn((_bareRepoPath: string, worktreePath: string) => {
-    try {
-      fs.rmSync(worktreePath, { recursive: true, force: true });
-    } catch {
-      // ignore
-    }
-  }),
-}));
+vi.mock('../repo-cache.js', async () => {
+  const _fs = await import('node:fs');
+  const _path = await import('node:path');
+  return {
+    checkoutWorktree: vi.fn(
+      async (owner: string, repo: string, _prNumber: number, baseDir: string, taskId: string) => {
+        const worktreePath = _path.join(baseDir, owner, `${repo}-worktrees`, taskId);
+        const bareRepoPath = _path.join(baseDir, owner, `${repo}.git`);
+        _fs.mkdirSync(worktreePath, { recursive: true });
+        return { worktreePath, bareRepoPath, cloned: true };
+      },
+    ),
+    cleanupWorktree: vi.fn(async (_bareRepoPath: string, worktreePath: string) => {
+      try {
+        _fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }),
+  };
+});
 
 // ── Helpers ──────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -32,26 +32,21 @@ describe('repo-cache', () => {
   });
 
   describe('ensureBareClone', () => {
-    it('creates bare clone via gh when repo does not exist', () => {
+    it('creates bare clone via gh when repo does not exist and gh is available', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      // Call 1: gh auth status, Call 2: gh repo clone
       vi.mocked(execFileSync).mockReturnValue('');
 
-      const result = ensureBareClone('acme', 'widgets', '/tmp/repos');
+      const result = ensureBareClone('acme', 'widgets', '/tmp/repos', true);
 
       expect(result.bareRepoPath).toBe('/tmp/repos/acme/widgets.git');
       expect(result.cloned).toBe(true);
 
       const calls = vi.mocked(execFileSync).mock.calls;
-      expect(calls.length).toBe(2);
-
-      // gh auth status
-      expect(calls[0][0]).toBe('gh');
-      expect(calls[0][1]).toEqual(['auth', 'status']);
+      expect(calls.length).toBe(1);
 
       // gh repo clone --bare
-      expect(calls[1][0]).toBe('gh');
-      expect(calls[1][1]).toEqual([
+      expect(calls[0][0]).toBe('gh');
+      expect(calls[0][1]).toEqual([
         'repo',
         'clone',
         'acme/widgets',
@@ -65,7 +60,7 @@ describe('repo-cache', () => {
     it('skips clone when bare repo already exists (HEAD file present)', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
-      const result = ensureBareClone('acme', 'widgets', '/tmp/repos');
+      const result = ensureBareClone('acme', 'widgets', '/tmp/repos', true);
 
       expect(result.bareRepoPath).toBe('/tmp/repos/acme/widgets.git');
       expect(result.cloned).toBe(false);
@@ -74,20 +69,15 @@ describe('repo-cache', () => {
 
     it('falls back to git clone when gh is not available', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(execFileSync)
-        .mockImplementationOnce(() => {
-          throw new Error('gh: command not found');
-        })
-        .mockReturnValue('');
+      vi.mocked(execFileSync).mockReturnValue('');
 
-      const result = ensureBareClone('acme', 'widgets', '/tmp/repos');
+      const result = ensureBareClone('acme', 'widgets', '/tmp/repos', false);
 
       expect(result.cloned).toBe(true);
 
       const calls = vi.mocked(execFileSync).mock.calls;
-      // Call 1: gh auth status (fails), Call 2: git clone --bare
-      expect(calls[1][0]).toBe('git');
-      expect(calls[1][1]).toEqual([
+      expect(calls[0][0]).toBe('git');
+      expect(calls[0][1]).toEqual([
         'clone',
         '--bare',
         '--filter=blob:none',
@@ -100,19 +90,19 @@ describe('repo-cache', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       vi.mocked(execFileSync).mockReturnValue('');
 
-      ensureBareClone('acme', 'widgets', '/tmp/repos');
+      ensureBareClone('acme', 'widgets', '/tmp/repos', true);
 
       expect(fs.mkdirSync).toHaveBeenCalledWith('/tmp/repos/acme', { recursive: true });
     });
 
     it('rejects invalid owner name', () => {
-      expect(() => ensureBareClone('../etc', 'repo', '/tmp/repos')).toThrow(
+      expect(() => ensureBareClone('../etc', 'repo', '/tmp/repos', true)).toThrow(
         'disallowed characters',
       );
     });
 
     it('rejects invalid repo name', () => {
-      expect(() => ensureBareClone('acme', '../../passwd', '/tmp/repos')).toThrow(
+      expect(() => ensureBareClone('acme', '../../passwd', '/tmp/repos', true)).toThrow(
         'disallowed characters',
       );
     });
@@ -122,30 +112,25 @@ describe('repo-cache', () => {
     it('fetches PR ref with credential helper when gh is available', () => {
       vi.mocked(execFileSync).mockReturnValue('');
 
-      fetchPRRef('/tmp/repos/acme/widgets.git', 42);
+      fetchPRRef('/tmp/repos/acme/widgets.git', 42, true);
 
-      const calls = vi.mocked(execFileSync).mock.calls;
-      // Call 1: gh auth status, Call 2: git fetch
-      expect(calls[1][0]).toBe('git');
-      expect(calls[1][1]).toContain('fetch');
-      expect(calls[1][1]).toContain('--force');
-      expect(calls[1][1]).toContain('pull/42/head');
-      expect(calls[1][1]).toContain('-c');
-      expect(calls[1][1]).toContain('credential.helper=!gh auth git-credential');
+      const call = vi.mocked(execFileSync).mock.calls[0];
+      expect(call[0]).toBe('git');
+      expect(call[1]).toContain('fetch');
+      expect(call[1]).toContain('--force');
+      expect(call[1]).toContain('pull/42/head');
+      expect(call[1]).toContain('-c');
+      expect(call[1]).toContain('credential.helper=!gh auth git-credential');
     });
 
     it('fetches without credential helper when gh is not available', () => {
-      vi.mocked(execFileSync)
-        .mockImplementationOnce(() => {
-          throw new Error('gh: command not found');
-        })
-        .mockReturnValue('');
+      vi.mocked(execFileSync).mockReturnValue('');
 
-      fetchPRRef('/tmp/repos/acme/widgets.git', 42);
+      fetchPRRef('/tmp/repos/acme/widgets.git', 42, false);
 
-      const fetchCall = vi.mocked(execFileSync).mock.calls[1];
-      expect(fetchCall[0]).toBe('git');
-      const args = fetchCall[1] as string[];
+      const call = vi.mocked(execFileSync).mock.calls[0];
+      expect(call[0]).toBe('git');
+      const args = call[1] as string[];
       expect(args).toContain('fetch');
       expect(args).not.toContain('-c');
     });
@@ -244,10 +229,13 @@ describe('repo-cache', () => {
   });
 
   describe('cleanupWorktree', () => {
-    it('delegates to removeWorktree', () => {
+    it('delegates to removeWorktree under lock', async () => {
       vi.mocked(execFileSync).mockReturnValue('');
 
-      cleanupWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/task-123');
+      await cleanupWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/task-123',
+      );
 
       const call = vi.mocked(execFileSync).mock.calls[0];
       expect(call[0]).toBe('git');
@@ -311,6 +299,26 @@ describe('repo-cache', () => {
       const result = await withRepoLock('acme/widgets', () => 42);
       expect(result).toBe(42);
     });
+
+    it('cleans up map entry after last concurrent operation', async () => {
+      // Run three concurrent operations on the same key
+      const op1 = withRepoLock('acme/widgets', async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      const op2 = withRepoLock('acme/widgets', async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      const op3 = withRepoLock('acme/widgets', async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+
+      await Promise.all([op1, op2, op3]);
+
+      // After all complete, lock should be cleaned up
+      // (We can't directly check the internal map, but verify lock is acquirable)
+      const result = await withRepoLock('acme/widgets', () => 'ok');
+      expect(result).toBe('ok');
+    });
   });
 
   describe('checkoutWorktree', () => {
@@ -325,22 +333,21 @@ describe('repo-cache', () => {
       expect(result.cloned).toBe(true);
 
       const calls = vi.mocked(execFileSync).mock.calls;
-      // 1: gh auth status (ensureBareClone)
+      // 1: gh auth status (isGhAvailable — hoisted)
       // 2: gh repo clone --bare (ensureBareClone)
-      // 3: gh auth status (fetchPRRef)
-      // 4: git fetch (fetchPRRef)
-      // 5: git worktree add (addWorktree)
-      expect(calls.length).toBe(5);
+      // 3: git fetch (fetchPRRef)
+      // 4: git worktree add (addWorktree)
+      expect(calls.length).toBe(4);
 
       // Verify bare clone
       expect(calls[1][1]).toContain('--bare');
 
       // Verify fetch
-      expect(calls[3][1]).toContain('pull/42/head');
+      expect(calls[2][1]).toContain('pull/42/head');
 
       // Verify worktree add
-      expect(calls[4][1]).toContain('worktree');
-      expect(calls[4][1]).toContain('FETCH_HEAD');
+      expect(calls[3][1]).toContain('worktree');
+      expect(calls[3][1]).toContain('FETCH_HEAD');
     });
 
     it('reuses existing bare clone', async () => {
@@ -352,7 +359,7 @@ describe('repo-cache', () => {
 
       expect(result.cloned).toBe(false);
 
-      // Should not have a clone call — only gh auth status (for fetch) + fetch + worktree add
+      // Should not have a clone call
       const calls = vi.mocked(execFileSync).mock.calls;
       const cloneCalls = calls.filter(
         (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('clone'),

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -721,7 +721,7 @@ async function handleTask(
   } finally {
     // Clean up task worktree (bare repo stays for reuse)
     if (taskCheckoutPath && taskBareRepoPath) {
-      cleanupWorktree(taskBareRepoPath, taskCheckoutPath);
+      await cleanupWorktree(taskBareRepoPath, taskCheckoutPath);
     }
   }
   return {};

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -11,8 +11,8 @@ const GH_CREDENTIAL_HELPER = '!gh auth git-credential';
 const GIT_TIMEOUT_MS = 120_000;
 
 /**
- * Per-repo mutex to serialize git fetch operations.
- * Multiple concurrent tasks on the same repo must not fetch simultaneously
+ * Per-repo mutex to serialize git operations (fetch, worktree add/remove).
+ * Multiple concurrent tasks on the same repo must not run git commands simultaneously
  * (git lock file conflicts).
  */
 const repoLocks = new Map<string, Promise<void>>();
@@ -31,20 +31,19 @@ export interface WorktreeCheckoutResult {
  * Concurrent callers on the same repoKey queue behind the current holder.
  */
 export async function withRepoLock<T>(repoKey: string, fn: () => T | Promise<T>): Promise<T> {
-  // Wait for any in-flight operation on this repo
   const existing = repoLocks.get(repoKey);
   let release: () => void;
   const gate = new Promise<void>((resolve) => {
     release = resolve;
   });
-  repoLocks.set(repoKey, existing ? existing.then(() => gate) : gate);
+  // Always store gate directly — await existing for ordering
+  repoLocks.set(repoKey, gate);
 
   try {
     if (existing) await existing;
     return await fn();
   } finally {
     release!();
-    // Clean up if we're still the latest holder
     if (repoLocks.get(repoKey) === gate) {
       repoLocks.delete(repoKey);
     }
@@ -62,6 +61,7 @@ export function ensureBareClone(
   owner: string,
   repo: string,
   baseDir: string,
+  ghAvailable: boolean,
 ): { bareRepoPath: string; cloned: boolean } {
   validatePathSegment(owner, 'owner');
   validatePathSegment(repo, 'repo');
@@ -74,8 +74,6 @@ export function ensureBareClone(
 
   // Create parent dir
   fs.mkdirSync(path.join(baseDir, owner), { recursive: true });
-
-  const ghAvailable = isGhAvailable();
 
   if (ghAvailable) {
     // gh repo clone with --bare
@@ -101,8 +99,7 @@ export function ensureBareClone(
  * Fetch a PR ref into the bare repo.
  * Uses credential helper when gh is available.
  */
-export function fetchPRRef(bareRepoPath: string, prNumber: number): void {
-  const ghAvailable = isGhAvailable();
+export function fetchPRRef(bareRepoPath: string, prNumber: number, ghAvailable: boolean): void {
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
   gitExec(
     'git',
@@ -155,6 +152,16 @@ export function removeWorktree(bareRepoPath: string, worktreePath: string): void
 }
 
 /**
+ * Derive the repo key (owner/repo) from a bare repo path.
+ * Bare repos are at `<baseDir>/<owner>/<repo>.git`.
+ */
+function repoKeyFromBarePath(bareRepoPath: string): string {
+  const repoName = path.basename(bareRepoPath, '.git');
+  const owner = path.basename(path.dirname(bareRepoPath));
+  return `${owner}/${repoName}`;
+}
+
+/**
  * High-level: checkout a PR into an isolated worktree.
  *
  * 1. Ensure bare clone exists (or reuse cached)
@@ -175,11 +182,12 @@ export async function checkoutWorktree(
   validatePathSegment(taskId, 'taskId');
 
   const repoKey = `${owner}/${repo}`;
+  const ghAvailable = isGhAvailable();
 
-  // Serialize fetch operations per repo to avoid git lock conflicts
+  // Serialize all git operations per repo to avoid lock file conflicts
   return withRepoLock(repoKey, () => {
-    const { bareRepoPath, cloned } = ensureBareClone(owner, repo, baseDir);
-    fetchPRRef(bareRepoPath, prNumber);
+    const { bareRepoPath, cloned } = ensureBareClone(owner, repo, baseDir, ghAvailable);
+    fetchPRRef(bareRepoPath, prNumber, ghAvailable);
     const worktreePath = addWorktree(bareRepoPath, taskId);
     return { worktreePath, bareRepoPath, cloned };
   });
@@ -187,9 +195,13 @@ export async function checkoutWorktree(
 
 /**
  * High-level: clean up a worktree after task completion.
+ * Acquires the per-repo lock to avoid racing with concurrent fetch/add operations.
  */
-export function cleanupWorktree(bareRepoPath: string, worktreePath: string): void {
-  removeWorktree(bareRepoPath, worktreePath);
+export async function cleanupWorktree(bareRepoPath: string, worktreePath: string): Promise<void> {
+  const repoKey = repoKeyFromBarePath(bareRepoPath);
+  await withRepoLock(repoKey, () => {
+    removeWorktree(bareRepoPath, worktreePath);
+  });
 }
 
 /**


### PR DESCRIPTION
Part of #473

## Summary
- Add `repo-cache.ts` module with persistent bare clone management and git worktree operations
- Replace per-task `cloneOrUpdate`/`cleanupTaskDir` with `checkoutWorktree`/`cleanupWorktree`
- Bare clones cached at `<codebase_dir>/<owner>/<repo>.git/` and reused across tasks
- Each review task gets isolated worktree at `<owner>/<repo>-worktrees/<taskId>/`
- Per-repo mutex serializes concurrent `git fetch` operations to avoid lock conflicts
- Graceful fallback to diff-only review when worktree operations fail

## Test plan
- Unit tests for all repo-cache functions (ensureBareClone, fetchPRRef, addWorktree, removeWorktree, withRepoLock, checkoutWorktree)
- Updated e2e tests verify worktree paths are passed as cwd to review tool
- Updated e2e tests verify worktree cleanup after task completion
- Updated agent-coverage test for worktree checkout failure fallback path
- All 1988 tests pass, lint/typecheck/format clean