### PR TITLE
[cli-dev] Share git worktree across tasks for the same PR

### DIFF
--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -24,11 +24,23 @@ import {
   cleanupWorktree,
   checkoutWorktree,
   withRepoLock,
+  prWorktreeKey,
+  getWorktreeRefCount,
+  resetWorktreeRefCounts,
 } from '../repo-cache.js';
 
 describe('repo-cache', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetWorktreeRefCounts();
+  });
+
+  describe('prWorktreeKey', () => {
+    it('generates pr-<number> key', () => {
+      expect(prWorktreeKey(42)).toBe('pr-42');
+      expect(prWorktreeKey(1)).toBe('pr-1');
+      expect(prWorktreeKey(9999)).toBe('pr-9999');
+    });
   });
 
   describe('ensureBareClone', () => {
@@ -138,11 +150,12 @@ describe('repo-cache', () => {
 
   describe('addWorktree', () => {
     it('creates worktree at correct path', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
       vi.mocked(execFileSync).mockReturnValue('');
 
-      const result = addWorktree('/tmp/repos/acme/widgets.git', 'task-123');
+      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42');
 
-      expect(result).toBe('/tmp/repos/acme/widgets-worktrees/task-123');
+      expect(result).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
       expect(fs.mkdirSync).toHaveBeenCalledWith('/tmp/repos/acme/widgets-worktrees', {
         recursive: true,
       });
@@ -153,19 +166,32 @@ describe('repo-cache', () => {
         'worktree',
         'add',
         '--detach',
-        '/tmp/repos/acme/widgets-worktrees/task-123',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
         'FETCH_HEAD',
       ]);
       expect(call[2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets.git' });
     });
 
-    it('rejects invalid taskId', () => {
+    it('reuses existing worktree directory without creating a new one', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42');
+
+      expect(result).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
+      // Should NOT call git worktree add
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+      // Should NOT call mkdirSync
+      expect(vi.mocked(fs.mkdirSync)).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid worktreeKey', () => {
       expect(() => addWorktree('/tmp/repos/acme/widgets.git', '../../etc')).toThrow(
         'disallowed characters',
       );
     });
 
-    it('rejects taskId with slashes', () => {
+    it('rejects worktreeKey with slashes', () => {
       expect(() => addWorktree('/tmp/repos/acme/widgets.git', 'a/b')).toThrow(
         'disallowed characters',
       );
@@ -176,7 +202,7 @@ describe('repo-cache', () => {
     it('removes worktree via git worktree remove', () => {
       vi.mocked(execFileSync).mockReturnValue('');
 
-      removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/task-123');
+      removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/pr-42');
 
       const call = vi.mocked(execFileSync).mock.calls[0];
       expect(call[0]).toBe('git');
@@ -184,7 +210,7 @@ describe('repo-cache', () => {
         'worktree',
         'remove',
         '--force',
-        '/tmp/repos/acme/widgets-worktrees/task-123',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
       ]);
       expect(call[2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets.git' });
     });
@@ -196,9 +222,9 @@ describe('repo-cache', () => {
         })
         .mockReturnValue(''); // prune succeeds
 
-      removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/task-123');
+      removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/pr-42');
 
-      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/repos/acme/widgets-worktrees/task-123', {
+      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/repos/acme/widgets-worktrees/pr-42', {
         recursive: true,
         force: true,
       });
@@ -220,7 +246,7 @@ describe('repo-cache', () => {
       });
 
       expect(() =>
-        removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/task-123'),
+        removeWorktree('/tmp/repos/acme/widgets.git', '/tmp/repos/acme/widgets-worktrees/pr-42'),
       ).not.toThrow();
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to clean up worktree'));
@@ -229,18 +255,73 @@ describe('repo-cache', () => {
   });
 
   describe('cleanupWorktree', () => {
-    it('delegates to removeWorktree under lock', async () => {
+    it('removes worktree when ref count is 0 (no prior checkout)', async () => {
       vi.mocked(execFileSync).mockReturnValue('');
 
       await cleanupWorktree(
         '/tmp/repos/acme/widgets.git',
-        '/tmp/repos/acme/widgets-worktrees/task-123',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
       );
 
       const call = vi.mocked(execFileSync).mock.calls[0];
       expect(call[0]).toBe('git');
       expect(call[1]).toContain('worktree');
       expect(call[1]).toContain('remove');
+    });
+
+    it('removes worktree when ref count drops to 0', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      // Checkout once (ref count = 1)
+      const result = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+      expect(getWorktreeRefCount(result.worktreePath)).toBe(1);
+
+      vi.clearAllMocks();
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      // Cleanup (ref count 1 → 0) — should remove
+      await cleanupWorktree(result.bareRepoPath, result.worktreePath);
+
+      expect(getWorktreeRefCount(result.worktreePath)).toBe(0);
+      const removeCalls = vi
+        .mocked(execFileSync)
+        .mock.calls.filter((c) => Array.isArray(c[1]) && (c[1] as string[]).includes('remove'));
+      expect(removeCalls).toHaveLength(1);
+    });
+
+    it('skips removal when ref count is still > 0', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      // Checkout twice (ref count = 2)
+      const result1 = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+
+      // Second checkout — existsSync now returns true for the worktree dir
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      const result2 = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+
+      expect(result1.worktreePath).toBe(result2.worktreePath);
+      expect(getWorktreeRefCount(result1.worktreePath)).toBe(2);
+
+      vi.clearAllMocks();
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      // First cleanup (ref count 2 → 1) — should NOT remove
+      await cleanupWorktree(result1.bareRepoPath, result1.worktreePath);
+
+      expect(getWorktreeRefCount(result1.worktreePath)).toBe(1);
+      // No git worktree remove calls
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+
+      // Second cleanup (ref count 1 → 0) — should remove
+      await cleanupWorktree(result1.bareRepoPath, result1.worktreePath);
+
+      expect(getWorktreeRefCount(result1.worktreePath)).toBe(0);
+      const removeCalls = vi
+        .mocked(execFileSync)
+        .mock.calls.filter((c) => Array.isArray(c[1]) && (c[1] as string[]).includes('remove'));
+      expect(removeCalls).toHaveLength(1);
     });
   });
 
@@ -322,13 +403,14 @@ describe('repo-cache', () => {
   });
 
   describe('checkoutWorktree', () => {
-    it('performs full checkout flow: bare clone + fetch + worktree add', async () => {
+    it('uses pr-keyed worktree path instead of taskId', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       vi.mocked(execFileSync).mockReturnValue('');
 
       const result = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos', 'task-abc');
 
-      expect(result.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/task-abc');
+      // Worktree is keyed by PR number, not taskId
+      expect(result.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
       expect(result.bareRepoPath).toBe('/tmp/repos/acme/widgets.git');
       expect(result.cloned).toBe(true);
 
@@ -345,9 +427,50 @@ describe('repo-cache', () => {
       // Verify fetch
       expect(calls[2][1]).toContain('pull/42/head');
 
-      // Verify worktree add
+      // Verify worktree add uses pr-42
       expect(calls[3][1]).toContain('worktree');
       expect(calls[3][1]).toContain('FETCH_HEAD');
+      expect(calls[3][1]).toContain('/tmp/repos/acme/widgets-worktrees/pr-42');
+    });
+
+    it('increments ref count on checkout', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      const result = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+      expect(getWorktreeRefCount(result.worktreePath)).toBe(1);
+    });
+
+    it('reuses worktree and increments ref count for same PR', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      const result1 = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos', 'task-1');
+
+      // Now the worktree dir exists
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const result2 = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos', 'task-2');
+
+      // Same worktree path
+      expect(result1.worktreePath).toBe(result2.worktreePath);
+      expect(result1.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
+
+      // Ref count is 2
+      expect(getWorktreeRefCount(result1.worktreePath)).toBe(2);
+    });
+
+    it('creates separate worktrees for different PRs', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      const result1 = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+      const result2 = await checkoutWorktree('acme', 'widgets', 99, '/tmp/repos');
+
+      expect(result1.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
+      expect(result2.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/pr-99');
+      expect(getWorktreeRefCount(result1.worktreePath)).toBe(1);
+      expect(getWorktreeRefCount(result2.worktreePath)).toBe(1);
     });
 
     it('reuses existing bare clone', async () => {
@@ -375,10 +498,16 @@ describe('repo-cache', () => {
       await expect(
         checkoutWorktree('acme', '../../passwd', 1, '/tmp/repos', 'task-1'),
       ).rejects.toThrow('disallowed characters');
+    });
 
-      await expect(checkoutWorktree('acme', 'repo', 1, '/tmp/repos', '../../etc')).rejects.toThrow(
-        'disallowed characters',
-      );
+    it('works without taskId parameter', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      const result = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos');
+
+      expect(result.worktreePath).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
+      expect(getWorktreeRefCount(result.worktreePath)).toBe(1);
     });
   });
 });

--- a/packages/cli/src/codebase-cleanup.ts
+++ b/packages/cli/src/codebase-cleanup.ts
@@ -122,7 +122,7 @@ export class CodebaseCleanupTracker {
  * and remove any older than the given TTL.
  *
  * Directory structure expected:
- *   <baseDir>/<owner>/<repo>-worktrees/<taskId>/
+ *   <baseDir>/<owner>/<repo>-worktrees/<pr-N>/
  *   <baseDir>/<owner>/<repo>.git/  (bare repos — never removed)
  *
  * Returns the number of stale directories removed.

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -17,6 +17,13 @@ const GIT_TIMEOUT_MS = 120_000;
  */
 const repoLocks = new Map<string, Promise<void>>();
 
+/**
+ * Ref-count tracker for shared worktrees.
+ * Key: worktree absolute path → number of active tasks using it.
+ * When count drops to 0, the worktree is eligible for removal.
+ */
+const worktreeRefCounts = new Map<string, number>();
+
 export interface WorktreeCheckoutResult {
   /** Absolute path to the worktree directory */
   worktreePath: string;
@@ -24,6 +31,14 @@ export interface WorktreeCheckoutResult {
   bareRepoPath: string;
   /** Whether the bare repo was freshly cloned */
   cloned: boolean;
+}
+
+/**
+ * Build the worktree directory name for a PR.
+ * Uses `pr-<number>` instead of taskId so multiple tasks on the same PR share one worktree.
+ */
+export function prWorktreeKey(prNumber: number): string {
+  return `pr-${prNumber}`;
 }
 
 /**
@@ -109,19 +124,27 @@ export function fetchPRRef(bareRepoPath: string, prNumber: number, ghAvailable: 
 }
 
 /**
- * Create a git worktree for a specific task from the bare repo.
+ * Create a git worktree from the bare repo.
  * The worktree is checked out at FETCH_HEAD (the PR ref just fetched).
  *
- * Path: `<bareRepoPath>/../<repo>-worktrees/<taskId>/`
+ * Path: `<bareRepoPath>/../<repo>-worktrees/<worktreeKey>/`
+ *
+ * If the worktree already exists (shared PR worktree), returns the existing path
+ * without creating a new one.
  */
-export function addWorktree(bareRepoPath: string, taskId: string): string {
-  validatePathSegment(taskId, 'taskId');
+export function addWorktree(bareRepoPath: string, worktreeKey: string): string {
+  validatePathSegment(worktreeKey, 'worktreeKey');
 
   // Place worktrees alongside the bare repo for clean organization
-  // e.g., <baseDir>/<owner>/<repo>-worktrees/<taskId>/
+  // e.g., <baseDir>/<owner>/<repo>-worktrees/<worktreeKey>/
   const repoName = path.basename(bareRepoPath, '.git');
   const worktreeBase = path.join(path.dirname(bareRepoPath), `${repoName}-worktrees`);
-  const worktreePath = path.join(worktreeBase, taskId);
+  const worktreePath = path.join(worktreeBase, worktreeKey);
+
+  // If the worktree directory already exists, reuse it
+  if (fs.existsSync(worktreePath)) {
+    return worktreePath;
+  }
 
   fs.mkdirSync(worktreeBase, { recursive: true });
 
@@ -164,9 +187,14 @@ function repoKeyFromBarePath(bareRepoPath: string): string {
 /**
  * High-level: checkout a PR into an isolated worktree.
  *
+ * Worktrees are keyed by PR number, not task ID. Multiple tasks for the same PR
+ * share a single worktree, tracked via ref counting. The worktree is only removed
+ * when the last task releases it via `cleanupWorktree`.
+ *
  * 1. Ensure bare clone exists (or reuse cached)
  * 2. Fetch PR ref (with per-repo lock)
- * 3. Create worktree for the task
+ * 3. Create or reuse worktree for this PR
+ * 4. Increment ref count
  *
  * Returns the worktree path for use as cwd during review.
  */
@@ -175,33 +203,66 @@ export async function checkoutWorktree(
   repo: string,
   prNumber: number,
   baseDir: string,
-  taskId: string,
+  _taskId?: string,
 ): Promise<WorktreeCheckoutResult> {
   validatePathSegment(owner, 'owner');
   validatePathSegment(repo, 'repo');
-  validatePathSegment(taskId, 'taskId');
 
   const repoKey = `${owner}/${repo}`;
   const ghAvailable = isGhAvailable();
+  const wtKey = prWorktreeKey(prNumber);
 
   // Serialize all git operations per repo to avoid lock file conflicts
   return withRepoLock(repoKey, () => {
     const { bareRepoPath, cloned } = ensureBareClone(owner, repo, baseDir, ghAvailable);
     fetchPRRef(bareRepoPath, prNumber, ghAvailable);
-    const worktreePath = addWorktree(bareRepoPath, taskId);
+    const worktreePath = addWorktree(bareRepoPath, wtKey);
+
+    // Increment ref count
+    const current = worktreeRefCounts.get(worktreePath) ?? 0;
+    worktreeRefCounts.set(worktreePath, current + 1);
+
     return { worktreePath, bareRepoPath, cloned };
   });
 }
 
 /**
  * High-level: clean up a worktree after task completion.
+ *
+ * Decrements the ref count for the worktree. Only actually removes it when
+ * the ref count drops to 0 (no more tasks using it).
  * Acquires the per-repo lock to avoid racing with concurrent fetch/add operations.
  */
 export async function cleanupWorktree(bareRepoPath: string, worktreePath: string): Promise<void> {
   const repoKey = repoKeyFromBarePath(bareRepoPath);
   await withRepoLock(repoKey, () => {
+    const current = worktreeRefCounts.get(worktreePath) ?? 0;
+    if (current > 1) {
+      // Other tasks still using this worktree — just decrement
+      worktreeRefCounts.set(worktreePath, current - 1);
+      return;
+    }
+
+    // Last reference — remove the worktree
+    worktreeRefCounts.delete(worktreePath);
     removeWorktree(bareRepoPath, worktreePath);
   });
+}
+
+/**
+ * Get the current ref count for a worktree path.
+ * Exported for testing only.
+ */
+export function getWorktreeRefCount(worktreePath: string): number {
+  return worktreeRefCounts.get(worktreePath) ?? 0;
+}
+
+/**
+ * Reset all worktree ref counts.
+ * Exported for testing only.
+ */
+export function resetWorktreeRefCounts(): void {
+  worktreeRefCounts.clear();
 }
 
 /**


### PR DESCRIPTION
Part of #580

## Summary
- Key worktrees by PR number (`pr-<N>`) instead of `taskId`, so multiple tasks (review + summary) for the same PR share one worktree checkout
- Add ref counting to track active users — worktree is only removed when the last task releases it via `cleanupWorktree`
- `addWorktree` reuses existing worktree directory when present (skips `git worktree add`)
- Different PRs still get separate worktrees
- Updated tests to cover ref counting, worktree reuse, and multi-PR isolation

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm vitest run packages/cli/src/__tests__/repo-cache.test.ts` — 30 tests pass
- [x] `pnpm vitest run packages/cli/src/__tests__/codebase-cleanup.test.ts` — 24 tests pass
- [x] `pnpm vitest run packages/cli/src/__tests__/agent.test.ts` — 28 tests pass
- [x] `pnpm lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes