### PR TITLE
[server-dev] Rate limit batch poll by authenticated identity instead of IP

### DIFF
--- a/packages/server/src/__tests__/rate-limit.test.ts
+++ b/packages/server/src/__tests__/rate-limit.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { checkRateLimit, resetRateLimits } from '../middleware/rate-limit.js';
+import { Hono } from 'hono';
+import type { Env, AppVariables } from '../types.js';
+import type { VerifiedIdentity } from '@opencara/shared';
+import {
+  checkRateLimit,
+  resetRateLimits,
+  rateLimitByIdentity,
+  rateLimitByIP,
+} from '../middleware/rate-limit.js';
 
 describe('Rate Limiter', () => {
   beforeEach(() => {
@@ -65,6 +73,77 @@ describe('Rate Limiter', () => {
       const retryAfter = checkRateLimit('new-key', config);
       expect(retryAfter).not.toBeNull();
       expect(retryAfter).toBe(60); // windowMs / 1000
+    });
+  });
+
+  describe('rateLimitByIdentity middleware', () => {
+    function createTestApp(identity?: VerifiedIdentity) {
+      const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+      // Simulate OAuth middleware setting the verified identity
+      app.use('*', async (c, next) => {
+        if (identity) c.set('verifiedIdentity', identity);
+        await next();
+      });
+      app.post(
+        '/test',
+        rateLimitByIdentity({ maxRequests: 2, windowMs: 60_000, prefix: 'test' }),
+        (c) => c.json({ ok: true }),
+      );
+      return app;
+    }
+
+    it('rate limits by github_user_id when identity is present', async () => {
+      const app = createTestApp({ github_user_id: 42, github_username: 'alice', verified_at: 0 });
+      const req = () =>
+        app.request('/test', { method: 'POST' }, { GITHUB_WEBHOOK_SECRET: '' } as Env);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(429);
+    });
+
+    it('different users get separate rate limit budgets', async () => {
+      const appA = createTestApp({ github_user_id: 1, github_username: 'a', verified_at: 0 });
+      const appB = createTestApp({ github_user_id: 2, github_username: 'b', verified_at: 0 });
+      // Exhaust user 1's budget
+      const reqA = () =>
+        appA.request('/test', { method: 'POST' }, { GITHUB_WEBHOOK_SECRET: '' } as Env);
+      expect((await reqA()).status).toBe(200);
+      expect((await reqA()).status).toBe(200);
+      expect((await reqA()).status).toBe(429);
+      // User 2 should still be allowed
+      const reqB = () =>
+        appB.request('/test', { method: 'POST' }, { GITHUB_WEBHOOK_SECRET: '' } as Env);
+      expect((await reqB()).status).toBe(200);
+    });
+
+    it('falls back to IP when no identity is present', async () => {
+      const app = createTestApp(); // no identity
+      const req = () =>
+        app.request('/test', { method: 'POST' }, { GITHUB_WEBHOOK_SECRET: '' } as Env);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(429);
+    });
+  });
+
+  describe('rateLimitByIP middleware', () => {
+    function createTestApp() {
+      const app = new Hono<{ Bindings: Env; Variables: AppVariables }>();
+      app.post(
+        '/test',
+        rateLimitByIP({ maxRequests: 2, windowMs: 60_000, prefix: 'ip-test' }),
+        (c) => c.json({ ok: true }),
+      );
+      return app;
+    }
+
+    it('rate limits by IP address', async () => {
+      const app = createTestApp();
+      const req = () =>
+        app.request('/test', { method: 'POST' }, { GITHUB_WEBHOOK_SECRET: '' } as Env);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(200);
+      expect((await req()).status).toBe(429);
     });
   });
 });

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -488,6 +488,55 @@ describe('Task Routes', () => {
       const res = await request('POST', '/api/tasks/poll', {});
       expect(res.status).toBe(400);
     });
+
+    it('batch poll rate limits by authenticated identity, not IP', async () => {
+      const batchBody = { agents: [{ agent_name: 'a', roles: ['review'] }] };
+      // POLL_RATE_LIMIT is 12 requests per 60s — all from same user identity (id=42)
+      for (let i = 0; i < 12; i++) {
+        const res = await request('POST', '/api/tasks/poll/batch', batchBody);
+        expect(res.status).toBe(200);
+      }
+      // 13th request from same identity should be rate limited
+      const res = await request('POST', '/api/tasks/poll/batch', batchBody);
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.error.code).toBe('RATE_LIMITED');
+    });
+
+    it('batch poll allows different authenticated users from same IP', async () => {
+      const batchBody = { agents: [{ agent_name: 'a', roles: ['review'] }] };
+
+      // User A (id=42) exhausts their budget
+      for (let i = 0; i < 12; i++) {
+        const res = await request('POST', '/api/tasks/poll/batch', batchBody);
+        expect(res.status).toBe(200);
+      }
+      expect((await request('POST', '/api/tasks/poll/batch', batchBody)).status).toBe(429);
+
+      // Switch to User B (id=99) — different identity, same IP
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 200,
+          json: () => Promise.resolve({ user: { id: 99, login: 'user-b' } }),
+        }),
+      );
+      // Need a different token to bypass OAuth cache
+      const resB = await app.request(
+        '/api/tasks/poll/batch',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer ghu_user_b_token',
+          },
+          body: JSON.stringify(batchBody),
+        },
+        mockEnv,
+      );
+      // User B should NOT be rate limited — separate identity budget
+      expect(resB.status).toBe(200);
+    });
   });
 
   // ── Dedup serialization ──────────────────────────────────

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -160,3 +160,45 @@ export function rateLimitByIP(config: RateLimiterConfig & { prefix?: string }): 
     await next();
   };
 }
+
+/**
+ * Create a Hono middleware that rate-limits by authenticated identity.
+ *
+ * Uses the verified `github_user_id` from OAuth (set by requireOAuth middleware)
+ * as the rate limit key. This allows multiple CLI instances from the same IP
+ * to each get their own rate limit budget when authenticated as different users,
+ * while still sharing a budget per-user.
+ *
+ * Falls back to IP-based limiting if no verified identity is present.
+ *
+ * IMPORTANT: This middleware must run AFTER requireOAuth() so that
+ * `verifiedIdentity` is available in the Hono context.
+ */
+export function rateLimitByIdentity(
+  config: RateLimiterConfig & { prefix?: string },
+): MiddlewareHandler {
+  return async (c: HonoContext, next) => {
+    const identity = c.get('verifiedIdentity');
+    let key: string;
+    if (identity?.github_user_id) {
+      key = config.prefix
+        ? `${config.prefix}:user:${identity.github_user_id}`
+        : `user:${identity.github_user_id}`;
+    } else {
+      // Fallback to IP if no identity (shouldn't happen after requireOAuth)
+      const ip = c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For') ?? 'unknown';
+      key = config.prefix ? `${config.prefix}:ip:${ip}` : `ip:${ip}`;
+    }
+
+    const retryAfter = checkRateLimit(key, config);
+    if (retryAfter !== null) {
+      c.header('Retry-After', String(retryAfter));
+      return c.json<ErrorResponse>(
+        { error: { code: 'RATE_LIMITED', message: 'Rate limit exceeded' } },
+        429,
+      );
+    }
+
+    await next();
+  };
+}

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -36,7 +36,7 @@ import {
 import { computeAgentReputation, effectiveGracePeriod } from '../reputation.js';
 import { evaluateSummaryQuality, MAX_SUMMARY_RETRIES } from '../summary-evaluator.js';
 import { isAgentEligibleForRole } from '../eligibility.js';
-import { rateLimitByAgent, rateLimitByIP } from '../middleware/rate-limit.js';
+import { rateLimitByAgent, rateLimitByIdentity } from '../middleware/rate-limit.js';
 import { requireOAuth } from '../middleware/oauth.js';
 import { apiError } from '../errors.js';
 import {
@@ -1074,7 +1074,7 @@ export function taskRoutes() {
 
   app.post(
     '/api/tasks/poll/batch',
-    rateLimitByIP({ ...POLL_RATE_LIMIT, prefix: 'batch-poll' }),
+    rateLimitByIdentity({ ...POLL_RATE_LIMIT, prefix: 'batch-poll' }),
     async (c) => {
       const store = c.get('store');
       const github = c.get('github');


### PR DESCRIPTION
Part of #662

## Summary
- Added `rateLimitByIdentity` middleware that keys rate limits on the verified `github_user_id` from OAuth instead of client IP
- Switched batch poll endpoint (`/api/tasks/poll/batch`) from `rateLimitByIP` to `rateLimitByIdentity`
- Multiple CLI instances from the same IP can now poll without rate limiting each other, as long as they authenticate as different users
- Falls back to IP-based limiting if no verified identity is present (safety net)
- Unauthenticated endpoints and per-agent rate limits are unchanged

## Test plan
- Unit tests for `rateLimitByIdentity` middleware (keys by user ID, separate budgets per user, IP fallback)
- Integration tests for batch poll rate limiting (429 on same identity, 200 for different identity from same IP)
- All 2675 existing tests pass
- Build, lint, format, typecheck all pass