### PR TITLE
Fix: add implement and fix to taskRoleSchema

### DIFF
--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -13,6 +13,8 @@ const taskRoleSchema = z.enum([
   'issue_dedup',
   'pr_triage',
   'issue_triage',
+  'implement',
+  'fix',
 ]);
 
 /** @deprecated Use taskRoleSchema for new code. Kept for backward compat. */


### PR DESCRIPTION
Part of #594

## Summary
- Add `'implement'` and `'fix'` to the `taskRoleSchema` Zod enum in `packages/server/src/schemas.ts`
- Without these values, the poll/claim endpoints reject implement and fix task types with a 400 validation error

## Test plan
- Build passes
- All existing tests pass (6 pre-existing failures in `auth.test.ts` are unrelated — from #dd4802b)
- Deploy to dev → re-run smoke test with `/opencara go` and `/opencara fix` commands