### PR TITLE
perf: parallelize independent agent operations in batch mode

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1652,7 +1652,8 @@ export async function batchPollLoop(
       }
 
       // Sweep deferred codebase cleanups for all agents (in parallel)
-      await Promise.all(
+      // sweep() is internally fault-tolerant (re-queues failures), safe with allSettled
+      await Promise.allSettled(
         agentStates
           .filter((state) => state.cleanupTracker)
           .map(async (state) => {
@@ -1896,8 +1897,8 @@ export async function startBatchAgents(
     githubToken: oauthToken,
   });
 
-  // Cleanup on shutdown (in parallel)
-  await Promise.all(
+  // Cleanup on shutdown (in parallel, allSettled so one failure doesn't hide others)
+  await Promise.allSettled(
     agentStates.map(async (state) => {
       state.routerRelay?.stop();
       if (state.cleanupTracker && state.cleanupTracker.size > 0) {


### PR DESCRIPTION
## Summary
- Parallelize command testing at startup (for-of → Promise.all)
- Parallelize codebase cleanup sweeps during poll cycles
- Parallelize shutdown cleanup (router stop + sweep + summary)

Each agent's operations are independent — no shared state between iterations. With 8 agents, startup drops from ~80s (sequential) to ~10s (bounded by slowest command test).

## Test plan
- [x] All 28 agent tests pass
- [x] Build succeeds
- [ ] Manual test: `npx opencara agent start --all` shows parallel command testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)