### PR TITLE
[server-dev] Fix zombie issue tasks and dedup namespace collision

### DIFF
--- a/packages/server/src/__tests__/integration.test.ts
+++ b/packages/server/src/__tests__/integration.test.ts
@@ -389,7 +389,7 @@ describe('Integration: full E2E flows', () => {
       expect(res.reason).toContain('timed out');
     });
 
-    it('leaves task in current state when GitHub posting fails during timeout', async () => {
+    it('deletes task even when GitHub posting fails during timeout (#641)', async () => {
       await store.createTask(
         makeTask({
           id: 'task-fail-timeout',
@@ -406,9 +406,9 @@ describe('Integration: full E2E flows', () => {
       // Trigger timeout check via poll
       await poll('any-agent');
 
-      // Task should NOT be marked timeout — GitHub posting failed
+      // Task should be deleted even though posting failed — prevents zombie tasks (#641)
       const task = await store.getTask('task-fail-timeout');
-      expect(task?.status).toBe('pending');
+      expect(task).toBeNull();
     });
 
     it('non-active tasks are not affected by timeout checks', async () => {

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -645,6 +645,75 @@ describe('Task Routes', () => {
       expect(body.tasks).toHaveLength(1);
       expect(body.tasks[0].task_id).toBe('issue-dedup-old');
     });
+
+    it('does not block pr_dedup tasks when issue_dedup exists for the same repo (#641)', async () => {
+      const now = Date.now();
+      // Create an issue_dedup task for the repo
+      await store.createTask(
+        makeTask({
+          id: 'issue-dedup-1',
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-issue-1',
+          created_at: now - 10_000,
+        }),
+      );
+      // Create a pr_dedup task for the same repo
+      await store.createTask(
+        makeTask({
+          id: 'pr-dedup-1',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-pr-1',
+          created_at: now,
+        }),
+      );
+
+      // Agent polling for both roles should see both tasks
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['pr_dedup', 'issue_dedup'],
+      });
+      const body = await res.json();
+      expect(body.tasks).toHaveLength(2);
+      const taskIds = body.tasks.map((t: { task_id: string }) => t.task_id).sort();
+      expect(taskIds).toEqual(['issue-dedup-1', 'pr-dedup-1']);
+    });
+
+    it('does not block pr_dedup when issue_dedup is claimed for same repo (#641)', async () => {
+      // Create and claim an issue_dedup task
+      await store.createTask(
+        makeTask({
+          id: 'issue-dedup-claimed',
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-issue-claimed',
+        }),
+      );
+      await request('POST', '/api/tasks/issue-dedup-claimed/claim', {
+        agent_id: 'agent-other',
+        role: 'issue_dedup',
+      });
+
+      // Create a pending pr_dedup task for the same repo
+      await store.createTask(
+        makeTask({
+          id: 'pr-dedup-pending',
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-pr-pending',
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/poll', {
+        agent_id: 'agent-1',
+        roles: ['pr_dedup'],
+      });
+      const body = await res.json();
+      // pr_dedup should NOT be blocked by a claimed issue_dedup
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].task_id).toBe('pr-dedup-pending');
+    });
   });
 
   // ── Claim ────────────────────────────────────────────────
@@ -1551,6 +1620,124 @@ describe('Task Routes', () => {
       const lastCheck = await store.getTimeoutLastCheck();
       expect(lastCheck).toBeGreaterThan(0);
       expect(lastCheck).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  // ── Zombie issue task cleanup (#641) ─────────────────────
+
+  describe('zombie issue task cleanup (#641)', () => {
+    it('deletes timed-out grouped task with pr_number=0 even when post fails', async () => {
+      // Create a grouped issue task with pr_number=0 and no issue_number
+      await store.createTask(
+        makeTask({
+          id: 'zombie-1',
+          pr_number: 0,
+          timeout_at: Date.now() - 1000,
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-zombie-1',
+        }),
+      );
+
+      // Poll triggers checkTimeouts — task should be deleted despite having no valid comment target
+      await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const task = await store.getTask('zombie-1');
+      expect(task).toBeNull();
+    });
+
+    it('deletes timed-out non-grouped task with pr_number=0 even when post fails', async () => {
+      // Create a non-grouped issue task with pr_number=0
+      await store.createTask(
+        makeTask({
+          id: 'zombie-legacy',
+          pr_number: 0,
+          timeout_at: Date.now() - 1000,
+          task_type: 'issue_triage',
+          feature: 'triage',
+          group_id: '', // non-grouped (legacy path)
+        }),
+      );
+
+      await request('POST', '/api/tasks/poll', { agent_id: 'agent-1' });
+      const task = await store.getTask('zombie-legacy');
+      expect(task).toBeNull();
+    });
+
+    it('posts timeout comment to issue_number for grouped issue tasks', async () => {
+      // Use MockGitHubService to track postPrComment calls
+      const { MockGitHubService } = await import('./helpers/github-mock.js');
+      const mockGithub = new MockGitHubService();
+      const trackingApp = createApp(store, mockGithub);
+
+      // Create a grouped issue task with pr_number=0 but valid issue_number
+      await store.createTask(
+        makeTask({
+          id: 'issue-timeout-1',
+          pr_number: 0,
+          issue_number: 42,
+          timeout_at: Date.now() - 1000,
+          task_type: 'issue_dedup',
+          feature: 'dedup_issue',
+          group_id: 'grp-issue-timeout',
+        }),
+      );
+
+      await trackingApp.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...OAUTH_HEADERS },
+          body: JSON.stringify({ agent_id: 'agent-1' }),
+        },
+        mockEnv,
+      );
+
+      // Verify postPrComment was called with issue_number (42), not pr_number (0)
+      const commentCalls = mockGithub.calls.filter((c) => c.method === 'postPrComment');
+      expect(commentCalls).toHaveLength(1);
+      expect(commentCalls[0].args.prNumber).toBe(42);
+
+      // Task should be cleaned up
+      const task = await store.getTask('issue-timeout-1');
+      expect(task).toBeNull();
+    });
+
+    it('posts timeout comment to pr_number for PR tasks (unchanged behavior)', async () => {
+      // Use MockGitHubService to track postPrComment calls
+      const { MockGitHubService } = await import('./helpers/github-mock.js');
+      const mockGithub = new MockGitHubService();
+      const trackingApp = createApp(store, mockGithub);
+
+      // Create a grouped PR task with pr_number=5
+      await store.createTask(
+        makeTask({
+          id: 'pr-timeout-1',
+          pr_number: 5,
+          timeout_at: Date.now() - 1000,
+          task_type: 'pr_dedup',
+          feature: 'dedup_pr',
+          group_id: 'grp-pr-timeout',
+        }),
+      );
+
+      await trackingApp.request(
+        '/api/tasks/poll',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...OAUTH_HEADERS },
+          body: JSON.stringify({ agent_id: 'agent-1' }),
+        },
+        mockEnv,
+      );
+
+      // Verify postPrComment was called with pr_number (5)
+      const commentCalls = mockGithub.calls.filter((c) => c.method === 'postPrComment');
+      expect(commentCalls).toHaveLength(1);
+      expect(commentCalls[0].args.prNumber).toBe(5);
+
+      // Task should be cleaned up
+      const task = await store.getTask('pr-timeout-1');
+      expect(task).toBeNull();
     });
   });
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -262,8 +262,11 @@ export async function checkTimeouts(
         const token = await github.getInstallationToken(task.github_installation_id);
         const timeoutMinutes = Math.round((task.timeout_at - task.created_at) / 60000);
         const body = formatTimeoutComment(timeoutMinutes, allReviews);
-        await github.postPrComment(task.owner, task.repo, task.pr_number, body, token);
-        await store.deleteTasksByGroup(task.group_id);
+        // Post to issue_number for issue tasks, pr_number for PR tasks
+        const commentTarget = task.pr_number > 0 ? task.pr_number : task.issue_number;
+        if (commentTarget) {
+          await github.postPrComment(task.owner, task.repo, commentTarget, body, token);
+        }
       } catch (err) {
         log.error('Timeout post failed', {
           taskId: task.id,
@@ -271,6 +274,8 @@ export async function checkTimeouts(
           action: 'timeout_post_failed',
           error: err instanceof Error ? err.message : String(err),
         });
+      } finally {
+        await store.deleteTasksByGroup(task.group_id);
       }
     } else {
       // Non-group task: handle individually (legacy path)
@@ -299,15 +304,19 @@ export async function checkTimeouts(
         }));
 
         const body = formatTimeoutComment(timeoutMinutes, reviews);
-        await github.postPrComment(task.owner, task.repo, task.pr_number, body, token);
-
-        await store.deleteTask(task.id);
+        // Post to issue_number for issue tasks, pr_number for PR tasks
+        const commentTarget = task.pr_number > 0 ? task.pr_number : task.issue_number;
+        if (commentTarget) {
+          await github.postPrComment(task.owner, task.repo, commentTarget, body, token);
+        }
       } catch (err) {
         log.error('Timeout post failed', {
           taskId: task.id,
           action: 'timeout_post_failed',
           error: err instanceof Error ? err.message : String(err),
         });
+      } finally {
+        await store.deleteTask(task.id);
       }
     }
   }
@@ -645,13 +654,13 @@ async function buildPollContext(store: DataStore): Promise<PollContext> {
   const dedupBlockedRepos = new Set<string>();
   for (const t of reviewingTasks) {
     if (isDedupRole(t.task_type)) {
-      dedupBlockedRepos.add(`${t.owner}/${t.repo}`);
+      dedupBlockedRepos.add(`${t.owner}/${t.repo}:${t.task_type}`);
     }
   }
   const oldestDedupPerRepo = new Map<string, ReviewTask>();
   for (const t of tasks) {
     if (!isDedupRole(t.task_type)) continue;
-    const repoKey = `${t.owner}/${t.repo}`;
+    const repoKey = `${t.owner}/${t.repo}:${t.task_type}`;
     const existing = oldestDedupPerRepo.get(repoKey);
     if (!existing || t.created_at < existing.created_at) {
       oldestDedupPerRepo.set(repoKey, t);
@@ -797,7 +806,7 @@ async function filterTasksForAgent(
 
     // Dedup serialization: skip if repo has a claimed dedup task or this isn't the oldest
     if (isDedupRole(task.task_type)) {
-      const repoKey = `${task.owner}/${task.repo}`;
+      const repoKey = `${task.owner}/${task.repo}:${task.task_type}`;
       if (dedupBlockedRepos.has(repoKey)) continue;
       const oldest = oldestDedupPerRepo.get(repoKey);
       if (oldest && oldest.id !== task.id) continue;


### PR DESCRIPTION
Part of #641

## Summary
- **Timeout handler**: Move `deleteTasksByGroup`/`deleteTask` to `finally` blocks so timed-out tasks are always cleaned up, even when GitHub posting fails (prevents zombie tasks)
- **Timeout handler**: Post timeout comments to `issue_number` for issue tasks (`pr_number=0`) instead of calling `/issues/0/comments` which returns 404
- **Dedup serialization**: Key on `{repo}:{task_type}` instead of just `{repo}`, so `issue_dedup` tasks don't block `pr_dedup` tasks for the same repo
- Unit tests for zombie task cleanup with `pr_number=0`, correct comment target routing, and dedup namespace separation

## Test plan
- [x] Existing tests pass (2552 tests, 0 failures)
- [x] New test: grouped task with `pr_number=0` is deleted after timeout
- [x] New test: non-grouped task with `pr_number=0` is deleted after timeout
- [x] New test: timeout comment posts to `issue_number` for issue tasks
- [x] New test: timeout comment posts to `pr_number` for PR tasks
- [x] New test: `pr_dedup` not blocked by `issue_dedup` for same repo (pending)
- [x] New test: `pr_dedup` not blocked by claimed `issue_dedup` for same repo
- [x] Integration test updated: tasks deleted even when GitHub posting fails
- [x] Build, lint, format, typecheck all pass