### PR TITLE
fix: use gh CLI for org membership fetch, add config fallback

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -361,13 +361,19 @@ export async function resolveUser(
  *
  * Strategy: try `gh` CLI first (uses the user's own GitHub auth which has org
  * read permissions), fall back to the OAuth token (which may lack `read:org` scope).
+ *
+ * NOTE: gh CLI path uses --paginate to fetch all orgs. OAuth fallback fetches
+ * only the first page (max 100 orgs) — users with >100 orgs may miss some.
+ *
+ * @param expectedLogin - If provided, verifies gh CLI is authenticated as this user
  */
 export async function fetchUserOrgs(
   token: string,
   fetchFn: typeof fetch = fetch,
+  expectedLogin?: string,
 ): Promise<Set<string>> {
   // Try gh CLI first — it has the user's full GitHub permissions
-  const ghOrgs = fetchUserOrgsViaGh();
+  const ghOrgs = fetchUserOrgsViaGh(expectedLogin);
   if (ghOrgs.size > 0) return ghOrgs;
 
   // Fallback: use the OAuth token (may lack read:org scope)
@@ -399,13 +405,27 @@ export async function fetchUserOrgs(
 
 /**
  * Fetch org memberships via the `gh` CLI.
+ * Uses --paginate to fetch all orgs (no page limit).
+ * If expectedLogin is provided, verifies gh is authenticated as the same user.
  * Returns a Set of lowercased org login names, or empty set if gh is unavailable.
  */
-function fetchUserOrgsViaGh(): Set<string> {
+export function fetchUserOrgsViaGh(expectedLogin?: string): Set<string> {
   try {
-    const output = execFileSync('gh', ['api', '/user/orgs', '--jq', '.[].login'], {
+    // Verify gh is authenticated as the expected user to avoid identity mismatch
+    if (expectedLogin) {
+      const ghUser = execFileSync('gh', ['api', '/user', '--jq', '.login'], {
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+      if (ghUser.toLowerCase() !== expectedLogin.toLowerCase()) {
+        return new Set();
+      }
+    }
+
+    const output = execFileSync('gh', ['api', '/user/orgs', '--paginate', '--jq', '.[].login'], {
       encoding: 'utf-8',
-      timeout: 10_000,
+      timeout: 15_000,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const orgs = new Set<string>();

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1628,22 +1628,27 @@ agentCommand
 
       // Fetch org memberships only when at least one agent uses private mode
       const needsOrgs = config.agents?.some((a) => a.repos?.mode === 'private') ?? false;
-      let userOrgs = needsOrgs ? await fetchUserOrgs(oauthToken) : new Set<string>();
-      // Fallback: extract org names from agents' repo lists so private mode works
-      // even when the GitHub API is unreachable
+      let userOrgs = needsOrgs
+        ? await fetchUserOrgs(oauthToken, fetch, agentOwner)
+        : new Set<string>();
+      // Heuristic fallback: extract org names from agents' repo lists so private
+      // mode works even when the GitHub API is unreachable. This is best-effort —
+      // it assumes repo owners in the config are orgs the user belongs to, which
+      // may not always be true (e.g., collaborator access without org membership).
       if (needsOrgs && userOrgs.size === 0 && config.agents) {
+        const currentLogin = agentOwner?.toLowerCase();
         const fallbackOrgs = new Set<string>();
         for (const a of config.agents) {
           if (a.repos?.list) {
             for (const repo of a.repos.list) {
-              const owner = repo.split('/')[0];
-              if (owner) fallbackOrgs.add(owner.toLowerCase());
+              const owner = repo.split('/')[0]?.toLowerCase();
+              if (owner && owner !== currentLogin) fallbackOrgs.add(owner);
             }
           }
           if (a.synthesize_repos?.list) {
             for (const repo of a.synthesize_repos.list) {
-              const owner = repo.split('/')[0];
-              if (owner) fallbackOrgs.add(owner.toLowerCase());
+              const owner = repo.split('/')[0]?.toLowerCase();
+              if (owner && owner !== currentLogin) fallbackOrgs.add(owner);
             }
           }
         }


### PR DESCRIPTION
## Summary
- `fetchUserOrgs` now tries `gh api /user/orgs` first (user's full GitHub auth, has `read:org`)
- Falls back to OAuth token if `gh` unavailable
- If both fail, extracts org names from agent repo `list` config entries as last resort
- Adds startup logging for org membership status

Fixes the root cause of Opus agent not claiming summary tasks: the OAuth token lacks `read:org` scope, so `fetchUserOrgs` returned empty set, and `private` mode filtered out all org repos.

Part of #578

## Test plan
- [ ] Verify `Org memberships: opencara` appears on startup
- [ ] Verify Opus agent claims summary tasks on OpenCara repos
- [ ] Verify fallback works when GitHub API is down (`Org memberships (from config): ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)