### PR TITLE
[server-dev] D1 migration + DataStore methods + reputation constants

### DIFF
--- a/packages/server/migrations/0017_reputation.sql
+++ b/packages/server/migrations/0017_reputation.sql
@@ -1,0 +1,29 @@
+-- Reputation system tables for emoji reaction-based agent scoring.
+
+CREATE TABLE posted_reviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  owner TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  group_id TEXT NOT NULL,
+  github_comment_id INTEGER NOT NULL,
+  feature TEXT NOT NULL,
+  posted_at TEXT NOT NULL,
+  reactions_checked_at TEXT
+);
+
+CREATE TABLE reputation_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  posted_review_id INTEGER NOT NULL REFERENCES posted_reviews(id),
+  agent_id TEXT NOT NULL,
+  operator_github_user_id INTEGER NOT NULL,
+  github_user_id INTEGER NOT NULL,
+  delta INTEGER NOT NULL CHECK(delta IN (-1, 1)),
+  created_at TEXT NOT NULL,
+  UNIQUE(posted_review_id, agent_id, github_user_id)
+);
+
+CREATE INDEX idx_reputation_agent ON reputation_events(agent_id, created_at);
+CREATE INDEX idx_reputation_operator ON reputation_events(operator_github_user_id, created_at);
+
+ALTER TABLE agent_rejections ADD COLUMN github_user_id INTEGER;

--- a/packages/server/src/__tests__/reputation-store.test.ts
+++ b/packages/server/src/__tests__/reputation-store.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryDataStore } from '../store/memory.js';
+
+describe('Reputation DataStore methods', () => {
+  let store: MemoryDataStore;
+
+  beforeEach(() => {
+    store = new MemoryDataStore();
+  });
+
+  // ── recordPostedReview / getPostedReviewsByPr ──────────────
+
+  describe('recordPostedReview', () => {
+    it('records a posted review and returns an id', async () => {
+      const id = await store.recordPostedReview({
+        owner: 'test-org',
+        repo: 'test-repo',
+        pr_number: 42,
+        group_id: 'grp-1',
+        github_comment_id: 12345,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      expect(id).toBeGreaterThan(0);
+    });
+
+    it('returns incrementing ids', async () => {
+      const id1 = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const id2 = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g2',
+        github_comment_id: 200,
+        feature: 'review',
+        posted_at: '2026-04-01T01:00:00Z',
+      });
+      expect(id2).toBeGreaterThan(id1);
+    });
+  });
+
+  describe('getPostedReviewsByPr', () => {
+    it('returns reviews matching owner/repo/pr_number', async () => {
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g2',
+        github_comment_id: 200,
+        feature: 'dedup',
+        posted_at: '2026-04-01T01:00:00Z',
+      });
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 2,
+        group_id: 'g3',
+        github_comment_id: 300,
+        feature: 'review',
+        posted_at: '2026-04-01T02:00:00Z',
+      });
+
+      const reviews = await store.getPostedReviewsByPr('org', 'repo', 1);
+      expect(reviews).toHaveLength(2);
+      expect(reviews.map((r) => r.github_comment_id).sort()).toEqual([100, 200]);
+    });
+
+    it('returns empty array when no reviews match', async () => {
+      const reviews = await store.getPostedReviewsByPr('org', 'repo', 999);
+      expect(reviews).toEqual([]);
+    });
+
+    it('returns reviews with reactions_checked_at as null initially', async () => {
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const reviews = await store.getPostedReviewsByPr('org', 'repo', 1);
+      expect(reviews[0].reactions_checked_at).toBeNull();
+    });
+  });
+
+  // ── markReactionsChecked ──────────────────────────────────��
+
+  describe('markReactionsChecked', () => {
+    it('sets reactions_checked_at on a posted review', async () => {
+      const id = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.markReactionsChecked(id, '2026-04-02T00:00:00Z');
+
+      const reviews = await store.getPostedReviewsByPr('org', 'repo', 1);
+      expect(reviews[0].reactions_checked_at).toBe('2026-04-02T00:00:00Z');
+    });
+
+    it('is a no-op for nonexistent review id', async () => {
+      await store.markReactionsChecked(9999, '2026-04-02T00:00:00Z');
+      // should not throw
+    });
+  });
+
+  // ── recordReputationEvent ─────────────────────────────────
+
+  describe('recordReputationEvent', () => {
+    it('records a reputation event', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toHaveLength(1);
+      expect(events[0].delta).toBe(1);
+      expect(events[0].agent_id).toBe('agent-1');
+      expect(events[0].github_user_id).toBe(2000);
+    });
+
+    it('is idempotent — duplicate insert is ignored', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      const event = {
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      };
+
+      await store.recordReputationEvent(event);
+      await store.recordReputationEvent(event); // duplicate
+
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toHaveLength(1);
+    });
+
+    it('allows same user to react to different reviews', async () => {
+      const reviewId1 = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const reviewId2 = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g2',
+        github_comment_id: 200,
+        feature: 'review',
+        posted_at: '2026-04-01T01:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId1,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId2,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: -1,
+        created_at: '2026-04-01T02:00:00Z',
+      });
+
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toHaveLength(2);
+    });
+
+    it('allows different users to react to same review', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 3000,
+        delta: -1,
+        created_at: '2026-04-01T02:00:00Z',
+      });
+
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toHaveLength(2);
+    });
+  });
+
+  // ── getAgentReputationEvents ──────────────────────────────
+
+  describe('getAgentReputationEvents', () => {
+    it('filters by agent_id', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-2',
+        operator_github_user_id: 1000,
+        github_user_id: 3000,
+        delta: -1,
+        created_at: '2026-04-01T02:00:00Z',
+      });
+
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toHaveLength(1);
+      expect(events[0].agent_id).toBe('agent-1');
+    });
+
+    it('filters by sinceMs', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-01-01T00:00:00Z', // old
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 3000,
+        delta: -1,
+        created_at: '2026-04-01T00:00:00Z', // recent
+      });
+
+      // sinceMs corresponds to 2026-03-01
+      const sinceMs = new Date('2026-03-01T00:00:00Z').getTime();
+      const events = await store.getAgentReputationEvents('agent-1', sinceMs);
+      expect(events).toHaveLength(1);
+      expect(events[0].delta).toBe(-1);
+    });
+
+    it('returns empty array when no events match', async () => {
+      const events = await store.getAgentReputationEvents('nonexistent', 0);
+      expect(events).toEqual([]);
+    });
+  });
+
+  // ── getAccountReputationEvents ────────────────────────────
+
+  describe('getAccountReputationEvents', () => {
+    it('filters by operator_github_user_id', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-2',
+        operator_github_user_id: 9999,
+        github_user_id: 3000,
+        delta: -1,
+        created_at: '2026-04-01T02:00:00Z',
+      });
+
+      const events = await store.getAccountReputationEvents(1000, 0);
+      expect(events).toHaveLength(1);
+      expect(events[0].operator_github_user_id).toBe(1000);
+    });
+
+    it('filters by sinceMs', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-01-01T00:00:00Z', // old
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 3000,
+        delta: -1,
+        created_at: '2026-04-01T00:00:00Z', // recent
+      });
+
+      const sinceMs = new Date('2026-03-01T00:00:00Z').getTime();
+      const events = await store.getAccountReputationEvents(1000, sinceMs);
+      expect(events).toHaveLength(1);
+      expect(events[0].delta).toBe(-1);
+    });
+
+    it('returns empty array when no events match', async () => {
+      const events = await store.getAccountReputationEvents(9999, 0);
+      expect(events).toEqual([]);
+    });
+  });
+
+  // ── countAccountRejections ────────────────────────────────
+
+  describe('countAccountRejections', () => {
+    it('counts rejections across all agents for a github user', async () => {
+      const now = Date.now();
+      await store.recordAgentRejection('agent-1', 'too_short', now, 1000);
+      await store.recordAgentRejection('agent-2', 'too_long', now, 1000);
+      await store.recordAgentRejection('agent-3', 'too_short', now, 2000);
+
+      const count = await store.countAccountRejections(1000, now - 1000);
+      expect(count).toBe(2);
+    });
+
+    it('filters by sinceMs', async () => {
+      const now = Date.now();
+      const old = now - 100_000;
+      await store.recordAgentRejection('agent-1', 'too_short', old, 1000);
+      await store.recordAgentRejection('agent-2', 'too_long', now, 1000);
+
+      const count = await store.countAccountRejections(1000, now - 1000);
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 when no rejections match', async () => {
+      const count = await store.countAccountRejections(9999, 0);
+      expect(count).toBe(0);
+    });
+
+    it('does not count rejections without github_user_id', async () => {
+      const now = Date.now();
+      await store.recordAgentRejection('agent-1', 'too_short', now);
+      await store.recordAgentRejection('agent-2', 'too_long', now, 1000);
+
+      const count = await store.countAccountRejections(1000, now - 1000);
+      expect(count).toBe(1);
+    });
+  });
+
+  // ── recordAgentRejection with github_user_id ──────────────
+
+  describe('recordAgentRejection with github_user_id', () => {
+    it('records rejection with github_user_id', async () => {
+      const now = Date.now();
+      await store.recordAgentRejection('agent-1', 'too_short', now, 1000);
+
+      // Agent-level count still works
+      const agentCount = await store.countAgentRejections('agent-1', now - 1000);
+      expect(agentCount).toBe(1);
+
+      // Account-level count works
+      const accountCount = await store.countAccountRejections(1000, now - 1000);
+      expect(accountCount).toBe(1);
+    });
+
+    it('records rejection without github_user_id (backward compatible)', async () => {
+      const now = Date.now();
+      await store.recordAgentRejection('agent-1', 'too_short', now);
+
+      const agentCount = await store.countAgentRejections('agent-1', now - 1000);
+      expect(agentCount).toBe(1);
+    });
+  });
+
+  // ── reset clears reputation data ──────────────────────────
+
+  describe('reset clears reputation data', () => {
+    it('clears posted reviews', async () => {
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      store.reset();
+      const reviews = await store.getPostedReviewsByPr('org', 'repo', 1);
+      expect(reviews).toEqual([]);
+    });
+
+    it('clears reputation events', async () => {
+      const id = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: id,
+        agent_id: 'agent-1',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      store.reset();
+      const events = await store.getAgentReputationEvents('agent-1', 0);
+      expect(events).toEqual([]);
+    });
+
+    it('resets posted review id counter', async () => {
+      await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      store.reset();
+      const id = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 2,
+        group_id: 'g2',
+        github_comment_id: 200,
+        feature: 'review',
+        posted_at: '2026-04-02T00:00:00Z',
+      });
+      expect(id).toBe(1);
+    });
+  });
+});

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -376,6 +376,26 @@ async function handleReviewSummaryResult(
     token,
   );
 
+  // Record the posted review for later reaction tracking
+  try {
+    await store.recordPostedReview({
+      owner: task.owner,
+      repo: task.repo,
+      pr_number: task.pr_number,
+      group_id: groupId,
+      github_comment_id: comment_id,
+      feature: task.feature,
+      posted_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    // Non-fatal — review was posted, just tracking failed
+    logger.error('Failed to record posted review', {
+      taskId: task.id,
+      commentId: comment_id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   logger.info('Review posted to GitHub', {
     taskId: task.id,
     owner: task.owner,
@@ -1216,6 +1236,7 @@ export function taskRoutes() {
     const store = c.get('store');
     const github = c.get('github');
     const logger = c.get('logger');
+    const verifiedIdentity = c.get('verifiedIdentity');
     const taskId = c.req.param('taskId');
 
     // Manual JSON parsing (instead of parseBody) so we can extract agent_id
@@ -1241,7 +1262,12 @@ export function taskRoutes() {
         const trimmed = raw.review_text.trim();
         if (trimmed.length < REVIEW_TEXT_MIN_LENGTH || trimmed.length > REVIEW_TEXT_MAX_LENGTH) {
           const reason = trimmed.length < REVIEW_TEXT_MIN_LENGTH ? 'too_short' : 'too_long';
-          await store.recordAgentRejection(agentId, reason, Date.now());
+          await store.recordAgentRejection(
+            agentId,
+            reason,
+            Date.now(),
+            verifiedIdentity?.github_user_id,
+          );
           logger.warn('Review text rejected — abuse tracking recorded', {
             agentId,
             reason,
@@ -1333,6 +1359,7 @@ export function taskRoutes() {
             agent_id,
             `summary_quality: ${evaluation.reason}`,
             Date.now(),
+            verifiedIdentity?.github_user_id,
           );
 
           const retryCount = await store.incrementSummaryRetryCount(taskId);

--- a/packages/server/src/store/constants.ts
+++ b/packages/server/src/store/constants.ts
@@ -12,3 +12,29 @@ export const AGENT_REJECTION_THRESHOLD = 5;
 
 /** Time window for rejection counting: 24 hours. */
 export const AGENT_REJECTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// ── Reputation system constants ──────────────────────────────────
+
+/** Bayesian prior alpha (pseudo-upvotes for cold start). */
+export const REPUTATION_PRIOR_UP = 2;
+
+/** Bayesian prior beta (pseudo-downvotes for cold start). */
+export const REPUTATION_PRIOR_DOWN = 2;
+
+/** Exponential decay half-life for reputation events: 14 days. */
+export const REPUTATION_DECAY_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000;
+
+/** Wilson score threshold for "proven good" agents (priority boost). */
+export const REPUTATION_GOOD_THRESHOLD = 0.7;
+
+/** Wilson score threshold below which agents get penalty multiplier. */
+export const REPUTATION_NEUTRAL_THRESHOLD = 0.4;
+
+/** Time window for reputation event queries: 90 days. */
+export const REPUTATION_SCORE_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Cooldown: fully cooled down after 10 minutes. */
+export const COOLDOWN_FULL_MS = 10 * 60_000;
+
+/** Cooldown: half-cooled threshold at 5 minutes. */
+export const COOLDOWN_HALF_MS = 5 * 60_000;

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -1,6 +1,6 @@
 import type { ReviewTask, TaskClaim, VerifiedIdentity } from '@opencara/shared';
 import type { TaskFilter } from '../types.js';
-import type { DataStore } from './interface.js';
+import type { DataStore, PostedReview, ReputationEvent } from './interface.js';
 import { DEFAULT_TTL_DAYS } from './constants.js';
 
 /** Terminal task statuses eligible for cleanup. */
@@ -891,10 +891,17 @@ export class D1DataStore implements DataStore {
 
   // ── Agent rejections (abuse tracking) ─────────────────────────
 
-  async recordAgentRejection(agentId: string, reason: string, timestamp: number): Promise<void> {
+  async recordAgentRejection(
+    agentId: string,
+    reason: string,
+    timestamp: number,
+    githubUserId?: number,
+  ): Promise<void> {
     await this.db
-      .prepare(`INSERT INTO agent_rejections (agent_id, reason, created_at) VALUES (?, ?, ?)`)
-      .bind(agentId, reason, timestamp)
+      .prepare(
+        `INSERT INTO agent_rejections (agent_id, reason, created_at, github_user_id) VALUES (?, ?, ?, ?)`,
+      )
+      .bind(agentId, reason, timestamp, githubUserId ?? null)
       .run();
   }
 
@@ -906,6 +913,116 @@ export class D1DataStore implements DataStore {
       .bind(agentId, sinceMs)
       .first<{ cnt: number }>();
     return row?.cnt ?? 0;
+  }
+
+  async countAccountRejections(githubUserId: number, sinceMs: number): Promise<number> {
+    const row = await this.db
+      .prepare(
+        'SELECT COUNT(*) as cnt FROM agent_rejections WHERE github_user_id = ? AND created_at >= ?',
+      )
+      .bind(githubUserId, sinceMs)
+      .first<{ cnt: number }>();
+    return row?.cnt ?? 0;
+  }
+
+  // ── Posted reviews (reputation reaction tracking) ──────────────
+
+  async recordPostedReview(review: {
+    owner: string;
+    repo: string;
+    pr_number: number;
+    group_id: string;
+    github_comment_id: number;
+    feature: string;
+    posted_at: string;
+  }): Promise<number> {
+    const result = await this.db
+      .prepare(
+        `INSERT INTO posted_reviews (owner, repo, pr_number, group_id, github_comment_id, feature, posted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        review.owner,
+        review.repo,
+        review.pr_number,
+        review.group_id,
+        review.github_comment_id,
+        review.feature,
+        review.posted_at,
+      )
+      .run();
+    return result.meta?.last_row_id ?? 0;
+  }
+
+  async getPostedReviewsByPr(
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ): Promise<PostedReview[]> {
+    const result = await this.db
+      .prepare('SELECT * FROM posted_reviews WHERE owner = ? AND repo = ? AND pr_number = ?')
+      .bind(owner, repo, prNumber)
+      .all<PostedReview>();
+    return result.results ?? [];
+  }
+
+  async markReactionsChecked(postedReviewId: number, timestamp: string): Promise<void> {
+    await this.db
+      .prepare('UPDATE posted_reviews SET reactions_checked_at = ? WHERE id = ?')
+      .bind(timestamp, postedReviewId)
+      .run();
+  }
+
+  // ── Reputation events (append-only) ────────────────────────────
+
+  async recordReputationEvent(event: {
+    posted_review_id: number;
+    agent_id: string;
+    operator_github_user_id: number;
+    github_user_id: number;
+    delta: number;
+    created_at: string;
+  }): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT OR IGNORE INTO reputation_events
+        (posted_review_id, agent_id, operator_github_user_id, github_user_id, delta, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        event.posted_review_id,
+        event.agent_id,
+        event.operator_github_user_id,
+        event.github_user_id,
+        event.delta,
+        event.created_at,
+      )
+      .run();
+  }
+
+  async getAgentReputationEvents(agentId: string, sinceMs: number): Promise<ReputationEvent[]> {
+    const sinceIso = new Date(sinceMs).toISOString();
+    const result = await this.db
+      .prepare(
+        'SELECT * FROM reputation_events WHERE agent_id = ? AND created_at >= ? ORDER BY created_at DESC',
+      )
+      .bind(agentId, sinceIso)
+      .all<ReputationEvent>();
+    return result.results ?? [];
+  }
+
+  async getAccountReputationEvents(
+    operatorGithubUserId: number,
+    sinceMs: number,
+  ): Promise<ReputationEvent[]> {
+    const sinceIso = new Date(sinceMs).toISOString();
+    const result = await this.db
+      .prepare(
+        'SELECT * FROM reputation_events WHERE operator_github_user_id = ? AND created_at >= ? ORDER BY created_at DESC',
+      )
+      .bind(operatorGithubUserId, sinceIso)
+      .all<ReputationEvent>();
+    return result.results ?? [];
   }
 
   // ── OAuth token cache ────────────────────────────────────────

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -1,6 +1,28 @@
 import type { ReviewTask, TaskClaim, VerifiedIdentity } from '@opencara/shared';
 import type { TaskFilter } from '../types.js';
 
+export interface PostedReview {
+  id: number;
+  owner: string;
+  repo: string;
+  pr_number: number;
+  group_id: string;
+  github_comment_id: number;
+  feature: string;
+  posted_at: string;
+  reactions_checked_at: string | null;
+}
+
+export interface ReputationEvent {
+  id: number;
+  posted_review_id: number;
+  agent_id: string;
+  operator_github_user_id: number;
+  github_user_id: number;
+  delta: number; // +1 or -1
+  created_at: string;
+}
+
 /**
  * DataStore — abstracted storage for tasks, claims, heartbeats, and meta.
  * Implementations: MemoryDataStore (dev/test), D1DataStore (production).
@@ -104,9 +126,50 @@ export interface DataStore {
 
   // Agent rejections (abuse tracking)
   /** Record a review_text validation rejection for an agent. */
-  recordAgentRejection(agentId: string, reason: string, timestamp: number): Promise<void>;
+  recordAgentRejection(
+    agentId: string,
+    reason: string,
+    timestamp: number,
+    githubUserId?: number,
+  ): Promise<void>;
   /** Count rejections for an agent within a time window. */
   countAgentRejections(agentId: string, sinceMs: number): Promise<number>;
+  /** Count rejections across all agents for a given GitHub user within a time window. */
+  countAccountRejections(githubUserId: number, sinceMs: number): Promise<number>;
+
+  // Posted reviews (reputation reaction tracking)
+  /** Record a posted review comment for later reaction fetching. Returns the inserted row ID. */
+  recordPostedReview(review: {
+    owner: string;
+    repo: string;
+    pr_number: number;
+    group_id: string;
+    github_comment_id: number;
+    feature: string;
+    posted_at: string;
+  }): Promise<number>;
+  /** Get all posted reviews for a PR. */
+  getPostedReviewsByPr(owner: string, repo: string, prNumber: number): Promise<PostedReview[]>;
+  /** Mark a posted review's reactions as checked at the given timestamp. */
+  markReactionsChecked(postedReviewId: number, timestamp: string): Promise<void>;
+
+  // Reputation events (append-only reaction-derived scores)
+  /** Record a reputation event. Uses INSERT OR IGNORE for idempotency (UNIQUE constraint). */
+  recordReputationEvent(event: {
+    posted_review_id: number;
+    agent_id: string;
+    operator_github_user_id: number;
+    github_user_id: number;
+    delta: number;
+    created_at: string;
+  }): Promise<void>;
+  /** Get reputation events for an agent since a given timestamp. */
+  getAgentReputationEvents(agentId: string, sinceMs: number): Promise<ReputationEvent[]>;
+  /** Get reputation events for an operator account since a given timestamp. */
+  getAccountReputationEvents(
+    operatorGithubUserId: number,
+    sinceMs: number,
+  ): Promise<ReputationEvent[]>;
 
   // OAuth token cache
   /** Look up a cached verified identity by token hash. Returns null if not found or expired. */

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -1,6 +1,6 @@
 import type { ReviewTask, TaskClaim, VerifiedIdentity } from '@opencara/shared';
 import type { TaskFilter } from '../types.js';
-import type { DataStore } from './interface.js';
+import type { DataStore, PostedReview, ReputationEvent } from './interface.js';
 import { DEFAULT_TTL_DAYS } from './constants.js';
 
 const TERMINAL_STATUSES = ['completed', 'timeout', 'failed'];
@@ -12,8 +12,17 @@ export class MemoryDataStore implements DataStore {
   private tasks = new Map<string, ReviewTask>();
   private claims = new Map<string, TaskClaim>();
   private agentLastSeen = new Map<string, number>();
-  private agentRejections: Array<{ agent_id: string; reason: string; created_at: number }> = [];
+  private agentRejections: Array<{
+    agent_id: string;
+    reason: string;
+    created_at: number;
+    github_user_id?: number;
+  }> = [];
   private oauthCache = new Map<string, { identity: VerifiedIdentity; expires_at: number }>();
+  private postedReviews: PostedReview[] = [];
+  private postedReviewNextId = 1;
+  private reputationEvents: ReputationEvent[] = [];
+  private reputationEventNextId = 1;
   private readonly ttlMs: number;
 
   constructor(ttlDays: number = DEFAULT_TTL_DAYS) {
@@ -461,13 +470,111 @@ export class MemoryDataStore implements DataStore {
 
   // Agent rejections (abuse tracking)
 
-  async recordAgentRejection(agentId: string, reason: string, timestamp: number): Promise<void> {
-    this.agentRejections.push({ agent_id: agentId, reason, created_at: timestamp });
+  async recordAgentRejection(
+    agentId: string,
+    reason: string,
+    timestamp: number,
+    githubUserId?: number,
+  ): Promise<void> {
+    this.agentRejections.push({
+      agent_id: agentId,
+      reason,
+      created_at: timestamp,
+      github_user_id: githubUserId,
+    });
   }
 
   async countAgentRejections(agentId: string, sinceMs: number): Promise<number> {
     return this.agentRejections.filter((r) => r.agent_id === agentId && r.created_at >= sinceMs)
       .length;
+  }
+
+  async countAccountRejections(githubUserId: number, sinceMs: number): Promise<number> {
+    return this.agentRejections.filter(
+      (r) => r.github_user_id === githubUserId && r.created_at >= sinceMs,
+    ).length;
+  }
+
+  // Posted reviews (reputation reaction tracking)
+
+  async recordPostedReview(review: {
+    owner: string;
+    repo: string;
+    pr_number: number;
+    group_id: string;
+    github_comment_id: number;
+    feature: string;
+    posted_at: string;
+  }): Promise<number> {
+    const id = this.postedReviewNextId++;
+    this.postedReviews.push({
+      id,
+      owner: review.owner,
+      repo: review.repo,
+      pr_number: review.pr_number,
+      group_id: review.group_id,
+      github_comment_id: review.github_comment_id,
+      feature: review.feature,
+      posted_at: review.posted_at,
+      reactions_checked_at: null,
+    });
+    return id;
+  }
+
+  async getPostedReviewsByPr(
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ): Promise<PostedReview[]> {
+    return this.postedReviews.filter(
+      (r) => r.owner === owner && r.repo === repo && r.pr_number === prNumber,
+    );
+  }
+
+  async markReactionsChecked(postedReviewId: number, timestamp: string): Promise<void> {
+    const review = this.postedReviews.find((r) => r.id === postedReviewId);
+    if (review) {
+      review.reactions_checked_at = timestamp;
+    }
+  }
+
+  // Reputation events (append-only)
+
+  async recordReputationEvent(event: {
+    posted_review_id: number;
+    agent_id: string;
+    operator_github_user_id: number;
+    github_user_id: number;
+    delta: number;
+    created_at: string;
+  }): Promise<void> {
+    // Idempotent: skip if (posted_review_id, agent_id, github_user_id) already exists
+    const exists = this.reputationEvents.some(
+      (e) =>
+        e.posted_review_id === event.posted_review_id &&
+        e.agent_id === event.agent_id &&
+        e.github_user_id === event.github_user_id,
+    );
+    if (exists) return;
+    this.reputationEvents.push({
+      id: this.reputationEventNextId++,
+      ...event,
+    });
+  }
+
+  async getAgentReputationEvents(agentId: string, sinceMs: number): Promise<ReputationEvent[]> {
+    const sinceIso = new Date(sinceMs).toISOString();
+    return this.reputationEvents.filter((e) => e.agent_id === agentId && e.created_at >= sinceIso);
+  }
+
+  async getAccountReputationEvents(
+    operatorGithubUserId: number,
+    sinceMs: number,
+  ): Promise<ReputationEvent[]> {
+    const sinceIso = new Date(sinceMs).toISOString();
+    return this.reputationEvents.filter(
+      (e) => e.operator_github_user_id === operatorGithubUserId && e.created_at >= sinceIso,
+    );
   }
 
   // OAuth token cache
@@ -523,6 +630,10 @@ export class MemoryDataStore implements DataStore {
     this.agentLastSeen.clear();
     this.agentRejections = [];
     this.oauthCache.clear();
+    this.postedReviews = [];
+    this.postedReviewNextId = 1;
+    this.reputationEvents = [];
+    this.reputationEventNextId = 1;
     this.timeoutLastCheck = 0;
   }
 }


### PR DESCRIPTION
Part of #655

## Summary
- D1 migration `0017_reputation.sql`: `posted_reviews` table, `reputation_events` table with indexes, ALTER `agent_rejections` to add `github_user_id` column
- DataStore interface: `PostedReview` and `ReputationEvent` types, 7 new methods (`recordPostedReview`, `getPostedReviewsByPr`, `markReactionsChecked`, `recordReputationEvent`, `getAgentReputationEvents`, `getAccountReputationEvents`, `countAccountRejections`)
- D1DataStore + MemoryDataStore implementations for all 7 methods
- Reputation constants in `store/constants.ts` (Wilson score priors, decay half-life, thresholds, cooldowns)
- `handleReviewSummaryResult` now calls `recordPostedReview` after posting to GitHub
- `recordAgentRejection` now accepts optional `github_user_id` for account-level tracking
- 26 unit tests covering all new methods including idempotency and aggregation

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2607 tests, 75 files)
- [x] `pnpm lint` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run format:check` passes
- [x] All 26 new reputation store tests pass
- [x] `recordReputationEvent` idempotency tested (duplicate ignored)
- [x] `countAccountRejections` aggregates across agent IDs
- [x] Backward compatibility: `recordAgentRejection` works without `github_user_id`