### PR TITLE
[cli-dev] Fix dedup init to use gh CLI instead of platform OAuth token

### DIFF
--- a/packages/cli/src/__tests__/dedup-init.test.ts
+++ b/packages/cli/src/__tests__/dedup-init.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { StoredAuth } from '../auth.js';
 import type { ToolExecutorResult } from '../tool-executor.js';
 import {
   formatEntry,
@@ -16,7 +15,7 @@ import {
   initIndex,
   runDedupInit,
 } from '../commands/dedup.js';
-import type { GitHubItem } from '../commands/dedup.js';
+import type { GitHubItem, ExecGhFn } from '../commands/dedup.js';
 
 // ── Test Helpers ─────────────────────────────────────────────
 
@@ -34,13 +33,6 @@ function makeItem(overrides: Partial<GitHubItem> = {}): GitHubItem {
 function makePR(overrides: Partial<GitHubItem> = {}): GitHubItem {
   return makeItem({ merged_at: null, ...overrides });
 }
-
-const validAuth: StoredAuth = {
-  access_token: 'ghp_test123',
-  expires_at: Date.now() + 3600_000,
-  github_username: 'testuser',
-  github_user_id: 12345,
-};
 
 // ── formatEntry ──────────────────────────────────────────────
 
@@ -224,39 +216,39 @@ describe('buildCommentBody', () => {
 // ── fetchRepoFile ────────────────────────────────────────────
 
 describe('fetchRepoFile', () => {
-  it('returns file content on success', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('version = 1', { status: 200 })) as unknown as typeof fetch;
+  it('returns file content on success', () => {
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue('version = 1');
 
-    const content = await fetchRepoFile('owner', 'repo', '.opencara.toml', 'token', mockFetch);
+    const content = fetchRepoFile('owner', 'repo', '.opencara.toml', mockExecGh);
     expect(content).toBe('version = 1');
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.github.com/repos/owner/repo/contents/.opencara.toml',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Bearer token',
-        }),
-      }),
-    );
+    expect(mockExecGh).toHaveBeenCalledWith([
+      'api',
+      'repos/owner/repo/contents/.opencara.toml',
+      '-H',
+      'Accept: application/vnd.github.raw+json',
+    ]);
   });
 
-  it('returns null on 404', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('Not Found', { status: 404 })) as unknown as typeof fetch;
+  it('returns null on 404', () => {
+    const error = new Error('gh failed');
+    (error as { stderr?: string }).stderr = 'HTTP 404: Not Found';
+    const mockExecGh: ExecGhFn = vi.fn().mockImplementation(() => {
+      throw error;
+    });
 
-    const content = await fetchRepoFile('owner', 'repo', 'missing', 'token', mockFetch);
+    const content = fetchRepoFile('owner', 'repo', 'missing', mockExecGh);
     expect(content).toBeNull();
   });
 
-  it('throws on other errors', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('Server Error', { status: 500 })) as unknown as typeof fetch;
+  it('throws on other errors', () => {
+    const error = new Error('gh failed');
+    (error as { stderr?: string }).stderr = 'HTTP 500: Internal Server Error';
+    const mockExecGh: ExecGhFn = vi.fn().mockImplementation(() => {
+      throw error;
+    });
 
-    await expect(fetchRepoFile('owner', 'repo', 'file', 'token', mockFetch)).rejects.toThrow(
-      'GitHub API error: 500',
+    expect(() => fetchRepoFile('owner', 'repo', 'file', mockExecGh)).toThrow(
+      'gh API error fetching file',
     );
   });
 });
@@ -264,69 +256,212 @@ describe('fetchRepoFile', () => {
 // ── fetchAllPRs ──────────────────────────────────────────────
 
 describe('fetchAllPRs', () => {
-  it('fetches single page of PRs', async () => {
-    const prs = [makePR({ number: 1, title: 'PR 1' })];
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(prs), { status: 200 }),
-      ) as unknown as typeof fetch;
+  it('fetches PRs via gh pr list', () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 1,
+        title: 'PR 1',
+        state: 'OPEN',
+        labels: [{ name: 'bug' }],
+        closedAt: '',
+        mergedAt: '',
+      },
+    ]);
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(ghOutput);
 
-    const result = await fetchAllPRs('owner', 'repo', 'token', mockFetch);
+    const result = fetchAllPRs('owner', 'repo', mockExecGh);
     expect(result).toHaveLength(1);
     expect(result[0].number).toBe(1);
+    expect(result[0].state).toBe('open');
+    expect(result[0].labels).toEqual([{ name: 'bug' }]);
+    expect(mockExecGh).toHaveBeenCalledWith([
+      'pr',
+      'list',
+      '--repo',
+      'owner/repo',
+      '--state',
+      'all',
+      '--limit',
+      '9999',
+      '--json',
+      'number,title,state,labels,closedAt,mergedAt',
+    ]);
   });
 
-  it('paginates multiple pages', async () => {
-    const page1 = Array.from({ length: 100 }, (_, i) => makePR({ number: i + 1 }));
-    const page2 = [makePR({ number: 101 })];
+  it('maps MERGED state to closed', () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 2,
+        title: 'Merged PR',
+        state: 'MERGED',
+        labels: [],
+        closedAt: '2026-03-20T00:00:00Z',
+        mergedAt: '2026-03-20T00:00:00Z',
+      },
+    ]);
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(ghOutput);
 
-    let callCount = 0;
-    const mockFetch = vi.fn(async () => {
-      callCount++;
-      const data = callCount === 1 ? page1 : page2;
-      return new Response(JSON.stringify(data), { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const result = await fetchAllPRs('owner', 'repo', 'token', mockFetch);
-    expect(result).toHaveLength(101);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const result = fetchAllPRs('owner', 'repo', mockExecGh);
+    expect(result[0].state).toBe('closed');
+    expect(result[0].merged_at).toBe('2026-03-20T00:00:00Z');
   });
 
-  it('throws on API error', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('Error', { status: 403 })) as unknown as typeof fetch;
+  it('maps CLOSED state to closed', () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 3,
+        title: 'Closed PR',
+        state: 'CLOSED',
+        labels: [],
+        closedAt: '2026-03-20T00:00:00Z',
+        mergedAt: '',
+      },
+    ]);
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(ghOutput);
 
-    await expect(fetchAllPRs('owner', 'repo', 'token', mockFetch)).rejects.toThrow(
-      'GitHub API error: 403',
-    );
+    const result = fetchAllPRs('owner', 'repo', mockExecGh);
+    expect(result[0].state).toBe('closed');
+    expect(result[0].merged_at).toBeNull();
+  });
+
+  it('throws on gh CLI error', () => {
+    const mockExecGh: ExecGhFn = vi.fn().mockImplementation(() => {
+      throw new Error('gh not found');
+    });
+
+    expect(() => fetchAllPRs('owner', 'repo', mockExecGh)).toThrow('gh not found');
   });
 });
 
 // ── fetchAllIssues ───────────────────────────────────────────
 
 describe('fetchAllIssues', () => {
-  it('filters out PRs from issues endpoint', async () => {
-    const items = [
-      makeItem({ number: 1, title: 'Issue 1' }),
-      makeItem({ number: 2, title: 'PR 1', pull_request: { url: '...' } }),
-    ];
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify(items), { status: 200 }),
-      ) as unknown as typeof fetch;
+  it('fetches issues via gh issue list', () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 1,
+        title: 'Issue 1',
+        state: 'OPEN',
+        labels: [],
+        closedAt: '',
+      },
+    ]);
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(ghOutput);
 
-    const result = await fetchAllIssues('owner', 'repo', 'token', mockFetch);
+    const result = fetchAllIssues('owner', 'repo', mockExecGh);
     expect(result).toHaveLength(1);
     expect(result[0].number).toBe(1);
+    expect(result[0].state).toBe('open');
+    expect(mockExecGh).toHaveBeenCalledWith([
+      'issue',
+      'list',
+      '--repo',
+      'owner/repo',
+      '--state',
+      'all',
+      '--limit',
+      '9999',
+      '--json',
+      'number,title,state,labels,closedAt',
+    ]);
+  });
+
+  it('maps CLOSED state to closed with closedAt', () => {
+    const ghOutput = JSON.stringify([
+      {
+        number: 2,
+        title: 'Closed Issue',
+        state: 'CLOSED',
+        labels: [{ name: 'bug' }],
+        closedAt: '2026-03-20T00:00:00Z',
+      },
+    ]);
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(ghOutput);
+
+    const result = fetchAllIssues('owner', 'repo', mockExecGh);
+    expect(result[0].state).toBe('closed');
+    expect(result[0].closed_at).toBe('2026-03-20T00:00:00Z');
+    expect(result[0].labels).toEqual([{ name: 'bug' }]);
   });
 });
 
 // ── initIndex ────────────────────────────────────────────────
 
 describe('initIndex', () => {
+  /** Build a mock execGh that returns canned data based on args. */
+  function buildMockExecGh(opts: {
+    prs?: GitHubItem[];
+    issues?: GitHubItem[];
+    existingComments?: Array<{ id: number; body: string }>;
+    createdComments?: string[];
+    updatedBodies?: Array<{ id: number; body: string }>;
+    failOnWrite?: boolean;
+  }): ExecGhFn {
+    const createdComments = opts.createdComments ?? [];
+    const updatedBodies = opts.updatedBodies ?? [];
+    let commentIdCounter = 200;
+
+    return vi.fn((args: string[]): string => {
+      const argsStr = args.join(' ');
+
+      // gh pr list
+      if (args[0] === 'pr' && args[1] === 'list') {
+        const items = (opts.prs ?? []).map((pr) => ({
+          number: pr.number,
+          title: pr.title,
+          state: pr.state === 'closed' ? (pr.merged_at ? 'MERGED' : 'CLOSED') : 'OPEN',
+          labels: pr.labels,
+          closedAt: pr.closed_at ?? '',
+          mergedAt: pr.merged_at ?? '',
+        }));
+        return JSON.stringify(items);
+      }
+
+      // gh issue list
+      if (args[0] === 'issue' && args[1] === 'list') {
+        const items = (opts.issues ?? []).map((issue) => ({
+          number: issue.number,
+          title: issue.title,
+          state: issue.state === 'closed' ? 'CLOSED' : 'OPEN',
+          labels: issue.labels,
+          closedAt: issue.closed_at ?? '',
+        }));
+        return JSON.stringify(items);
+      }
+
+      // gh api --paginate .../comments (fetch comments)
+      if (args.includes('--paginate') && argsStr.includes('/comments')) {
+        return JSON.stringify(opts.existingComments ?? []);
+      }
+
+      // gh api -X POST .../comments (create comment)
+      if (args.includes('-X') && args.includes('POST') && argsStr.includes('/comments')) {
+        if (opts.failOnWrite) throw new Error('Should not write');
+        // -f body=... format: find the arg after `-f` that starts with `body=`
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        createdComments.push(body);
+        commentIdCounter++;
+        return String(commentIdCounter);
+      }
+
+      // gh api -X PATCH .../comments/{id} (update comment)
+      if (args.includes('-X') && args.includes('PATCH') && argsStr.includes('/comments/')) {
+        if (opts.failOnWrite) throw new Error('Should not write');
+        const pathArg = args[1];
+        const idMatch = pathArg.match(/comments\/(\d+)/);
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        updatedBodies.push({ id: parseInt(idMatch![1], 10), body });
+        return '{}';
+      }
+
+      throw new Error(`Unexpected gh call: ${argsStr}`);
+    });
+  }
+
   const baseOpts = {
     owner: 'acme',
     repo: 'widgets',
@@ -334,7 +469,6 @@ describe('initIndex', () => {
     kind: 'prs' as const,
     recentDays: 30,
     dryRun: false,
-    token: 'ghp_test',
     log: vi.fn(),
   };
 
@@ -355,31 +489,10 @@ describe('initIndex', () => {
       }),
     ];
 
-    let callCount = 0;
     const createdComments: string[] = [];
+    const mockExecGh = buildMockExecGh({ prs, createdComments });
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (
-        url.includes(`/issues/${baseOpts.indexIssue}/comments`) &&
-        (!init || init.method !== 'POST')
-      ) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (url.includes(`/issues/${baseOpts.indexIssue}/comments`) && init?.method === 'POST') {
-        callCount++;
-        const body = JSON.parse(init.body as string) as { body: string };
-        createdComments.push(body.body);
-        return new Response(JSON.stringify({ id: callCount }), { status: 201 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
-
-    const result = await initIndex({ ...baseOpts, fetchFn: mockFetch });
+    const result = await initIndex({ ...baseOpts, execGh: mockExecGh });
     expect(result.openCount).toBe(1);
     expect(result.recentCount).toBe(1);
     expect(result.archivedCount).toBe(1);
@@ -409,29 +522,9 @@ describe('initIndex', () => {
     ];
 
     const updatedBodies: Array<{ id: number; body: string }> = [];
+    const mockExecGh = buildMockExecGh({ prs, existingComments, updatedBodies });
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (
-        url.includes(`/issues/${baseOpts.indexIssue}/comments`) &&
-        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
-      ) {
-        return new Response(JSON.stringify(existingComments), { status: 200 });
-      }
-      if (url.includes('/issues/comments/') && init?.method === 'PATCH') {
-        const idMatch = url.match(/comments\/(\d+)/);
-        const body = JSON.parse(init.body as string) as { body: string };
-        updatedBodies.push({ id: parseInt(idMatch![1], 10), body: body.body });
-        return new Response('{}', { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
-
-    const result = await initIndex({ ...baseOpts, fetchFn: mockFetch });
+    const result = await initIndex({ ...baseOpts, execGh: mockExecGh });
     expect(result.openCount).toBe(2);
     expect(result.newEntries).toBe(1); // Only #4 is new
 
@@ -447,48 +540,22 @@ describe('initIndex', () => {
   it('dry run does not call GitHub write APIs', async () => {
     const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const mockExecGh = buildMockExecGh({ prs, failOnWrite: true });
 
-      if (init?.method === 'POST' || init?.method === 'PATCH') {
-        throw new Error('Should not write in dry run mode');
-      }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
-
-    const result = await initIndex({ ...baseOpts, dryRun: true, fetchFn: mockFetch });
+    const result = await initIndex({ ...baseOpts, dryRun: true, execGh: mockExecGh });
     expect(result.openCount).toBe(1);
     expect(result.newEntries).toBe(1);
   });
 
   it('works for issues kind', async () => {
     const issues = [makeItem({ number: 10, title: 'Bug report', state: 'open' })];
-
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/issues?state=all')) {
-        return new Response(JSON.stringify(issues), { status: 200 });
-      }
-      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+    const createdComments: string[] = [];
+    const mockExecGh = buildMockExecGh({ issues, createdComments });
 
     const result = await initIndex({
       ...baseOpts,
       kind: 'issues',
-      fetchFn: mockFetch,
+      execGh: mockExecGh,
     });
     expect(result.openCount).toBe(1);
   });
@@ -512,82 +579,35 @@ describe('runDedupInit', () => {
     process.exitCode = originalExitCode;
   });
 
-  it('exits when ensureAuth throws AuthError (login cancelled)', async () => {
-    const { AuthError } = await import('../auth.js');
-    const ensureAuthFn = vi.fn().mockRejectedValue(new AuthError('Authorization denied by user'));
-    await runDedupInit({ repo: 'owner/repo' }, { log, logError, ensureAuthFn });
-    expect(logError).toHaveBeenCalledWith(expect.stringContaining('Authorization denied by user'));
-    expect(process.exitCode).toBe(1);
-  });
-
-  it('auto-triggers login when ensureAuth resolves after login flow', async () => {
-    const ensureAuthFn = vi.fn().mockResolvedValue(validAuth.access_token);
-    // Without a fetchFn that returns a valid toml, should fail at toml fetch — not at auth
-    await runDedupInit(
-      { repo: 'owner/repo' },
-      {
-        log,
-        logError,
-        ensureAuthFn,
-        fetchFn: vi
-          .fn()
-          .mockResolvedValue(new Response('', { status: 404 })) as unknown as typeof fetch,
-      },
-    );
-    expect(ensureAuthFn).toHaveBeenCalledOnce();
-    expect(logError).toHaveBeenCalledWith(expect.stringContaining('No .opencara.toml'));
-    expect(process.exitCode).toBe(1);
-  });
-
   it('requires --repo flag', async () => {
-    const ensureAuthFn = vi.fn().mockResolvedValue(validAuth.access_token);
-    await runDedupInit({}, { log, logError, ensureAuthFn });
+    await runDedupInit({}, { log, logError });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('--repo is required'));
     expect(process.exitCode).toBe(1);
   });
 
   it('validates repo format', async () => {
-    await runDedupInit(
-      { repo: 'invalid' },
-      { log, logError, ensureAuthFn: () => Promise.resolve(validAuth.access_token) },
-    );
+    await runDedupInit({ repo: 'invalid' }, { log, logError });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('Invalid repo format'));
     expect(process.exitCode).toBe(1);
   });
 
   it('errors when .opencara.toml not found', async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('Not Found', { status: 404 })) as unknown as typeof fetch;
+    const error = new Error('gh failed');
+    (error as { stderr?: string }).stderr = 'HTTP 404: Not Found';
+    const mockExecGh: ExecGhFn = vi.fn().mockImplementation(() => {
+      throw error;
+    });
 
-    await runDedupInit(
-      { repo: 'owner/repo' },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-      },
-    );
+    await runDedupInit({ repo: 'owner/repo' }, { log, logError, execGh: mockExecGh });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('No .opencara.toml'));
     expect(process.exitCode).toBe(1);
   });
 
   it('errors when no dedup config in .opencara.toml', async () => {
     const toml = 'version = 1\n\n[review]\nprompt = "Review this"';
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response(toml, { status: 200 })) as unknown as typeof fetch;
+    const mockExecGh: ExecGhFn = vi.fn().mockReturnValue(toml);
 
-    await runDedupInit(
-      { repo: 'owner/repo' },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-      },
-    );
+    await runDedupInit({ repo: 'owner/repo' }, { log, logError, execGh: mockExecGh });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('No dedup index issues'));
     expect(process.exitCode).toBe(1);
   });
@@ -597,32 +617,20 @@ describe('runDedupInit', () => {
 [dedup.issues]
 index_issue = 10
 `;
-    const mockFetch = vi.fn(async (input: string | URL | Request) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      if (args[0] === 'api' && args[1].includes('contents/')) {
+        return toml;
       }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+      throw new Error(`Unexpected: ${args.join(' ')}`);
+    });
 
-    await runDedupInit(
-      { repo: 'owner/repo' },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-      },
-    );
+    await runDedupInit({ repo: 'owner/repo' }, { log, logError, execGh: mockExecGh });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('No PR dedup index configured'));
     expect(process.exitCode).toBe(1);
   });
 
   it('validates --days flag', async () => {
-    await runDedupInit(
-      { repo: 'owner/repo', days: 'abc' },
-      { log, logError, ensureAuthFn: () => Promise.resolve(validAuth.access_token) },
-    );
+    await runDedupInit({ repo: 'owner/repo', days: 'abc' }, { log, logError });
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('--days must be a positive'));
     expect(process.exitCode).toBe(1);
   });
@@ -632,38 +640,41 @@ index_issue = 10
 [dedup.prs]
 index_issue = 53
 `;
-    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
-
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
-      }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (
-        url.includes('/comments') &&
-        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
-      ) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('{}', { status: 200 });
-    }) as unknown as typeof fetch;
-
-    await runDedupInit(
-      { repo: 'acme/widgets' },
+    const prs = [
       {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
+        number: 1,
+        title: 'PR 1',
+        state: 'OPEN',
+        labels: [],
+        closedAt: '',
+        mergedAt: '',
       },
-    );
+    ];
+
+    let commentIdCounter = 200;
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      // fetchRepoFile
+      if (args[0] === 'api' && args[1].includes('contents/')) {
+        return toml;
+      }
+      // fetchAllPRs
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return JSON.stringify(prs);
+      }
+      // fetchIssueComments
+      if (args.includes('--paginate') && argsStr.includes('/comments')) {
+        return JSON.stringify([]);
+      }
+      // createIssueComment
+      if (args.includes('-X') && args.includes('POST')) {
+        commentIdCounter++;
+        return String(commentIdCounter);
+      }
+      return '{}';
+    });
+
+    await runDedupInit({ repo: 'acme/widgets' }, { log, logError, execGh: mockExecGh });
     expect(process.exitCode).toBeUndefined();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Initializing prs'));
   });
@@ -676,44 +687,27 @@ index_issue = 53
 [dedup.issues]
 index_issue = 54
 `;
-    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
-    const issues = [makeItem({ number: 10, title: 'Issue 1', state: 'open' })];
+    const prs = [
+      { number: 1, title: 'PR 1', state: 'OPEN', labels: [], closedAt: '', mergedAt: '' },
+    ];
+    const issues = [{ number: 10, title: 'Issue 1', state: 'OPEN', labels: [], closedAt: '' }];
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    let commentIdCounter = 200;
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      if (args[0] === 'pr' && args[1] === 'list') return JSON.stringify(prs);
+      if (args[0] === 'issue' && args[1] === 'list') return JSON.stringify(issues);
+      if (args.includes('--paginate') && argsStr.includes('/comments')) return JSON.stringify([]);
+      if (args.includes('-X') && args.includes('POST')) {
+        commentIdCounter++;
+        return String(commentIdCounter);
+      }
+      return '{}';
+    });
 
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
-      }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/issues?state=all')) {
-        return new Response(JSON.stringify(issues), { status: 200 });
-      }
-      if (
-        url.includes('/comments') &&
-        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
-      ) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('{}', { status: 200 });
-    }) as unknown as typeof fetch;
-
-    await runDedupInit(
-      { repo: 'acme/widgets', all: true },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-      },
-    );
+    await runDedupInit({ repo: 'acme/widgets', all: true }, { log, logError, execGh: mockExecGh });
     expect(process.exitCode).toBeUndefined();
-    // Should have logs for both prs and issues
     const logCalls = log.mock.calls.map((c: string[]) => c[0]);
     expect(logCalls.some((c: string) => c.includes('prs'))).toBe(true);
     expect(logCalls.some((c: string) => c.includes('issues'))).toBe(true);
@@ -724,34 +718,24 @@ index_issue = 54
 [dedup.prs]
 index_issue = 53
 `;
-    const prs = [makePR({ number: 1, title: 'PR 1', state: 'open' })];
+    const prs = [
+      { number: 1, title: 'PR 1', state: 'OPEN', labels: [], closedAt: '', mergedAt: '' },
+    ];
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (init?.method === 'POST' || init?.method === 'PATCH') {
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      if (args.includes('-X') && (args.includes('POST') || args.includes('PATCH'))) {
         throw new Error('Should not write in dry run');
       }
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
-      }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      if (args[0] === 'pr' && args[1] === 'list') return JSON.stringify(prs);
+      if (args.includes('--paginate') && argsStr.includes('/comments')) return JSON.stringify([]);
+      throw new Error(`Unexpected: ${argsStr}`);
+    });
 
     await runDedupInit(
       { repo: 'acme/widgets', dryRun: true },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-      },
+      { log, logError, execGh: mockExecGh },
     );
     expect(process.exitCode).toBeUndefined();
     const logCalls = log.mock.calls.map((c: string[]) => c[0]);
@@ -763,23 +747,14 @@ index_issue = 53
 [dedup.prs]
 index_issue = 53
 `;
-    const mockFetch = vi.fn(async (input: string | URL | Request) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      throw new Error(`Unexpected: ${args.join(' ')}`);
+    });
 
     await runDedupInit(
       { repo: 'acme/widgets', agent: 'nonexistent-tool' },
-      {
-        log,
-        logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
-        resolveAgentCommandFn: () => null,
-      },
+      { log, logError, execGh: mockExecGh, resolveAgentCommandFn: () => null },
     );
     expect(logError).toHaveBeenCalledWith(expect.stringContaining('Unknown agent tool'));
     expect(process.exitCode).toBe(1);
@@ -790,28 +765,27 @@ index_issue = 53
 [dedup.prs]
 index_issue = 53
 `;
-    const prs = [makePR({ number: 1, title: 'Fix login bug', state: 'open' })];
+    const prs = [
+      { number: 1, title: 'Fix login bug', state: 'OPEN', labels: [], closedAt: '', mergedAt: '' },
+    ];
     const createdComments: string[] = [];
+    let commentIdCounter = 200;
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      if (args[0] === 'pr' && args[1] === 'list') return JSON.stringify(prs);
+      if (args.includes('--paginate') && argsStr.includes('/comments')) return JSON.stringify([]);
+      if (args.includes('-X') && args.includes('POST')) {
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        createdComments.push(body);
+        commentIdCounter++;
+        return String(commentIdCounter);
       }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        const body = JSON.parse(init.body as string) as { body: string };
-        createdComments.push(body.body);
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('{}', { status: 200 });
-    }) as unknown as typeof fetch;
+      return '{}';
+    });
 
     const mockRunTool = vi.fn(async () => ({
       stdout: '{"description": "Authentication flow fix for login page"}',
@@ -826,8 +800,7 @@ index_issue = 53
       {
         log,
         logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
+        execGh: mockExecGh,
         resolveAgentCommandFn: () => 'claude --print',
         runTool: mockRunTool,
       },
@@ -844,28 +817,27 @@ index_issue = 53
 [dedup.prs]
 index_issue = 53
 `;
-    const prs = [makePR({ number: 1, title: 'Fix login bug', state: 'open' })];
+    const prs = [
+      { number: 1, title: 'Fix login bug', state: 'OPEN', labels: [], closedAt: '', mergedAt: '' },
+    ];
     const createdComments: string[] = [];
+    let commentIdCounter = 200;
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      if (args[0] === 'pr' && args[1] === 'list') return JSON.stringify(prs);
+      if (args.includes('--paginate') && argsStr.includes('/comments')) return JSON.stringify([]);
+      if (args.includes('-X') && args.includes('POST')) {
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        createdComments.push(body);
+        commentIdCounter++;
+        return String(commentIdCounter);
       }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        const body = JSON.parse(init.body as string) as { body: string };
-        createdComments.push(body.body);
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('{}', { status: 200 });
-    }) as unknown as typeof fetch;
+      return '{}';
+    });
 
     // AI tool throws an error
     const mockRunTool = vi.fn(async () => {
@@ -877,8 +849,7 @@ index_issue = 53
       {
         log,
         logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
+        execGh: mockExecGh,
         resolveAgentCommandFn: () => 'claude --print',
         runTool: mockRunTool,
       },
@@ -896,25 +867,20 @@ index_issue = 53
 [dedup.prs]
 index_issue = 53
 `;
-    const prs = [makePR({ number: 1, title: 'Fix login bug', state: 'open' })];
+    const prs = [
+      { number: 1, title: 'Fix login bug', state: 'OPEN', labels: [], closedAt: '', mergedAt: '' },
+    ];
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (init?.method === 'POST' || init?.method === 'PATCH') {
+    const mockExecGh: ExecGhFn = vi.fn((args: string[]) => {
+      const argsStr = args.join(' ');
+      if (args.includes('-X') && (args.includes('POST') || args.includes('PATCH'))) {
         throw new Error('Should not write in dry run');
       }
-      if (url.includes('contents/')) {
-        return new Response(toml, { status: 200 });
-      }
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+      if (args[0] === 'api' && args[1].includes('contents/')) return toml;
+      if (args[0] === 'pr' && args[1] === 'list') return JSON.stringify(prs);
+      if (args.includes('--paginate') && argsStr.includes('/comments')) return JSON.stringify([]);
+      throw new Error(`Unexpected: ${argsStr}`);
+    });
 
     const mockRunTool = vi.fn(async () => ({
       stdout: '{"description": "AI enriched description"}',
@@ -929,8 +895,7 @@ index_issue = 53
       {
         log,
         logError,
-        ensureAuthFn: () => Promise.resolve(validAuth.access_token),
-        fetchFn: mockFetch,
+        execGh: mockExecGh,
         resolveAgentCommandFn: () => 'claude --print',
         runTool: mockRunTool,
       },
@@ -1091,6 +1056,53 @@ describe('buildCommentBody with AI descriptions', () => {
 // ── initIndex with agent ─────────────────────────────────────
 
 describe('initIndex with agent', () => {
+  function buildMockExecGh(opts: {
+    prs?: Array<{
+      number: number;
+      title: string;
+      state: string;
+      labels: Array<{ name: string }>;
+      closedAt: string;
+      mergedAt: string;
+    }>;
+    existingComments?: Array<{ id: number; body: string }>;
+    createdComments?: string[];
+    updatedBodies?: Array<{ id: number; body: string }>;
+  }): ExecGhFn {
+    const createdComments = opts.createdComments ?? [];
+    const updatedBodies = opts.updatedBodies ?? [];
+    let commentIdCounter = 200;
+
+    return vi.fn((args: string[]): string => {
+      const argsStr = args.join(' ');
+
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return JSON.stringify(opts.prs ?? []);
+      }
+      if (args.includes('--paginate') && argsStr.includes('/comments')) {
+        return JSON.stringify(opts.existingComments ?? []);
+      }
+      if (args.includes('-X') && args.includes('POST') && argsStr.includes('/comments')) {
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        createdComments.push(body);
+        commentIdCounter++;
+        return String(commentIdCounter);
+      }
+      if (args.includes('-X') && args.includes('PATCH') && argsStr.includes('/comments/')) {
+        const pathArg = args[1];
+        const idMatch = pathArg.match(/comments\/(\d+)/);
+        const fIdx = args.indexOf('-f');
+        const bodyArg = fIdx >= 0 ? args[fIdx + 1] : '';
+        const body = bodyArg.startsWith('body=') ? bodyArg.slice(5) : bodyArg;
+        updatedBodies.push({ id: parseInt(idMatch![1], 10), body });
+        return '{}';
+      }
+      throw new Error(`Unexpected gh call: ${argsStr}`);
+    });
+  }
+
   const baseOpts = {
     owner: 'acme',
     repo: 'widgets',
@@ -1098,30 +1110,22 @@ describe('initIndex with agent', () => {
     kind: 'prs' as const,
     recentDays: 30,
     dryRun: false,
-    token: 'ghp_test',
     log: vi.fn(),
   };
 
   it('uses AI-enriched descriptions when agentCommandTemplate is set', async () => {
-    const prs = [makePR({ number: 1, title: 'Open PR', state: 'open' })];
+    const prs = [
+      {
+        number: 1,
+        title: 'Open PR',
+        state: 'OPEN',
+        labels: [] as Array<{ name: string }>,
+        closedAt: '',
+        mergedAt: '',
+      },
+    ];
     const createdComments: string[] = [];
-
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        const body = JSON.parse(init.body as string) as { body: string };
-        createdComments.push(body.body);
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+    const mockExecGh = buildMockExecGh({ prs, createdComments });
 
     const mockRunTool = vi.fn(
       async (): Promise<ToolExecutorResult> => ({
@@ -1135,7 +1139,7 @@ describe('initIndex with agent', () => {
 
     const result = await initIndex({
       ...baseOpts,
-      fetchFn: mockFetch,
+      execGh: mockExecGh,
       agentCommandTemplate: 'claude --print',
       runTool: mockRunTool,
     });
@@ -1148,27 +1152,25 @@ describe('initIndex with agent', () => {
 
   it('falls back to raw title when AI fails for an item', async () => {
     const prs = [
-      makePR({ number: 1, title: 'PR One', state: 'open' }),
-      makePR({ number: 2, title: 'PR Two', state: 'open' }),
+      {
+        number: 1,
+        title: 'PR One',
+        state: 'OPEN',
+        labels: [] as Array<{ name: string }>,
+        closedAt: '',
+        mergedAt: '',
+      },
+      {
+        number: 2,
+        title: 'PR Two',
+        state: 'OPEN',
+        labels: [] as Array<{ name: string }>,
+        closedAt: '',
+        mergedAt: '',
+      },
     ];
     const createdComments: string[] = [];
-
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (url.includes('/comments') && (!init || init.method !== 'POST')) {
-        return new Response(JSON.stringify([]), { status: 200 });
-      }
-      if (init?.method === 'POST') {
-        const body = JSON.parse(init.body as string) as { body: string };
-        createdComments.push(body.body);
-        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+    const mockExecGh = buildMockExecGh({ prs, createdComments });
 
     let callCount = 0;
     const mockRunTool = vi.fn(async (): Promise<ToolExecutorResult> => {
@@ -1188,7 +1190,7 @@ describe('initIndex with agent', () => {
 
     const result = await initIndex({
       ...baseOpts,
-      fetchFn: mockFetch,
+      execGh: mockExecGh,
       agentCommandTemplate: 'claude --print',
       runTool: mockRunTool,
     });
@@ -1200,7 +1202,16 @@ describe('initIndex with agent', () => {
   });
 
   it('skips AI enrichment when no new entries exist', async () => {
-    const prs = [makePR({ number: 1, title: 'Existing PR', state: 'open' })];
+    const prs = [
+      {
+        number: 1,
+        title: 'Existing PR',
+        state: 'OPEN',
+        labels: [] as Array<{ name: string }>,
+        closedAt: '',
+        mergedAt: '',
+      },
+    ];
 
     const existingComments = [
       {
@@ -1211,23 +1222,7 @@ describe('initIndex with agent', () => {
       { id: 102, body: '<!-- opencara-dedup-index:archived -->\n## Archived Items\n' },
     ];
 
-    const mockFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
-
-      if (url.includes('/pulls?')) {
-        return new Response(JSON.stringify(prs), { status: 200 });
-      }
-      if (
-        url.includes('/comments') &&
-        (!init || (init.method !== 'POST' && init.method !== 'PATCH'))
-      ) {
-        return new Response(JSON.stringify(existingComments), { status: 200 });
-      }
-      if (url.includes('/issues/comments/') && init?.method === 'PATCH') {
-        return new Response('{}', { status: 200 });
-      }
-      return new Response('Not Found', { status: 404 });
-    }) as unknown as typeof fetch;
+    const mockExecGh = buildMockExecGh({ prs, existingComments });
 
     const mockRunTool = vi.fn(
       async (): Promise<ToolExecutorResult> => ({
@@ -1241,7 +1236,7 @@ describe('initIndex with agent', () => {
 
     const result = await initIndex({
       ...baseOpts,
-      fetchFn: mockFetch,
+      execGh: mockExecGh,
       agentCommandTemplate: 'claude --print',
       runTool: mockRunTool,
     });

--- a/packages/cli/src/commands/dedup.ts
+++ b/packages/cli/src/commands/dedup.ts
@@ -1,8 +1,8 @@
+import { execFileSync } from 'node:child_process';
 import { Command } from 'commander';
 import pc from 'picocolors';
 import { parseOpenCaraConfig, DEFAULT_REGISTRY } from '@opencara/shared';
 import type { OpenCaraConfig } from '@opencara/shared';
-import { ensureAuth, AuthError } from '../auth.js';
 import { loadConfig } from '../config.js';
 import { executeTool, type ToolExecutorResult } from '../tool-executor.js';
 import { extractJson } from '../dedup.js';
@@ -14,9 +14,6 @@ export { buildIndexEntryPrompt };
 
 /** Default window for "recently closed" items (in days). */
 const DEFAULT_RECENT_DAYS = 30;
-
-/** Per-page limit for GitHub API pagination. */
-const PER_PAGE = 100;
 
 /** Comment markers — must match server's dedup-index.ts. */
 const OPEN_MARKER = '<!-- opencara-dedup-index:open -->';
@@ -50,13 +47,24 @@ export interface CategorizedItems {
   archived: GitHubItem[];
 }
 
+/** Type for the injected gh CLI executor — allows mocking in tests. */
+export type ExecGhFn = (args: string[]) => string;
+
+/** Default gh CLI executor using execFileSync. */
+export function defaultExecGh(args: string[]): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    maxBuffer: 50 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 /** Dependencies for dedup init — allows injection for testing. */
 export interface DedupInitDeps {
-  fetchFn?: typeof fetch;
+  execGh?: ExecGhFn;
   log?: (msg: string) => void;
   logError?: (msg: string) => void;
-  /** Override ensureAuth for testing — returns an access token string. */
-  ensureAuthFn?: () => Promise<string>;
   resolveAgentCommandFn?: (toolName: string) => string | null;
   runTool?: (
     commandTemplate: string,
@@ -65,175 +73,172 @@ export interface DedupInitDeps {
   ) => Promise<ToolExecutorResult>;
 }
 
-// ── GitHub API Helpers ───────────────────────────────────────
+// ── GitHub API Helpers (via gh CLI) ─────────────────────────
 
 /**
- * Fetch a file from a GitHub repo via the Contents API.
+ * Fetch a file from a GitHub repo via `gh api`.
  * Returns the decoded text content, or null if not found.
  */
-export async function fetchRepoFile(
+export function fetchRepoFile(
   owner: string,
   repo: string,
   path: string,
-  token: string,
-  fetchFn: typeof fetch = fetch,
-): Promise<string | null> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
-  const res = await fetchFn(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github.raw+json',
-    },
-  });
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching ${path}`);
-  return res.text();
+  execGh: ExecGhFn = defaultExecGh,
+): string | null {
+  try {
+    return execGh([
+      'api',
+      `repos/${owner}/${repo}/contents/${path}`,
+      '-H',
+      'Accept: application/vnd.github.raw+json',
+    ]);
+  } catch (err) {
+    const message = String((err as { stderr?: string }).stderr ?? err);
+    if (message.includes('404') || message.includes('Not Found')) return null;
+    throw new Error(`gh API error fetching ${path}: ${message}`);
+  }
 }
 
 /**
- * Fetch all PRs from a repo using pagination.
- * Returns items sorted by number.
+ * Fetch all PRs from a repo using `gh pr list --json`.
+ * Returns items as GitHubItem[].
  */
-export async function fetchAllPRs(
+export function fetchAllPRs(
   owner: string,
   repo: string,
-  token: string,
-  fetchFn: typeof fetch = fetch,
+  execGh: ExecGhFn = defaultExecGh,
   log?: (msg: string) => void,
-): Promise<GitHubItem[]> {
-  const items: GitHubItem[] = [];
-  let page = 1;
-
-  while (true) {
-    const url = `https://api.github.com/repos/${owner}/${repo}/pulls?state=all&per_page=${PER_PAGE}&page=${page}&sort=created&direction=desc`;
-    const res = await fetchFn(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-      },
-    });
-    if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching PRs page ${page}`);
-
-    const batch = (await res.json()) as GitHubItem[];
-    items.push(...batch);
-
-    if (log) log(`  Fetched ${items.length} PRs...`);
-
-    if (batch.length < PER_PAGE) break;
-    page++;
-  }
-
+): GitHubItem[] {
+  const output = execGh([
+    'pr',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--state',
+    'all',
+    '--limit',
+    '9999',
+    '--json',
+    'number,title,state,labels,closedAt,mergedAt',
+  ]);
+  const raw = JSON.parse(output) as Array<{
+    number: number;
+    title: string;
+    state: string;
+    labels: Array<{ name: string }>;
+    closedAt: string;
+    mergedAt: string;
+  }>;
+  const items: GitHubItem[] = raw.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    state: pr.state === 'MERGED' ? 'closed' : pr.state.toLowerCase(),
+    labels: pr.labels,
+    closed_at: pr.closedAt || null,
+    merged_at: pr.mergedAt || null,
+  }));
+  if (log) log(`  Fetched ${items.length} PRs...`);
   return items;
 }
 
 /**
- * Fetch all issues from a repo using pagination (excludes PRs).
- * The GitHub Issues API returns both issues and PRs — items with
- * `pull_request` field are filtered out.
+ * Fetch all issues from a repo using `gh issue list --json`.
+ * Returns only issues (not PRs) as GitHubItem[].
  */
-export async function fetchAllIssues(
+export function fetchAllIssues(
   owner: string,
   repo: string,
-  token: string,
-  fetchFn: typeof fetch = fetch,
+  execGh: ExecGhFn = defaultExecGh,
   log?: (msg: string) => void,
-): Promise<GitHubItem[]> {
-  const items: GitHubItem[] = [];
-  let page = 1;
-
-  while (true) {
-    const url = `https://api.github.com/repos/${owner}/${repo}/issues?state=all&per_page=${PER_PAGE}&page=${page}&sort=created&direction=desc`;
-    const res = await fetchFn(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-      },
-    });
-    if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching issues page ${page}`);
-
-    const batch = (await res.json()) as GitHubItem[];
-    // Filter out PRs (they appear in issues endpoint with pull_request field)
-    const issuesOnly = batch.filter((item) => !item.pull_request);
-    items.push(...issuesOnly);
-
-    if (log) log(`  Fetched ${items.length} issues...`);
-
-    if (batch.length < PER_PAGE) break;
-    page++;
-  }
-
+): GitHubItem[] {
+  const output = execGh([
+    'issue',
+    'list',
+    '--repo',
+    `${owner}/${repo}`,
+    '--state',
+    'all',
+    '--limit',
+    '9999',
+    '--json',
+    'number,title,state,labels,closedAt',
+  ]);
+  const raw = JSON.parse(output) as Array<{
+    number: number;
+    title: string;
+    state: string;
+    labels: Array<{ name: string }>;
+    closedAt: string;
+  }>;
+  const items: GitHubItem[] = raw.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    state: issue.state.toLowerCase(),
+    labels: issue.labels,
+    closed_at: issue.closedAt || null,
+  }));
+  if (log) log(`  Fetched ${items.length} issues...`);
   return items;
 }
 
 /**
- * Fetch comments on an issue.
+ * Fetch comments on an issue via `gh api --paginate`.
  */
-async function fetchIssueComments(
+function fetchIssueComments(
   owner: string,
   repo: string,
   issueNumber: number,
-  token: string,
-  fetchFn: typeof fetch = fetch,
-): Promise<Array<{ id: number; body: string }>> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`;
-  const res = await fetchFn(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-    },
-  });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} fetching comments`);
-  return (await res.json()) as Array<{ id: number; body: string }>;
+  execGh: ExecGhFn = defaultExecGh,
+): Array<{ id: number; body: string }> {
+  const output = execGh([
+    'api',
+    '--paginate',
+    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+  ]);
+  return JSON.parse(output) as Array<{ id: number; body: string }>;
 }
 
 /**
- * Create a comment on an issue. Returns the comment ID.
+ * Create a comment on an issue via `gh issue comment`. Returns the comment ID.
  */
-async function createIssueComment(
+function createIssueComment(
   owner: string,
   repo: string,
   issueNumber: number,
   body: string,
-  token: string,
-  fetchFn: typeof fetch = fetch,
-): Promise<number> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
-  const res = await fetchFn(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ body }),
-  });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} creating comment`);
-  const data = (await res.json()) as { id: number };
-  return data.id;
+  execGh: ExecGhFn = defaultExecGh,
+): number {
+  const output = execGh([
+    'api',
+    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    '-X',
+    'POST',
+    '-f',
+    `body=${body}`,
+    '--jq',
+    '.id',
+  ]);
+  return parseInt(output.trim(), 10);
 }
 
 /**
- * Update a comment on an issue.
+ * Update a comment on an issue via `gh api -X PATCH`.
  */
-async function updateIssueComment(
+function updateIssueComment(
   owner: string,
   repo: string,
   commentId: number,
   body: string,
-  token: string,
-  fetchFn: typeof fetch = fetch,
-): Promise<void> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/issues/comments/${commentId}`;
-  const res = await fetchFn(url, {
-    method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ body }),
-  });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} updating comment`);
+  execGh: ExecGhFn = defaultExecGh,
+): void {
+  execGh([
+    'api',
+    `repos/${owner}/${repo}/issues/comments/${commentId}`,
+    '-X',
+    'PATCH',
+    '-f',
+    `body=${body}`,
+  ]);
 }
 
 // ── Index Entry Formatting ───────────────────────────────────
@@ -442,10 +447,9 @@ export interface InitIndexOptions {
   kind: 'prs' | 'issues';
   recentDays: number;
   dryRun: boolean;
-  token: string;
   /** When set, uses the AI tool to generate enriched entry descriptions. */
   agentCommandTemplate?: string;
-  fetchFn?: typeof fetch;
+  execGh?: ExecGhFn;
   log?: (msg: string) => void;
   /** Injected tool executor for testing. */
   runTool?: (
@@ -465,8 +469,8 @@ export async function initIndex(opts: InitIndexOptions): Promise<{
   archivedCount: number;
   newEntries: number;
 }> {
-  const { owner, repo, indexIssue, kind, recentDays, dryRun, token } = opts;
-  const fetchFn = opts.fetchFn ?? fetch;
+  const { owner, repo, indexIssue, kind, recentDays, dryRun } = opts;
+  const execGh = opts.execGh ?? defaultExecGh;
   const log = opts.log ?? (() => {});
   const runTool = opts.runTool ?? executeTool;
 
@@ -474,8 +478,8 @@ export async function initIndex(opts: InitIndexOptions): Promise<{
   log(`Scanning ${kind}...`);
   const items =
     kind === 'prs'
-      ? await fetchAllPRs(owner, repo, token, fetchFn, log)
-      : await fetchAllIssues(owner, repo, token, fetchFn, log);
+      ? fetchAllPRs(owner, repo, execGh, log)
+      : fetchAllIssues(owner, repo, execGh, log);
 
   log(`${icons.info} Found ${items.length} ${kind}.`);
 
@@ -487,7 +491,7 @@ export async function initIndex(opts: InitIndexOptions): Promise<{
   );
 
   // 3. Fetch existing comments on the index issue
-  const comments = await fetchIssueComments(owner, repo, indexIssue, token, fetchFn);
+  const comments = fetchIssueComments(owner, repo, indexIssue, execGh);
   const found = findIndexComments(comments);
 
   // Count new entries (needed before AI enrichment to know which items to process)
@@ -566,21 +570,21 @@ export async function initIndex(opts: InitIndexOptions): Promise<{
   log(`Populating index issue #${indexIssue}...`);
 
   if (found.open) {
-    await updateIssueComment(owner, repo, found.open.id, openBody, token, fetchFn);
+    updateIssueComment(owner, repo, found.open.id, openBody, execGh);
   } else {
-    await createIssueComment(owner, repo, indexIssue, openBody, token, fetchFn);
+    createIssueComment(owner, repo, indexIssue, openBody, execGh);
   }
 
   if (found.recent) {
-    await updateIssueComment(owner, repo, found.recent.id, recentBody, token, fetchFn);
+    updateIssueComment(owner, repo, found.recent.id, recentBody, execGh);
   } else {
-    await createIssueComment(owner, repo, indexIssue, recentBody, token, fetchFn);
+    createIssueComment(owner, repo, indexIssue, recentBody, execGh);
   }
 
   if (found.archived) {
-    await updateIssueComment(owner, repo, found.archived.id, archivedBody, token, fetchFn);
+    updateIssueComment(owner, repo, found.archived.id, archivedBody, execGh);
   } else {
-    await createIssueComment(owner, repo, indexIssue, archivedBody, token, fetchFn);
+    createIssueComment(owner, repo, indexIssue, archivedBody, execGh);
   }
 
   log(
@@ -602,26 +606,12 @@ export async function runDedupInit(
   options: { repo?: string; all?: boolean; dryRun?: boolean; days?: string; agent?: string },
   deps: DedupInitDeps = {},
 ): Promise<void> {
-  const fetchFn = deps.fetchFn ?? fetch;
+  const execGh = deps.execGh ?? defaultExecGh;
   const log = deps.log ?? console.log;
   const logError = deps.logError ?? console.error;
   const resolveCmd = deps.resolveAgentCommandFn ?? resolveAgentCommand;
-  const ensureAuthFn = deps.ensureAuthFn ?? (() => ensureAuth('https://opencara.workers.dev'));
 
-  // 1. Require authentication (auto-triggers login if not authenticated)
-  let token: string;
-  try {
-    token = await ensureAuthFn();
-  } catch (err) {
-    if (err instanceof AuthError) {
-      logError(`${icons.error} ${err.message}`);
-      process.exitCode = 1;
-      return;
-    }
-    throw err;
-  }
-
-  // 2. Parse --repo flag
+  // 1. Parse --repo flag
   if (!options.repo) {
     logError(`${icons.error} --repo is required. Usage: opencara dedup init --repo owner/repo`);
     process.exitCode = 1;
@@ -641,9 +631,9 @@ export async function runDedupInit(
     return;
   }
 
-  // 3. Fetch .opencara.toml from the repo
+  // 2. Fetch .opencara.toml from the repo
   log(`Fetching .opencara.toml from ${options.repo}...`);
-  const tomlContent = await fetchRepoFile(owner, repo, '.opencara.toml', token, fetchFn);
+  const tomlContent = fetchRepoFile(owner, repo, '.opencara.toml', execGh);
   if (!tomlContent) {
     logError(`${icons.error} No .opencara.toml found in ${options.repo}`);
     process.exitCode = 1;
@@ -658,7 +648,7 @@ export async function runDedupInit(
   }
   const config = parsed as OpenCaraConfig;
 
-  // 4. Determine which indexes to initialize
+  // 3. Determine which indexes to initialize
   const targets: Array<{ kind: 'prs' | 'issues'; indexIssue: number }> = [];
 
   if (config.dedup?.prs?.indexIssue) {
@@ -694,7 +684,7 @@ export async function runDedupInit(
     return;
   }
 
-  // 5. Resolve agent command template if --agent is specified
+  // 4. Resolve agent command template if --agent is specified
   let agentCommandTemplate: string | undefined;
   if (options.agent) {
     const cmd = resolveCmd(options.agent);
@@ -709,7 +699,7 @@ export async function runDedupInit(
     log(`Using AI agent "${options.agent}" for enriched descriptions`);
   }
 
-  // 6. Initialize each target
+  // 5. Initialize each target
   for (const target of filteredTargets) {
     log(`\n${pc.bold(`Initializing ${target.kind} dedup index (issue #${target.indexIssue})...`)}`);
     await initIndex({
@@ -719,9 +709,8 @@ export async function runDedupInit(
       kind: target.kind,
       recentDays,
       dryRun: options.dryRun ?? false,
-      token,
       agentCommandTemplate,
-      fetchFn,
+      execGh,
       log,
       runTool: deps.runTool,
     });
@@ -751,10 +740,7 @@ export function dedupCommand(): Command {
         days?: string;
         agent?: string;
       }) => {
-        const config = loadConfig();
-        await runDedupInit(options, {
-          ensureAuthFn: () => ensureAuth(config.platformUrl, { configPath: config.authFile }),
-        });
+        await runDedupInit(options);
       },
     );
 


### PR DESCRIPTION
Part of #636

## Summary
- Replace all 6 raw `fetch` GitHub API calls in `dedup init` with `gh` CLI equivalents (`gh pr list`, `gh issue list`, `gh api`)
- Remove `token`/`fetchFn` params from all GitHub helper functions, inject `execGh` for testability
- Remove `ensureAuth()` dependency from `runDedupInit` — no platform OAuth token needed
- Fix: private repos now work because `gh` CLI uses the user's own GitHub credentials

## Test plan
- All 2520 existing tests pass
- Updated all dedup-init tests to mock `execGh` instead of `fetch`/`token`
- Tests cover: fetchRepoFile (success, 404, error), fetchAllPRs (state mapping), fetchAllIssues, initIndex (create, merge, dry-run, issues kind), runDedupInit (all validation paths, --agent, --all, --dry-run)
- Lint, typecheck, format all pass