### PR TITLE
[cli-dev] Fix default agent roles missing implement and fix

### DIFF
--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1028,9 +1028,9 @@ describe('computeRoles', () => {
     expect(computeRoles(agent)).toEqual(['summary']);
   });
 
-  it('returns ["review", "summary"] for agent with neither flag', () => {
+  it('returns default roles for agent with neither flag', () => {
     const agent: LocalAgentConfig = { model: 'claude-opus-4-6', tool: 'claude' };
-    expect(computeRoles(agent)).toEqual(['review', 'summary']);
+    expect(computeRoles(agent)).toEqual(['review', 'summary', 'implement', 'fix']);
   });
 
   it('returns explicit roles when roles field is set', () => {
@@ -1078,6 +1078,6 @@ describe('computeRoles', () => {
       tool: 'claude',
       roles: undefined,
     };
-    expect(computeRoles(agent)).toEqual(['review', 'summary']);
+    expect(computeRoles(agent)).toEqual(['review', 'summary', 'implement', 'fix']);
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -168,7 +168,7 @@ export function computeRoles(agent: LocalAgentConfig): TaskRole[] {
   if (agent.roles && agent.roles.length > 0) return agent.roles as TaskRole[];
   if (agent.review_only) return ['review'];
   if (agent.synthesizer_only) return ['summary'];
-  return ['review', 'summary'];
+  return ['review', 'summary', 'implement', 'fix'];
 }
 
 /** Diff fetch method identifier for logging. */


### PR DESCRIPTION
Part of #597

## Summary
- Added `implement` and `fix` to the default roles returned by `computeRoles()` when no explicit roles are configured
- Previously only `review` and `summary` were included, so agents without explicit role config would never auto-claim implement/fix tasks
- Updated corresponding unit tests

## Test plan
- [x] `computeRoles` unit tests updated and passing (28/28)
- [x] Build passes (`pnpm build`)
- [x] No new test failures introduced (pre-existing auth.test.ts failures unrelated)