### PR TITLE
[server-dev] Add POST /api/tasks/poll/batch endpoint

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -3308,7 +3308,7 @@ describe('Task Routes', () => {
       expect(body.assignments['generic'].tasks).toHaveLength(0);
     });
 
-    it('distributes multiple tasks across agents', async () => {
+    it('distributes multiple tasks round-robin across agents', async () => {
       await store.createTask(
         makeTask({ id: 'task-1', task_type: 'review', review_count: 3, queue: 'review' }),
       );
@@ -3327,14 +3327,20 @@ describe('Task Routes', () => {
       });
       expect(res.status).toBe(200);
       const body = await res.json();
-      // Each agent gets tasks, totaling 3 across all agents, no duplicates
+      // Round-robin: each agent gets exactly 1 task
+      const aCount = body.assignments['agent-a'].tasks.length;
+      const bCount = body.assignments['agent-b'].tasks.length;
+      const cCount = body.assignments['agent-c'].tasks.length;
+      expect(aCount).toBe(1);
+      expect(bCount).toBe(1);
+      expect(cCount).toBe(1);
+      // No duplicates
       const allTaskIds = [
         ...body.assignments['agent-a'].tasks.map((t: { task_id: string }) => t.task_id),
         ...body.assignments['agent-b'].tasks.map((t: { task_id: string }) => t.task_id),
         ...body.assignments['agent-c'].tasks.map((t: { task_id: string }) => t.task_id),
       ];
-      expect(allTaskIds).toHaveLength(3);
-      expect(new Set(allTaskIds).size).toBe(3); // no duplicates
+      expect(new Set(allTaskIds).size).toBe(3);
     });
 
     it('filters tasks by agent role', async () => {
@@ -3386,6 +3392,25 @@ describe('Task Routes', () => {
       expect(body.assignments['agent-b']).toBeDefined();
       expect(body.assignments['agent-a'].tasks).toEqual([]);
       expect(body.assignments['agent-b'].tasks).toEqual([]);
+    });
+
+    it('rejects request with duplicate agent_name values', async () => {
+      const res = await request('POST', '/api/tasks/poll/batch', {
+        agents: [
+          { agent_name: 'agent-a', roles: ['review'] },
+          { agent_name: 'agent-a', roles: ['summary'] },
+        ],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects request with more than 20 agents', async () => {
+      const agents = Array.from({ length: 21 }, (_, i) => ({
+        agent_name: `agent-${i}`,
+        roles: ['review' as const],
+      }));
+      const res = await request('POST', '/api/tasks/poll/batch', { agents });
+      expect(res.status).toBe(400);
     });
 
     it('existing single poll endpoint still works (backward compat)', async () => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -34,7 +34,7 @@ import {
 } from '../store/constants.js';
 import { evaluateSummaryQuality, MAX_SUMMARY_RETRIES } from '../summary-evaluator.js';
 import { isAgentEligibleForRole } from '../eligibility.js';
-import { rateLimitByAgent } from '../middleware/rate-limit.js';
+import { rateLimitByAgent, rateLimitByIP } from '../middleware/rate-limit.js';
 import { requireApiKey } from '../middleware/auth.js';
 import { requireOAuth } from '../middleware/oauth.js';
 import { apiError } from '../errors.js';
@@ -694,7 +694,8 @@ interface AgentFilter {
   agentRepos: Set<string> | null;
   model?: string;
   tool?: string;
-  synthesizeRepos?: RepoConfig;
+  /** All repo filters for summary task visibility (any match = allowed). */
+  repoFilters?: RepoConfig[];
   githubUsername?: string;
 }
 
@@ -746,9 +747,10 @@ async function filterTasksForAgent(
     // Grace period visibility checks
     if (isSummaryTask(task)) {
       if (!isSummaryVisibleToAgent(task, agent.agentId, agent.model)) continue;
-      // Repo filter for summary agents
-      if (agent.synthesizeRepos) {
-        if (!isRepoAllowed(agent.synthesizeRepos, task.owner, task.repo)) continue;
+      // Repo filter for summary agents — any matching filter allows the task
+      if (agent.repoFilters && agent.repoFilters.length > 0) {
+        const allowed = agent.repoFilters.some((rf) => isRepoAllowed(rf, task.owner, task.repo));
+        if (!allowed) continue;
       }
     } else {
       // Worker task — check model/tool preference grace period
@@ -944,7 +946,7 @@ export function taskRoutes() {
         agentRepos,
         model: body.model,
         tool: body.tool,
-        synthesizeRepos: synthesize_repos,
+        repoFilters: synthesize_repos ? [synthesize_repos] : undefined,
         githubUsername: verifiedIdentity?.github_username,
       },
       store,
@@ -957,94 +959,106 @@ export function taskRoutes() {
 
   // ── Batch Poll ──────────────────────────────────────────────
 
-  app.post('/api/tasks/poll/batch', rateLimitByAgent(POLL_RATE_LIMIT), async (c) => {
-    const store = c.get('store');
-    const github = c.get('github');
-    const logger = c.get('logger');
-    const verifiedIdentity = c.get('verifiedIdentity');
-    const body = await parseBody(c, BatchPollRequestSchema);
-    if (body instanceof Response) return body;
+  app.post(
+    '/api/tasks/poll/batch',
+    rateLimitByIP({ ...POLL_RATE_LIMIT, prefix: 'batch-poll' }),
+    async (c) => {
+      const store = c.get('store');
+      const github = c.get('github');
+      const logger = c.get('logger');
+      const verifiedIdentity = c.get('verifiedIdentity');
+      const body = await parseBody(c, BatchPollRequestSchema);
+      if (body instanceof Response) return body;
 
-    // Check timeouts lazily (throttled to every 30s per isolate)
-    await maybeCheckTimeouts(store, github, logger);
+      // Check timeouts lazily (throttled to every 30s per isolate)
+      await maybeCheckTimeouts(store, github, logger);
 
-    // Build shared poll context once for all agents
-    const pollCtx = await buildPollContext(store);
+      // Build shared poll context once for all agents
+      const pollCtx = await buildPollContext(store);
 
-    // Collect per-agent task lists
-    const agentTasks = new Map<string, PollTask[]>();
-    for (const agent of body.agents) {
-      // First repo_filter that matches determines synthesize_repos for summary agents
-      // repo_filters also controls private repo access (via whitelist entries)
-      const repoFilterSet =
-        agent.repo_filters && agent.repo_filters.length > 0 ? agent.repo_filters : null;
-      // Build a set of declared repos from whitelist repo_filters
-      const declaredRepos = new Set<string>();
-      if (repoFilterSet) {
-        for (const rf of repoFilterSet) {
-          if (rf.list) {
-            for (const entry of rf.list) declaredRepos.add(entry);
+      // Collect per-agent task lists
+      const agentTasks = new Map<string, PollTask[]>();
+      for (const agent of body.agents) {
+        // repo_filters controls both private repo access and summary task visibility
+        const repoFilterSet =
+          agent.repo_filters && agent.repo_filters.length > 0 ? agent.repo_filters : null;
+        // Build a set of declared repos from whitelist repo_filters
+        const declaredRepos = new Set<string>();
+        if (repoFilterSet) {
+          for (const rf of repoFilterSet) {
+            if (rf.list) {
+              for (const entry of rf.list) declaredRepos.add(entry);
+            }
+          }
+        }
+
+        const available = await filterTasksForAgent(
+          pollCtx,
+          {
+            agentId: agent.agent_name,
+            acceptedRoles: new Set(agent.roles),
+            agentRepos: declaredRepos.size > 0 ? declaredRepos : null,
+            model: agent.model,
+            tool: agent.tool,
+            repoFilters: repoFilterSet ?? undefined,
+            githubUsername: verifiedIdentity?.github_username,
+          },
+          store,
+          github,
+          logger,
+        );
+        agentTasks.set(agent.agent_name, available);
+      }
+
+      // Deduplicate across agents — each task goes to exactly one agent.
+      // Priority: preferred model/tool match wins, then first-come (request order).
+      const assignedTaskIds = new Set<string>();
+      const assignments: Record<string, PollTask[]> = {};
+
+      // Initialize all agents with empty arrays
+      for (const agent of body.agents) {
+        assignments[agent.agent_name] = [];
+      }
+
+      // First pass: assign tasks where agent matches an explicit preferred model/tool
+      for (const agent of body.agents) {
+        const tasks = agentTasks.get(agent.agent_name) ?? [];
+        for (const task of tasks) {
+          if (assignedTaskIds.has(task.task_id)) continue;
+          const reviewTask = pollCtx.tasksById.get(task.task_id);
+          if (!reviewTask) continue;
+          // Only prioritize when the task has explicit preferences AND the agent matches
+          const { preferredModels, preferredTools } = reviewTask.config;
+          if (preferredModels.length === 0 && preferredTools.length === 0) continue;
+          if (isReviewPreferredAgent(reviewTask.config, agent.model, agent.tool)) {
+            assignments[agent.agent_name].push(task);
+            assignedTaskIds.add(task.task_id);
           }
         }
       }
 
-      const available = await filterTasksForAgent(
-        pollCtx,
-        {
-          agentId: agent.agent_name,
-          acceptedRoles: new Set(agent.roles),
-          agentRepos: declaredRepos.size > 0 ? declaredRepos : null,
-          model: agent.model,
-          tool: agent.tool,
-          synthesizeRepos: repoFilterSet?.[0],
-          githubUsername: verifiedIdentity?.github_username,
-        },
-        store,
-        github,
-        logger,
-      );
-      agentTasks.set(agent.agent_name, available);
-    }
-
-    // Deduplicate across agents — each task goes to exactly one agent.
-    // Priority: preferred model/tool match wins, then first-come (request order).
-    const assignedTaskIds = new Set<string>();
-    const assignments: Record<string, PollTask[]> = {};
-
-    // Initialize all agents with empty arrays
-    for (const agent of body.agents) {
-      assignments[agent.agent_name] = [];
-    }
-
-    // First pass: assign tasks where agent has a preferred match
-    for (const agent of body.agents) {
-      const tasks = agentTasks.get(agent.agent_name) ?? [];
-      for (const task of tasks) {
-        if (assignedTaskIds.has(task.task_id)) continue;
-        const reviewTask = pollCtx.tasksById.get(task.task_id);
-        if (reviewTask && isReviewPreferredAgent(reviewTask.config, agent.model, agent.tool)) {
-          assignments[agent.agent_name].push(task);
-          assignedTaskIds.add(task.task_id);
+      // Second pass: distribute remaining tasks round-robin across agents
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const agent of body.agents) {
+          const tasks = agentTasks.get(agent.agent_name) ?? [];
+          const next = tasks.find((t) => !assignedTaskIds.has(t.task_id));
+          if (next) {
+            assignments[agent.agent_name].push(next);
+            assignedTaskIds.add(next.task_id);
+            changed = true;
+          }
         }
       }
-    }
 
-    // Second pass: assign remaining tasks round-robin (first agent that can take it)
-    for (const agent of body.agents) {
-      const tasks = agentTasks.get(agent.agent_name) ?? [];
-      for (const task of tasks) {
-        if (assignedTaskIds.has(task.task_id)) continue;
-        assignments[agent.agent_name].push(task);
-        assignedTaskIds.add(task.task_id);
-      }
-    }
-
-    return c.json<BatchPollResponse>({
-      assignments: Object.fromEntries(
-        Object.entries(assignments).map(([name, tasks]) => [name, { tasks }]),
-      ),
-    });
-  });
+      return c.json<BatchPollResponse>({
+        assignments: Object.fromEntries(
+          Object.entries(assignments).map(([name, tasks]) => [name, { tasks }]),
+        ),
+      });
+    },
+  );
 
   // ── Claim ────────────────────────────────────────────────────
 

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -61,7 +61,11 @@ export const BatchPollRequestSchema = z.object({
   agents: z
     .array(batchPollAgentSchema)
     .min(1, 'agents must contain at least one agent')
-    .max(20, 'agents must not exceed 20 entries'),
+    .max(20, 'agents must not exceed 20 entries')
+    .refine(
+      (agents) => new Set(agents.map((a) => a.agent_name)).size === agents.length,
+      'agent_name values must be unique',
+    ),
 });
 
 export const ClaimRequestSchema = z.object({


### PR DESCRIPTION
Part of #602

## Summary
- Extract poll filtering logic into reusable `filterTasksForAgent()` and `buildPollContext()` helpers shared between single and batch poll endpoints
- Add `BatchPollRequestSchema` Zod validation in schemas.ts
- Implement `POST /api/tasks/poll/batch` endpoint that accepts multiple agent profiles, filters tasks per agent, and deduplicates assignments (preferred model/tool match wins, then first-come)
- Existing `POST /api/tasks/poll` refactored to use the shared helper (backward compatible)

## Test plan
- [x] Batch poll with 1 agent returns correct tasks
- [x] Batch poll with 2 agents returns per-agent assignments by role
- [x] Dedup across agents — no two agents get same task
- [x] Preferred model/tool match wins dedup priority
- [x] Multiple tasks distributed across 3+ agents
- [x] Role filtering works correctly in batch poll
- [x] Validation rejects empty agents array, missing roles, empty roles
- [x] All agents get entries in response even with no tasks
- [x] Existing single poll endpoint still works (backward compat)
- [x] All 150 route-tasks tests pass
- [x] Full test suite: 2255 passed (6 pre-existing auth.test.ts failures on main)