### PR TITLE
[server-dev] Handle unified trigger modes in webhook handlers

### DIFF
--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -15,20 +15,28 @@ This document describes how to create and configure the GitHub App for OpenCara.
 
 Configure these **Repository permissions**:
 
-| Permission    | Access       | Purpose                          |
-| ------------- | ------------ | -------------------------------- |
-| Pull requests | Read & Write | Read PR details, post comments   |
-| Issues        | Read         | Read issue context               |
-| Contents      | Read         | Read `.opencara.toml` from repos |
+| Permission    | Access       | Purpose                           |
+| ------------- | ------------ | --------------------------------- |
+| Pull requests | Read & Write | Read PR details, post comments    |
+| Issues        | Read & Write | Read issue context, update labels |
+| Contents      | Read         | Read `.opencara.toml` from repos  |
 
-No **Organization permissions** or **Account permissions** are needed.
+Configure these **Organization permissions** (only needed for status triggers):
+
+| Permission            | Access | Purpose                                          |
+| --------------------- | ------ | ------------------------------------------------ |
+| Organization projects | Read   | Resolve project item content for status triggers |
+
+If you don't use status-based triggers (e.g., `trigger.status = "Ready"`), this permission is not required.
 
 ## Subscribe to Events
 
 Enable these webhook events:
 
-- **Pull request** — triggers review when PRs are opened or updated
-- **Issue comment** — enables `/opencara review` manual trigger on PRs
+- **Pull request** — triggers review when PRs are opened or updated; label triggers on PRs
+- **Issues** — triggers triage/implement on issue events; label triggers on issues
+- **Issue comment** — enables `/opencara review`, `/opencara triage`, `/opencara go`, `/opencara fix` commands
+- **Projects v2 item** — enables status-based triggers (e.g., implement when status changes to "Ready")
 - **Installation** — tracks when the app is installed/uninstalled on repos
 
 ## Post-Creation Setup

--- a/packages/server/src/__tests__/helpers/github-mock.ts
+++ b/packages/server/src/__tests__/helpers/github-mock.ts
@@ -292,6 +292,26 @@ export class MockGitHubService implements GitHubService {
     }
   }
 
+  resolveProjectItemResult: {
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null = null;
+
+  async resolveProjectItemContent(
+    nodeId: string,
+    token: string,
+  ): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    this.calls.push({ method: 'resolveProjectItemContent', args: { nodeId, token } });
+    return this.resolveProjectItemResult;
+  }
+
   /** Count postPrComment calls (convenience for assertions). */
   get commentCount(): number {
     return this.calls.filter((c) => c.method === 'postPrComment').length;

--- a/packages/server/src/__tests__/trigger-modes.test.ts
+++ b/packages/server/src/__tests__/trigger-modes.test.ts
@@ -1,0 +1,1284 @@
+/**
+ * Tests for unified trigger modes (label, event, comment, status).
+ *
+ * Covers:
+ * - Label triggers: issues.labeled / pull_request.labeled create tasks per feature
+ * - Status triggers: projects_v2_item creates implement tasks when status matches
+ * - Comment triggers: /opencara triage, gating for go/fix/review commands
+ * - Event triggers: gated by isEventTriggerEnabled()
+ * - Backward compatibility: configs without trigger section use defaults
+ * - Dedup: no duplicate tasks from combined triggers
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_REVIEW_CONFIG,
+  DEFAULT_OPENCARA_CONFIG,
+  type OpenCaraConfig,
+  type ReviewConfig,
+  type ReviewSectionConfig,
+} from '@opencara/shared';
+import type { GitHubService, PrDetails, IssueDetails } from '../github/service.js';
+import { MemoryDataStore } from '../store/memory.js';
+import { createApp } from '../index.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+import { parseTriageCommand } from '../routes/webhook.js';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+function getMockEnv() {
+  return {
+    GITHUB_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: 'unused-in-mock',
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+class TestGitHubService implements GitHubService {
+  openCaraConfig: OpenCaraConfig = DEFAULT_OPENCARA_CONFIG;
+  openCaraConfigParseError = false;
+  reviewConfig: ReviewConfig = DEFAULT_REVIEW_CONFIG;
+  reviewConfigParseError = false;
+  fetchPrResult: PrDetails | null = {
+    number: 1,
+    html_url: 'https://github.com/acme/widget/pull/1',
+    diff_url: 'https://github.com/acme/widget/pull/1.diff',
+    base: { ref: 'main' },
+    head: { ref: 'feat/test', sha: 'abc123' },
+    user: { login: 'pr-author' },
+    draft: false,
+    labels: [],
+  };
+  resolveProjectItemResult: {
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null = null;
+
+  async getInstallationToken(): Promise<string> {
+    return 'ghs_mock_token';
+  }
+  async postPrComment(): Promise<string> {
+    return 'https://github.com/test/repo/pull/1#comment-mock';
+  }
+  async fetchPrDetails(): Promise<PrDetails | null> {
+    return this.fetchPrResult;
+  }
+  async loadReviewConfig(): Promise<{ config: ReviewConfig; parseError: boolean }> {
+    return { config: this.reviewConfig, parseError: this.reviewConfigParseError };
+  }
+  async loadOpenCaraConfig(): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    return { config: this.openCaraConfig, parseError: this.openCaraConfigParseError };
+  }
+  async fetchPrReviewComments(): Promise<string> {
+    return '[mock-reviewer] src/index.ts:10\nPlease fix this bug';
+  }
+  async updateIssue(): Promise<void> {}
+  async fetchIssueBody(): Promise<string | null> {
+    return null;
+  }
+  async fetchIssueDetails(
+    _owner: string,
+    _repo: string,
+    number: number,
+  ): Promise<IssueDetails | null> {
+    return {
+      number,
+      html_url: `https://github.com/acme/widget/issues/${number}`,
+      title: `Test issue #${number}`,
+      body: 'Test issue body content',
+      user: { login: 'alice' },
+    };
+  }
+  async createIssue(): Promise<number> {
+    return 0;
+  }
+  async listIssueComments(): Promise<Array<{ id: number; body: string }>> {
+    return [];
+  }
+  async createIssueComment(): Promise<number> {
+    return 0;
+  }
+  async updateIssueComment(): Promise<void> {}
+  async resolveProjectItemContent(): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    return this.resolveProjectItemResult;
+  }
+}
+
+function makePRPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 999 },
+    repository: { owner: { login: 'acme' }, name: 'widget', default_branch: 'main' },
+    pull_request: {
+      number: 42,
+      html_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base: { ref: 'main' },
+      head: { ref: 'feat/test', sha: 'abc123' },
+      draft: false,
+      labels: [],
+    },
+    ...overrides,
+  };
+}
+
+function makePRLabelPayload(labelName: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'labeled',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    pull_request: {
+      number: 42,
+      html_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base: { ref: 'main' },
+      head: { ref: 'feat/test', sha: 'abc123' },
+      draft: false,
+      labels: [{ name: labelName }],
+    },
+    label: { name: labelName },
+    ...overrides,
+  };
+}
+
+function makeIssueLabelPayload(labelName: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'labeled',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 10,
+      html_url: 'https://github.com/acme/widget/issues/10',
+      title: 'Bug: something is broken',
+      body: 'Steps to reproduce...',
+      user: { login: 'alice' },
+      labels: [{ name: labelName }],
+    },
+    label: { name: labelName },
+    ...overrides,
+  };
+}
+
+function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'edited',
+    installation: { id: 999 },
+    projects_v2_item: { content_node_id: 'node123' },
+    changes: {
+      field_value: {
+        field_name: 'Status',
+        from: 'Backlog',
+        to: statusTo,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeIssueCommentPayload(commentBody: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 10,
+      // no pull_request field — this is a plain issue, not a PR
+    },
+    comment: {
+      body: commentBody,
+      user: { login: 'alice' },
+      author_association: 'OWNER',
+    },
+    ...overrides,
+  };
+}
+
+function makePrCommentPayload(commentBody: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 42,
+      pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/42' },
+    },
+    comment: {
+      body: commentBody,
+      user: { login: 'alice' },
+      author_association: 'OWNER',
+    },
+    ...overrides,
+  };
+}
+
+async function sendWebhook(
+  app: ReturnType<typeof createApp>,
+  event: string,
+  payload: unknown,
+  env: ReturnType<typeof getMockEnv>,
+) {
+  const body = JSON.stringify(payload);
+  const signature = await signPayload(body, WEBHOOK_SECRET);
+  return app.request(
+    '/webhook/github',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': event,
+      },
+      body,
+    },
+    env,
+  );
+}
+
+function makeReviewConfig(overrides: Partial<ReviewSectionConfig> = {}): ReviewSectionConfig {
+  return { ...DEFAULT_REVIEW_CONFIG, ...overrides };
+}
+
+const DEFAULT_TRIAGE_CONFIG = {
+  enabled: true,
+  prompt: 'Triage this issue',
+  agentCount: 1,
+  timeout: '10m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  defaultMode: 'comment' as const,
+  autoLabel: false,
+  trigger: { events: ['opened'], comment: '/opencara triage' },
+};
+
+const DEFAULT_IMPLEMENT_CONFIG = {
+  enabled: true,
+  prompt: 'Implement the requested changes.',
+  agentCount: 1,
+  timeout: '10m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  trigger: { comment: '/opencara go', status: 'Ready' },
+};
+
+const DEFAULT_FIX_CONFIG = {
+  enabled: true,
+  prompt: 'Fix the review comments.',
+  agentCount: 1,
+  timeout: '10m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  trigger: { comment: '/opencara fix' },
+};
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('Unified trigger modes', () => {
+  let store: MemoryDataStore;
+  let github: TestGitHubService;
+  let app: ReturnType<typeof createApp>;
+  let env: ReturnType<typeof getMockEnv>;
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    github = new TestGitHubService();
+    app = createApp(store, github);
+    env = getMockEnv();
+  });
+
+  // ── parseTriageCommand ─────────────────────────────────────
+
+  describe('parseTriageCommand', () => {
+    it('parses /opencara triage without model', () => {
+      expect(parseTriageCommand('/opencara triage')).toEqual({ targetModel: undefined });
+    });
+
+    it('parses /opencara triage with model', () => {
+      expect(parseTriageCommand('/opencara triage gpt-5.4')).toEqual({ targetModel: 'gpt-5.4' });
+    });
+
+    it('parses @opencara triage without model', () => {
+      expect(parseTriageCommand('@opencara triage')).toEqual({ targetModel: undefined });
+    });
+
+    it('parses @opencara triage with model', () => {
+      expect(parseTriageCommand('@opencara triage claude-opus')).toEqual({
+        targetModel: 'claude-opus',
+      });
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseTriageCommand('/OpenCara Triage')).toEqual({ targetModel: undefined });
+      expect(parseTriageCommand('/OPENCARA TRIAGE gpt-5')).toEqual({ targetModel: 'gpt-5' });
+    });
+
+    it('handles leading/trailing whitespace', () => {
+      expect(parseTriageCommand('  /opencara triage  ')).toEqual({ targetModel: undefined });
+    });
+
+    it('returns null for non-triage commands', () => {
+      expect(parseTriageCommand('/opencara review')).toBeNull();
+      expect(parseTriageCommand('/opencara go')).toBeNull();
+      expect(parseTriageCommand('/opencara fix')).toBeNull();
+      expect(parseTriageCommand('hello world')).toBeNull();
+      expect(parseTriageCommand('')).toBeNull();
+    });
+
+    it('returns null for partial matches', () => {
+      expect(parseTriageCommand('opencara triage')).toBeNull();
+      expect(parseTriageCommand('/opencaratriage')).toBeNull();
+    });
+
+    it('returns null for conversational comments', () => {
+      expect(parseTriageCommand('/opencara triage this bug please')).toBeNull();
+    });
+  });
+
+  // ── Label triggers: PR ────────────────────────────────────
+
+  describe('PR label triggers', () => {
+    it('creates review task when label matches trigger.label', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review', label: 'opencara:review' },
+        }),
+      };
+
+      const res = await sendWebhook(
+        app,
+        'pull_request',
+        makePRLabelPayload('opencara:review'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+    });
+
+    it('ignores label when trigger.label is absent', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review' },
+        }),
+      };
+
+      const res = await sendWebhook(
+        app,
+        'pull_request',
+        makePRLabelPayload('opencara:review'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('ignores label when it does not match trigger.label', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review', label: 'opencara:review' },
+        }),
+      };
+
+      const res = await sendWebhook(
+        app,
+        'pull_request',
+        makePRLabelPayload('unrelated-label'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('creates fix task when fix label trigger matches', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: {
+          ...DEFAULT_FIX_CONFIG,
+          trigger: { comment: '/opencara fix', label: 'opencara:fix' },
+        },
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRLabelPayload('opencara:fix'), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('fix');
+    });
+
+    it('creates both review and fix tasks when label matches both', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review', label: 'opencara:all' },
+        }),
+        fix: {
+          ...DEFAULT_FIX_CONFIG,
+          trigger: { comment: '/opencara fix', label: 'opencara:all' },
+        },
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRLabelPayload('opencara:all'), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(2);
+      const features = new Set(tasks.map((t) => t.feature));
+      expect(features).toEqual(new Set(['review', 'fix']));
+    });
+
+    it('respects skip conditions on label trigger', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: {
+            events: ['opened'],
+            comment: '/opencara review',
+            label: 'opencara:review',
+            skip: ['draft'],
+          },
+        }),
+      };
+
+      const payload = makePRLabelPayload('opencara:review', {
+        pull_request: {
+          number: 42,
+          html_url: 'https://github.com/acme/widget/pull/42',
+          diff_url: 'https://github.com/acme/widget/pull/42.diff',
+          base: { ref: 'main' },
+          head: { ref: 'feat/test', sha: 'abc123' },
+          draft: true,
+          labels: [{ name: 'opencara:review' }],
+        },
+      });
+      const res = await sendWebhook(app, 'pull_request', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+  });
+
+  // ── Label triggers: Issue ─────────────────────────────────
+
+  describe('Issue label triggers', () => {
+    it('creates implement task when label matches trigger.label', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: {
+            comment: '/opencara go',
+            status: 'Ready',
+            label: 'opencara:implement',
+          },
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        makeIssueLabelPayload('opencara:implement'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].task_type).toBe('implement');
+      expect(tasks[0].issue_number).toBe(10);
+    });
+
+    it('creates triage task when label matches trigger.label', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          ...DEFAULT_TRIAGE_CONFIG,
+          trigger: {
+            events: ['opened'],
+            comment: '/opencara triage',
+            label: 'opencara:triage',
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssueLabelPayload('opencara:triage'), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+      expect(tasks[0].task_type).toBe('issue_triage');
+    });
+
+    it('ignores label when no label trigger configured', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        makeIssueLabelPayload('opencara:implement'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores label when it does not match', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: {
+            comment: '/opencara go',
+            label: 'opencara:implement',
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', makeIssueLabelPayload('unrelated-label'), env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('skips PR issues on labeled event', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: {
+            comment: '/opencara go',
+            label: 'opencara:implement',
+          },
+        },
+      };
+
+      const payload = makeIssueLabelPayload('opencara:implement', {
+        issue: {
+          number: 10,
+          html_url: 'https://github.com/acme/widget/issues/10',
+          title: 'Bug',
+          body: 'Body',
+          user: { login: 'alice' },
+          pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/10' },
+          labels: [{ name: 'opencara:implement' }],
+        },
+      });
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+  });
+
+  // ── Status triggers ───────────────────────────────────────
+
+  describe('Status triggers (projects_v2_item)', () => {
+    it('creates implement task when status matches trigger.status', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].task_type).toBe('implement');
+      expect(tasks[0].issue_number).toBe(10);
+    });
+
+    it('ignores when status does not match trigger.status', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('In Progress'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when trigger.status is absent', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: { comment: '/opencara go' }, // no status field
+        },
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when content resolves to PullRequest', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'PullRequest',
+        owner: 'acme',
+        repo: 'widget',
+        number: 42,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when content cannot be resolved', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = null;
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when field change is not Status', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+
+      const payload = {
+        action: 'edited',
+        installation: { id: 999 },
+        projects_v2_item: { content_node_id: 'node123' },
+        changes: {
+          field_value: { field_name: 'Priority', from: 'Low', to: 'High' },
+        },
+      };
+
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores non-edited actions', async () => {
+      const payload = {
+        action: 'created',
+        installation: { id: 999 },
+        projects_v2_item: { content_node_id: 'node123' },
+      };
+
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when implement is disabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: { ...DEFAULT_IMPLEMENT_CONFIG, enabled: false },
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('ignores when no installation', async () => {
+      const payload = makeProjectsV2ItemPayload('Ready', { installation: undefined });
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+  });
+
+  // ── Comment triggers: triage ──────────────────────────────
+
+  describe('Triage comment trigger', () => {
+    it('/opencara triage creates triage task when enabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+      expect(tasks[0].task_type).toBe('issue_triage');
+      expect(tasks[0].issue_number).toBe(10);
+    });
+
+    it('@opencara triage also works', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('@opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+    });
+
+    it('/opencara triage with model sets target_model', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara triage gpt-5'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].target_model).toBe('gpt-5');
+    });
+
+    it('triage command without model does not set target_model', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].target_model).toBeUndefined();
+    });
+
+    it('triage command is ignored when triage.enabled=false', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: { ...DEFAULT_TRIAGE_CONFIG, enabled: false },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('triage command is ignored when comment trigger disabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          ...DEFAULT_TRIAGE_CONFIG,
+          trigger: { events: ['opened'] }, // no comment field
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('triage command from non-trusted user is ignored', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const payload = makeIssueCommentPayload('/opencara triage', {
+        comment: {
+          body: '/opencara triage',
+          user: { login: 'random' },
+          author_association: 'NONE',
+        },
+      });
+
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('triage command from CONTRIBUTOR is allowed (trusted)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const payload = makeIssueCommentPayload('/opencara triage', {
+        comment: {
+          body: '/opencara triage',
+          user: { login: 'contrib-user' },
+          author_association: 'CONTRIBUTOR',
+        },
+      });
+
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+    });
+
+    it('triage command on PR is ignored', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      // PR comment (has pull_request field)
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara triage'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('duplicate triage commands are deduplicated', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      await sendWebhook(app, 'issue_comment', makeIssueCommentPayload('/opencara triage'), env);
+      await sendWebhook(app, 'issue_comment', makeIssueCommentPayload('/opencara triage'), env);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+  });
+
+  // ── Comment trigger gating ────────────────────────────────
+
+  describe('Comment trigger gating', () => {
+    it('go command is ignored when comment trigger disabled for implement', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: { status: 'Ready' }, // no comment field
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('fix command is ignored when comment trigger disabled for fix', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: {
+          ...DEFAULT_FIX_CONFIG,
+          trigger: { label: 'opencara:fix' }, // no comment field
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara fix'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('review comment trigger is ignored when comment trigger disabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'] }, // no comment field
+        }),
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara review'),
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+  });
+
+  // ── Event trigger gating ──────────────────────────────────
+
+  describe('Event trigger gating', () => {
+    it('PR event trigger works when events configured', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review' },
+        }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+    });
+
+    it('PR event trigger skips when events empty', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: [], comment: '/opencara review' },
+        }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('PR event trigger skips when events absent', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { comment: '/opencara review' }, // no events
+        }),
+      };
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('issue event trigger for triage works when action in events', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: DEFAULT_TRIAGE_CONFIG,
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        {
+          action: 'opened',
+          installation: { id: 999 },
+          repository: { owner: { login: 'acme' }, name: 'widget', default_branch: 'main' },
+          issue: {
+            number: 10,
+            html_url: 'https://github.com/acme/widget/issues/10',
+            title: 'Bug',
+            body: 'Body',
+            user: { login: 'alice' },
+          },
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('triage');
+    });
+
+    it('issue event trigger skips when events absent for triage', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          ...DEFAULT_TRIAGE_CONFIG,
+          trigger: { comment: '/opencara triage' }, // no events
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        {
+          action: 'opened',
+          installation: { id: 999 },
+          repository: { owner: { login: 'acme' }, name: 'widget', default_branch: 'main' },
+          issue: {
+            number: 10,
+            html_url: 'https://github.com/acme/widget/issues/10',
+            title: 'Bug',
+            body: 'Body',
+            user: { login: 'alice' },
+          },
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+  });
+
+  // ── Backward compatibility ────────────────────────────────
+
+  describe('Backward compatibility', () => {
+    it('default config works with event triggers', async () => {
+      // DEFAULT_OPENCARA_CONFIG has events: ['opened'], comment: '/opencara review'
+      github.openCaraConfig = DEFAULT_OPENCARA_CONFIG;
+
+      const res = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+    });
+
+    it('default config works with comment triggers', async () => {
+      github.openCaraConfig = DEFAULT_OPENCARA_CONFIG;
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara review'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('review');
+    });
+  });
+
+  // ── Dedup across triggers ─────────────────────────────────
+
+  describe('Dedup across triggers', () => {
+    it('duplicate label trigger does not create duplicate tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { events: ['opened'], comment: '/opencara review', label: 'opencara:review' },
+        }),
+      };
+
+      await sendWebhook(app, 'pull_request', makePRLabelPayload('opencara:review'), env);
+      await sendWebhook(app, 'pull_request', makePRLabelPayload('opencara:review'), env);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+
+    it('duplicate status trigger does not create duplicate tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      await sendWebhook(app, 'projects_v2_item', makeProjectsV2ItemPayload('Ready'), env);
+      await sendWebhook(app, 'projects_v2_item', makeProjectsV2ItemPayload('Ready'), env);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+    });
+  });
+
+  // ── All triggers together ─────────────────────────────────
+
+  describe('All triggers work together', () => {
+    it('config with all trigger modes enabled creates correct tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: {
+            events: ['opened'],
+            comment: '/opencara review',
+            label: 'opencara:review',
+          },
+        }),
+        triage: {
+          ...DEFAULT_TRIAGE_CONFIG,
+          trigger: {
+            events: ['opened'],
+            comment: '/opencara triage',
+            label: 'opencara:triage',
+          },
+        },
+        implement: {
+          ...DEFAULT_IMPLEMENT_CONFIG,
+          trigger: {
+            comment: '/opencara go',
+            status: 'Ready',
+            label: 'opencara:implement',
+          },
+        },
+        fix: {
+          ...DEFAULT_FIX_CONFIG,
+          trigger: {
+            comment: '/opencara fix',
+            label: 'opencara:fix',
+          },
+        },
+      };
+
+      // Event trigger: PR opened → review task
+      const prRes = await sendWebhook(app, 'pull_request', makePRPayload(), env);
+      expect(prRes.status).toBe(200);
+      const prTasks = await store.listTasks();
+      expect(prTasks).toHaveLength(1);
+      expect(prTasks[0].feature).toBe('review');
+    });
+  });
+});

--- a/packages/server/src/__tests__/webhook-refactor.test.ts
+++ b/packages/server/src/__tests__/webhook-refactor.test.ts
@@ -121,6 +121,20 @@ class TestGitHubService implements GitHubService {
   async createIssue(): Promise<number> {
     return 0;
   }
+  resolveProjectItemResult: {
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null = null;
+  async resolveProjectItemContent(): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    return this.resolveProjectItemResult;
+  }
   async listIssueComments(): Promise<Array<{ id: number; body: string }>> {
     return [];
   }

--- a/packages/server/src/github/service.ts
+++ b/packages/server/src/github/service.ts
@@ -116,6 +116,16 @@ export interface GitHubService {
     body: string,
     token: string,
   ): Promise<void>;
+
+  /**
+   * Resolve a GitHub Projects V2 item's content_node_id to the underlying
+   * issue or PR details via the GraphQL API.
+   * Returns { type, owner, repo, number } or null if unresolvable.
+   */
+  resolveProjectItemContent(
+    nodeId: string,
+    token: string,
+  ): Promise<{ type: 'Issue' | 'PullRequest'; owner: string; repo: string; number: number } | null>;
 }
 
 /**
@@ -404,6 +414,68 @@ export class RealGitHubService implements GitHubService {
       );
     }
   }
+
+  async resolveProjectItemContent(
+    nodeId: string,
+    token: string,
+  ): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    const query = `
+      query($nodeId: ID!) {
+        node(id: $nodeId) {
+          ... on Issue {
+            __typename
+            number
+            repository { owner { login } name }
+          }
+          ... on PullRequest {
+            __typename
+            number
+            repository { owner { login } name }
+          }
+        }
+      }
+    `;
+    const response = await githubFetch('https://api.github.com/graphql', {
+      method: 'POST',
+      token,
+      body: JSON.stringify({ query, variables: { nodeId } }),
+    });
+
+    if (!response.ok) {
+      this.logger.warn('GraphQL query failed for project item content', {
+        status: response.status,
+        nodeId,
+      });
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      data?: {
+        node?: {
+          __typename: string;
+          number: number;
+          repository: { owner: { login: string }; name: string };
+        };
+      };
+    };
+
+    const node = data.data?.node;
+    if (!node || (node.__typename !== 'Issue' && node.__typename !== 'PullRequest')) {
+      return null;
+    }
+
+    return {
+      type: node.__typename as 'Issue' | 'PullRequest',
+      owner: node.repository.owner.login,
+      repo: node.repository.name,
+      number: node.number,
+    };
+  }
 }
 
 /**
@@ -568,5 +640,15 @@ export class NoOpGitHubService implements GitHubService {
         return;
       }
     }
+  }
+
+  async resolveProjectItemContent(nodeId: string): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    this.logger.info('Dev mode — returning null for project item content', { nodeId });
+    return null;
   }
 }

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -7,7 +7,13 @@ import type {
   TaskRole,
   ReviewTask,
 } from '@opencara/shared';
-import { DEFAULT_REVIEW_CONFIG } from '@opencara/shared';
+import {
+  DEFAULT_REVIEW_CONFIG,
+  isEventTriggerEnabled,
+  isCommentTriggerEnabled,
+  isLabelTriggerEnabled,
+  isStatusTriggerEnabled,
+} from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
@@ -87,6 +93,22 @@ interface IssuePayload {
     body: string | null;
     user: { login: string };
     pull_request?: { url: string };
+    labels?: Array<{ name: string }>;
+  };
+}
+
+interface ProjectsV2ItemPayload {
+  action: string;
+  installation?: { id: number };
+  projects_v2_item: {
+    content_node_id: string;
+  };
+  changes?: {
+    field_value?: {
+      field_name: string;
+      from?: string | null;
+      to?: string | null;
+    };
   };
 }
 
@@ -432,8 +454,12 @@ async function createIssueTaskGroups(
   // for idempotency; subsequent groups skip dedup (the primary guards).
   let primaryCreated = false;
 
-  // Triage task group
-  if (fullConfig.triage?.enabled && fullConfig.triage.trigger.events?.includes(action)) {
+  // Triage task group (event trigger)
+  if (
+    fullConfig.triage?.enabled &&
+    isEventTriggerEnabled(fullConfig.triage.trigger) &&
+    fullConfig.triage.trigger.events!.includes(action)
+  ) {
     const groupId = await createTaskGroup(
       store,
       'triage',
@@ -515,6 +541,16 @@ export function webhookRoutes() {
           );
         }
         break;
+      case 'projects_v2_item':
+        if (action === 'edited') {
+          return handleProjectsV2Item(
+            github,
+            store,
+            payload as unknown as ProjectsV2ItemPayload,
+            logger,
+          );
+        }
+        break;
       case 'installation':
         logger.info('Installation event', { action });
         break;
@@ -585,11 +621,33 @@ async function handlePullRequest(
     return new Response('OK', { status: 200 });
   }
 
-  if (!reviewConfig.trigger.events?.includes(action)) {
+  // Handle label triggers for PR-scoped features (review, fix)
+  if (action === 'labeled') {
+    const addedLabel = (payload as unknown as { label?: { name: string } }).label?.name;
+    if (addedLabel) {
+      return handlePrLabelTrigger(
+        store,
+        installation.id,
+        owner,
+        repo,
+        pull_request,
+        fullConfig,
+        reviewConfig,
+        addedLabel,
+        repository.private ?? false,
+        logger,
+      );
+    }
+    return new Response('OK', { status: 200 });
+  }
+
+  // Event-based triggers for review
+  const reviewTrigger = reviewConfig.trigger;
+  if (!isEventTriggerEnabled(reviewTrigger) || !reviewTrigger.events!.includes(action)) {
     logger.info('Action not in trigger.events — skipping', {
       prNumber,
       action,
-      triggerEvents: reviewConfig.trigger.events,
+      triggerEvents: reviewTrigger.events,
     });
     return new Response('OK', { status: 200 });
   }
@@ -700,6 +758,48 @@ export async function handleIssueEvent(
     return new Response('OK', { status: 200 });
   }
 
+  // Handle label trigger for issue-scoped features (implement, triage)
+  if (action === 'labeled') {
+    const addedLabel = (payload as unknown as { label?: { name: string } }).label?.name;
+    if (!addedLabel) return new Response('OK', { status: 200 });
+
+    let token: string;
+    try {
+      token = await github.getInstallationToken(installation.id);
+    } catch (err) {
+      logger.error('Failed to get installation token', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+
+    const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
+      owner,
+      repo,
+      defaultBranch,
+      token,
+    );
+
+    if (parseError) {
+      logger.info('Aborting due to .opencara.toml parse error', { issueNumber: issue.number });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+
+    return handleIssueLabelTrigger(
+      github,
+      store,
+      installation.id,
+      owner,
+      repo,
+      issue,
+      fullConfig,
+      addedLabel,
+      repository.private ?? false,
+      token,
+      logger,
+    );
+  }
+
   if (action !== 'opened' && action !== 'edited') {
     logger.info('Issue action not handled — skipping', { action, issueNumber: issue.number });
     return new Response('OK', { status: 200 });
@@ -731,9 +831,11 @@ export async function handleIssueEvent(
 
   const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
 
-  // Check if any feature is enabled for issues
+  // Check if any feature is enabled for issues via event triggers
   const triageEnabled =
-    fullConfig.triage?.enabled && fullConfig.triage.trigger.events?.includes(action);
+    fullConfig.triage?.enabled &&
+    isEventTriggerEnabled(fullConfig.triage.trigger) &&
+    fullConfig.triage.trigger.events!.includes(action);
   const dedupIssuesEnabled = fullConfig.dedup?.issues?.enabled;
 
   if (!triageEnabled && !dedupIssuesEnabled) {
@@ -857,6 +959,18 @@ export function parseGoCommand(body: string): { targetModel?: string } | null {
   return { targetModel: match[1] || undefined };
 }
 
+/**
+ * Parse a triage command from a comment body.
+ * Matches `/opencara triage [model]` or `@opencara triage [model]`.
+ * Returns the optional target model, or null if not a triage command.
+ */
+export function parseTriageCommand(body: string): { targetModel?: string } | null {
+  const trimmed = body.trim();
+  const match = trimmed.match(/^[/@]opencara\s+triage(?:\s+(\S+))?\s*$/i);
+  if (!match) return null;
+  return { targetModel: match[1] || undefined };
+}
+
 async function handleIssueComment(
   github: GitHubService,
   store: DataStore,
@@ -870,30 +984,47 @@ async function handleIssueComment(
     return new Response('OK', { status: 200 });
   }
 
-  // Check for go command on issues (not PRs)
-  const goCmd = parseGoCommand(comment.body);
-  if (goCmd) {
-    if (issue.pull_request) {
-      // go command is only valid on issues, not PRs
-      return new Response('OK', { status: 200 });
+  // Issue-only commands: go and triage (not valid on PRs)
+  if (!issue.pull_request) {
+    const goCmd = parseGoCommand(comment.body);
+    if (goCmd) {
+      return handleGoCommand(
+        github,
+        store,
+        installation.id,
+        repository.owner.login,
+        repository.name,
+        issue.number,
+        repository.default_branch ?? 'main',
+        comment,
+        goCmd,
+        repository.private ?? false,
+        logger,
+      );
     }
-    return handleGoCommand(
-      github,
-      store,
-      installation.id,
-      repository.owner.login,
-      repository.name,
-      issue.number,
-      repository.default_branch ?? 'main',
-      comment,
-      goCmd,
-      repository.private ?? false,
-      logger,
-    );
+
+    const triageCmd = parseTriageCommand(comment.body);
+    if (triageCmd) {
+      return handleTriageCommand(
+        github,
+        store,
+        installation.id,
+        repository.owner.login,
+        repository.name,
+        issue.number,
+        repository.default_branch ?? 'main',
+        comment,
+        triageCmd,
+        repository.private ?? false,
+        logger,
+      );
+    }
+
+    return new Response('OK', { status: 200 });
   }
 
-  // All remaining commands (fix, review) require a PR context
-  if (!issue.pull_request) {
+  // Check for go command — invalid on PRs, skip silently
+  if (parseGoCommand(comment.body)) {
     return new Response('OK', { status: 200 });
   }
 
@@ -956,11 +1087,11 @@ async function handleIssueComment(
     );
   }
 
-  // Check for review trigger command
-  const triggerCommand = reviewConfig.trigger.comment;
-  if (!triggerCommand) {
+  // Check for review trigger command (gated by isCommentTriggerEnabled)
+  if (!isCommentTriggerEnabled(reviewConfig.trigger)) {
     return new Response('OK', { status: 200 });
   }
+  const triggerCommand = reviewConfig.trigger.comment!;
   const body = comment.body.trim().toLowerCase();
   const cmd = triggerCommand.toLowerCase();
   // Only slash-commands get an @-alias (e.g. /opencara review → @opencara review).
@@ -1056,6 +1187,15 @@ async function handleFixCommand(
 
   if (!fullConfig.fix?.enabled) {
     logger.info('Fix command ignored — [fix].enabled is not true', {
+      owner,
+      repo,
+      prNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  if (!isCommentTriggerEnabled(fullConfig.fix.trigger)) {
+    logger.info('Fix command ignored — comment trigger not enabled', {
       owner,
       repo,
       prNumber,
@@ -1214,6 +1354,15 @@ async function handleGoCommand(
     return new Response('OK', { status: 200 });
   }
 
+  if (!isCommentTriggerEnabled(fullConfig.implement.trigger)) {
+    logger.info('Go command ignored — comment trigger not enabled', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
   // Fetch issue details from GitHub API
   let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
   try {
@@ -1283,6 +1432,523 @@ async function handleGoCommand(
       issueNumber,
     });
     return new Response('Service Unavailable', { status: 503 });
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+/**
+ * Handle `/opencara triage [model]` command on an issue comment.
+ * Creates a triage task group with issue context.
+ */
+async function handleTriageCommand(
+  github: GitHubService,
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  defaultBranch: string,
+  comment: IssueCommentPayload['comment'],
+  triageCmd: { targetModel?: string },
+  isPrivate: boolean,
+  logger: Logger,
+): Promise<Response> {
+  if (!TRUSTED_ASSOCIATIONS.has(comment.author_association)) {
+    logger.info('Triage command ignored — not a trusted contributor', {
+      user: comment.user.login,
+      association: comment.author_association,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  logger.info('Triage command received', {
+    user: comment.user.login,
+    owner,
+    repo,
+    issueNumber,
+    targetModel: triageCmd.targetModel,
+  });
+
+  let token: string;
+  try {
+    token = await github.getInstallationToken(installationId);
+  } catch (err) {
+    logger.error('Failed to get installation token', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
+    owner,
+    repo,
+    defaultBranch,
+    token,
+  );
+
+  if (parseError) {
+    logger.info('Aborting triage command due to .opencara.toml parse error', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  if (!fullConfig.triage?.enabled) {
+    logger.info('Triage command ignored — [triage].enabled is not true', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  if (!isCommentTriggerEnabled(fullConfig.triage.trigger)) {
+    logger.info('Triage command ignored — comment trigger not enabled', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  // Fetch issue details from GitHub API
+  let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
+  try {
+    issue = await github.fetchIssueDetails(owner, repo, issueNumber, token);
+  } catch (err) {
+    logger.error('Failed to fetch issue details', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+  if (!issue) {
+    logger.error('Issue not found', { owner, repo, issueNumber });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const triageConfig = fullConfig.triage;
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+  const timeoutMs = parseTimeoutMs(triageConfig.timeout);
+
+  const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+    owner,
+    repo,
+    pr_number: 0,
+    pr_url: '',
+    diff_url: '',
+    base_ref: '',
+    head_ref: '',
+    review_count: triageConfig.agentCount,
+    timeout_at: Date.now() + timeoutMs,
+    status: 'pending',
+    queue: 'summary',
+    github_installation_id: installationId,
+    private: isPrivate,
+    config: reviewConfig,
+    created_at: Date.now(),
+  };
+
+  try {
+    await createTaskGroup(store, 'triage', triageConfig, baseTask, logger, {
+      issue_number: issue.number,
+      issue_url: issue.html_url,
+      issue_title: issue.title,
+      issue_body: issue.body ?? undefined,
+      issue_author: issue.user.login,
+      ...(triageCmd.targetModel ? { target_model: triageCmd.targetModel } : {}),
+    });
+  } catch (err) {
+    logger.error('Failed to create triage task group', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+// ── Label Trigger Handlers ──────────────────────────────────────
+
+/**
+ * Handle label triggers on a PR: review and fix features.
+ */
+async function handlePrLabelTrigger(
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  pullRequest: PullRequestPayload['pull_request'],
+  fullConfig: OpenCaraConfig,
+  reviewConfig: ReviewConfig,
+  addedLabel: string,
+  isPrivate: boolean,
+  logger: Logger,
+): Promise<Response> {
+  const prNumber = pullRequest.number;
+  const headRef = pullRequest.head.ref;
+
+  // Skip conditions apply to label triggers too
+  const skipReason = shouldSkipReview(reviewConfig, {
+    draft: pullRequest.draft,
+    labels: pullRequest.labels,
+    headRef,
+  });
+  if (skipReason) {
+    logger.info('PR label trigger skipped', { prNumber, reason: skipReason });
+    return new Response('OK', { status: 200 });
+  }
+
+  const diffSize =
+    typeof pullRequest.additions === 'number' && typeof pullRequest.deletions === 'number'
+      ? pullRequest.additions + pullRequest.deletions
+      : undefined;
+
+  const timeoutMs = parseTimeoutMs(reviewConfig.timeout);
+  const baseTask = buildBaseTask(
+    installationId,
+    owner,
+    repo,
+    prNumber,
+    pullRequest.html_url,
+    pullRequest.diff_url,
+    pullRequest.base.ref,
+    headRef,
+    reviewConfig,
+    isPrivate,
+    timeoutMs,
+    diffSize,
+  );
+
+  let created = false;
+
+  // Review label trigger
+  if (isLabelTriggerEnabled(reviewConfig.trigger) && reviewConfig.trigger.label === addedLabel) {
+    logger.info('Review label trigger matched', { prNumber, label: addedLabel });
+    const groupId = await createTaskGroup(
+      store,
+      'review',
+      reviewConfig,
+      baseTask,
+      logger,
+      undefined,
+      created,
+    );
+    if (groupId !== null) created = true;
+  }
+
+  // Fix label trigger
+  if (
+    fullConfig.fix?.enabled &&
+    isLabelTriggerEnabled(fullConfig.fix.trigger) &&
+    fullConfig.fix.trigger.label === addedLabel
+  ) {
+    logger.info('Fix label trigger matched', { prNumber, label: addedLabel });
+    await createTaskGroup(store, 'fix', fullConfig.fix, baseTask, logger, undefined, created);
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+/**
+ * Handle label triggers on an issue: implement and triage features.
+ */
+async function handleIssueLabelTrigger(
+  github: GitHubService,
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  issue: IssuePayload['issue'],
+  fullConfig: OpenCaraConfig,
+  addedLabel: string,
+  isPrivate: boolean,
+  token: string,
+  logger: Logger,
+): Promise<Response> {
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+  const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+    owner,
+    repo,
+    pr_number: 0,
+    pr_url: '',
+    diff_url: '',
+    base_ref: '',
+    head_ref: '',
+    review_count: 1,
+    timeout_at: Date.now() + 10 * 60 * 1000,
+    status: 'pending',
+    queue: 'summary',
+    github_installation_id: installationId,
+    private: isPrivate,
+    config: reviewConfig,
+    created_at: Date.now(),
+  };
+
+  const issueFields: Partial<ReviewTask> = {
+    issue_number: issue.number,
+    issue_url: issue.html_url,
+    issue_title: issue.title,
+    issue_body: issue.body ?? undefined,
+    issue_author: issue.user.login,
+  };
+
+  let created = false;
+
+  // Implement label trigger
+  if (
+    fullConfig.implement?.enabled &&
+    isLabelTriggerEnabled(fullConfig.implement.trigger) &&
+    fullConfig.implement.trigger.label === addedLabel
+  ) {
+    logger.info('Implement label trigger matched', {
+      issueNumber: issue.number,
+      label: addedLabel,
+    });
+
+    // Fetch full issue details for implement tasks
+    let issueDetails: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
+    try {
+      issueDetails = await github.fetchIssueDetails(owner, repo, issue.number, token);
+    } catch (err) {
+      logger.error('Failed to fetch issue details for implement label trigger', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+    if (!issueDetails) {
+      logger.error('Issue not found for implement label trigger', {
+        issueNumber: issue.number,
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+
+    const implementConfig = fullConfig.implement;
+    const implementTimeoutMs = parseTimeoutMs(implementConfig.timeout);
+    const implementTaskConfig: ReviewConfig = {
+      ...reviewConfig,
+      agentCount: implementConfig.agentCount,
+      timeout: implementConfig.timeout,
+      preferredModels: implementConfig.preferredModels,
+      preferredTools: implementConfig.preferredTools,
+      prompt: implementConfig.prompt,
+      modelDiversityGraceMs: implementConfig.modelDiversityGraceMs,
+    };
+
+    const implementBase: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> =
+      {
+        ...baseTask,
+        review_count: implementConfig.agentCount,
+        timeout_at: Date.now() + implementTimeoutMs,
+        config: implementTaskConfig,
+      };
+
+    const groupId = await createTaskGroup(
+      store,
+      'implement',
+      implementConfig,
+      implementBase,
+      logger,
+      {
+        issue_number: issueDetails.number,
+        issue_url: issueDetails.html_url,
+        issue_title: issueDetails.title,
+        issue_body: issueDetails.body ?? undefined,
+        issue_author: issueDetails.user.login,
+      },
+      created,
+    );
+    if (groupId !== null) created = true;
+  }
+
+  // Triage label trigger
+  if (
+    fullConfig.triage?.enabled &&
+    isLabelTriggerEnabled(fullConfig.triage.trigger) &&
+    fullConfig.triage.trigger.label === addedLabel
+  ) {
+    logger.info('Triage label trigger matched', {
+      issueNumber: issue.number,
+      label: addedLabel,
+    });
+
+    await createTaskGroup(
+      store,
+      'triage',
+      fullConfig.triage,
+      baseTask,
+      logger,
+      issueFields,
+      created,
+    );
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
+// ── Status Trigger Handler ──────────────────────────────────────
+
+/**
+ * Handle `projects_v2_item` webhook for status-based triggers.
+ * When a project item's Status field changes to a configured value,
+ * creates the appropriate task group.
+ */
+async function handleProjectsV2Item(
+  github: GitHubService,
+  store: DataStore,
+  payload: ProjectsV2ItemPayload,
+  logger: Logger,
+): Promise<Response> {
+  const { installation, projects_v2_item, changes } = payload;
+
+  if (!installation) {
+    logger.info('Projects V2 item event without installation — skipping');
+    return new Response('OK', { status: 200 });
+  }
+
+  const fieldChange = changes?.field_value;
+  if (!fieldChange || fieldChange.field_name !== 'Status') {
+    logger.info('Projects V2 item event — not a Status field change, skipping');
+    return new Response('OK', { status: 200 });
+  }
+
+  const newStatus = fieldChange.to;
+  if (!newStatus) {
+    logger.info('Projects V2 item event — no new status value, skipping');
+    return new Response('OK', { status: 200 });
+  }
+
+  logger.info('Projects V2 item status changed', {
+    contentNodeId: projects_v2_item.content_node_id,
+    from: fieldChange.from,
+    to: newStatus,
+  });
+
+  let token: string;
+  try {
+    token = await github.getInstallationToken(installation.id);
+  } catch (err) {
+    logger.error('Failed to get installation token for status trigger', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  // Resolve the project item to an issue or PR
+  const content = await github.resolveProjectItemContent(projects_v2_item.content_node_id, token);
+
+  if (!content) {
+    logger.info('Could not resolve project item content — skipping', {
+      contentNodeId: projects_v2_item.content_node_id,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  const { type, owner, repo, number } = content;
+
+  // Load config from the repo
+  const defaultBranch = 'main'; // GraphQL doesn't give us default_branch, use 'main'
+  const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
+    owner,
+    repo,
+    defaultBranch,
+    token,
+  );
+
+  if (parseError) {
+    logger.info('Aborting status trigger due to .opencara.toml parse error', {
+      owner,
+      repo,
+      number,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  // Implement status trigger (primary use case — issues only)
+  if (
+    type === 'Issue' &&
+    fullConfig.implement?.enabled &&
+    isStatusTriggerEnabled(fullConfig.implement.trigger) &&
+    fullConfig.implement.trigger.status === newStatus
+  ) {
+    logger.info('Implement status trigger matched', {
+      owner,
+      repo,
+      issueNumber: number,
+      status: newStatus,
+    });
+
+    let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
+    try {
+      issue = await github.fetchIssueDetails(owner, repo, number, token);
+    } catch (err) {
+      logger.error('Failed to fetch issue details for status trigger', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+    if (!issue) {
+      logger.error('Issue not found for status trigger', { owner, repo, number });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+
+    const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+    const implementConfig = fullConfig.implement;
+    const timeoutMs = parseTimeoutMs(implementConfig.timeout);
+
+    const implementTaskConfig: ReviewConfig = {
+      ...reviewConfig,
+      agentCount: implementConfig.agentCount,
+      timeout: implementConfig.timeout,
+      preferredModels: implementConfig.preferredModels,
+      preferredTools: implementConfig.preferredTools,
+      prompt: implementConfig.prompt,
+      modelDiversityGraceMs: implementConfig.modelDiversityGraceMs,
+    };
+
+    const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+      owner,
+      repo,
+      pr_number: 0,
+      pr_url: '',
+      diff_url: '',
+      base_ref: '',
+      head_ref: '',
+      review_count: implementConfig.agentCount,
+      timeout_at: Date.now() + timeoutMs,
+      status: 'pending',
+      queue: 'summary',
+      github_installation_id: installation.id,
+      private: false,
+      config: implementTaskConfig,
+      created_at: Date.now(),
+    };
+
+    try {
+      await createTaskGroup(store, 'implement', implementConfig, baseTask, logger, {
+        issue_number: issue.number,
+        issue_url: issue.html_url,
+        issue_title: issue.title,
+        issue_body: issue.body ?? undefined,
+        issue_author: issue.user.login,
+      });
+    } catch (err) {
+      logger.error('Failed to create implement task group from status trigger', {
+        error: err instanceof Error ? err.message : String(err),
+        owner,
+        repo,
+        issueNumber: number,
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
   }
 
   return new Response('OK', { status: 200 });


### PR DESCRIPTION
Part of #628

## Summary
- Add label triggers for `issues.labeled` (implement, triage) and `pull_request.labeled` (review, fix)
- Add status triggers via `projects_v2_item` webhook with GraphQL resolution (implement on status change)
- Add `/opencara triage [model]` comment command for issue triage
- Gate all existing comment handlers (go, fix, review) with `isCommentTriggerEnabled()`
- Gate all event handlers with `isEventTriggerEnabled()`
- Gate label/status handlers with `isLabelTriggerEnabled()` / `isStatusTriggerEnabled()`
- Add `resolveProjectItemContent` to GitHubService for GraphQL project item resolution
- Update `docs/github-app-setup.md` with `organization_projects:read` permission and new event subscriptions
- 52 new tests covering all trigger x feature combinations, backward compat, and dedup

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 2513 tests pass (52 new trigger-modes tests)
- [x] `pnpm lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes
- [x] Label trigger creates review task when `trigger.label` set and label matches
- [x] Label trigger creates implement/triage tasks on issues when configured
- [x] Label trigger ignored when `trigger.label` absent
- [x] Status trigger creates implement task when `trigger.status` set and status matches
- [x] Status trigger ignored when `trigger.status` absent or content is PR
- [x] `/opencara triage` creates triage task when `trigger.comment` set
- [x] Triage comment only valid on issues, not PRs
- [x] Comment triggers gated by `isCommentTriggerEnabled()`
- [x] Event triggers gated by `isEventTriggerEnabled()`
- [x] Backward compatible: existing configs without trigger section work with defaults
- [x] Dedup: no duplicate tasks from combined triggers