### PR TITLE
[cli-dev] Fix SIGTERM/SIGINT handlers to prevent zombie processes

### DIFF
--- a/packages/cli/src/__tests__/shutdown-handler.test.ts
+++ b/packages/cli/src/__tests__/shutdown-handler.test.ts
@@ -132,17 +132,36 @@ describe('registerShutdownHandlers', () => {
     const log = vi.fn();
     cleanup = registerShutdownHandlers(controller, log);
 
+    const countBefore = process.listenerCount('SIGTERM');
+    const countBeforeInt = process.listenerCount('SIGINT');
+
     // Remove listeners
     cleanup();
     cleanup = undefined;
 
-    // Signal should no longer be caught by our handler
-    const listenerCountBefore = process.listenerCount('SIGTERM');
-    // Emit shouldn't abort our controller (listeners removed)
-    // Note: we can't safely emit SIGTERM without a handler, so just verify listener count
+    // Verify listener count decreased
+    expect(process.listenerCount('SIGTERM')).toBe(countBefore - 1);
+    expect(process.listenerCount('SIGINT')).toBe(countBeforeInt - 1);
+    // Controller should not have been aborted
     expect(controller.signal.aborted).toBe(false);
-    // Verify our listeners were removed by checking the controller wasn't aborted
-    // (if they were still registered, emitting would abort it)
-    expect(listenerCountBefore).toBe(process.listenerCount('SIGTERM'));
+  });
+
+  it('clears force timer when cleanup is called after signal', () => {
+    const controller = new AbortController();
+    const log = vi.fn();
+    cleanup = registerShutdownHandlers(controller, log, 5000);
+
+    // Trigger signal — starts the force timer
+    process.emit('SIGTERM');
+    expect(controller.signal.aborted).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    // Cleanup should clear the force timer
+    cleanup();
+    cleanup = undefined;
+
+    // Advance past grace period — timer should have been cleared
+    vi.advanceTimersByTime(10000);
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -135,6 +135,7 @@ export function registerShutdownHandlers(
   graceMs = SHUTDOWN_GRACE_MS,
 ): () => void {
   let shutdownInitiated = false;
+  let forceTimer: ReturnType<typeof setTimeout> | undefined;
 
   const onSignal = (signal: string) => {
     if (shutdownInitiated) {
@@ -147,7 +148,7 @@ export function registerShutdownHandlers(
     controller.abort();
 
     // Force exit after grace period in case cleanup hangs
-    const forceTimer = setTimeout(() => {
+    forceTimer = setTimeout(() => {
       log(`${icons.stop} Shutdown timed out after ${graceMs / 1000}s — forcing exit`);
       process.exit(1);
     }, graceMs);
@@ -164,6 +165,7 @@ export function registerShutdownHandlers(
   return () => {
     process.removeListener('SIGINT', onSigint);
     process.removeListener('SIGTERM', onSigterm);
+    if (forceTimer) clearTimeout(forceTimer);
   };
 }
 
@@ -1542,44 +1544,46 @@ export async function startAgent(
   const abortController = new AbortController();
   const removeShutdownHandlers = registerShutdownHandlers(abortController, log);
 
-  await pollLoop(client, agentId, reviewDeps, deps, agentInfo, logger, agentSession, {
-    pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-    maxConsecutiveErrors: options?.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
-    routerRelay: options?.routerRelay,
-    reviewOnly: options?.reviewOnly,
-    repoConfig: options?.repoConfig,
-    roles: options?.roles,
-    synthesizeRepos: options?.synthesizeRepos,
-    signal: abortController.signal,
-    cleanupTracker,
-    verbose: options?.verbose,
-    agentOwner: options?.agentOwner,
-    userOrgs: options?.userOrgs,
-  });
+  try {
+    await pollLoop(client, agentId, reviewDeps, deps, agentInfo, logger, agentSession, {
+      pollIntervalMs: options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      maxConsecutiveErrors: options?.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS,
+      routerRelay: options?.routerRelay,
+      reviewOnly: options?.reviewOnly,
+      repoConfig: options?.repoConfig,
+      roles: options?.roles,
+      synthesizeRepos: options?.synthesizeRepos,
+      signal: abortController.signal,
+      cleanupTracker,
+      verbose: options?.verbose,
+      agentOwner: options?.agentOwner,
+      userOrgs: options?.userOrgs,
+    });
 
-  // Final sweep: clean up any remaining tracked worktrees on shutdown
-  if (cleanupTracker && cleanupTracker.size > 0) {
-    const finalSwept = await cleanupTracker.sweep(cleanupWorktree);
-    if (finalSwept > 0) {
+    // Final sweep: clean up any remaining tracked worktrees on shutdown
+    if (cleanupTracker && cleanupTracker.size > 0) {
+      const finalSwept = await cleanupTracker.sweep(cleanupWorktree);
+      if (finalSwept > 0) {
+        log(
+          `${icons.info} Cleaned up ${finalSwept} codebase director${finalSwept === 1 ? 'y' : 'ies'} on shutdown`,
+        );
+      }
+    }
+
+    // Print usage summary on shutdown
+    if (deps.usageTracker) {
       log(
-        `${icons.info} Cleaned up ${finalSwept} codebase director${finalSwept === 1 ? 'y' : 'ies'} on shutdown`,
+        deps.usageTracker.formatSummary(
+          deps.usageLimits ?? usageLimits,
+          deps.agentLimits,
+          deps.agentId,
+        ),
       );
     }
+    log(formatExitSummary(agentSession));
+  } finally {
+    removeShutdownHandlers();
   }
-
-  // Print usage summary on shutdown
-  if (deps.usageTracker) {
-    log(
-      deps.usageTracker.formatSummary(
-        deps.usageLimits ?? usageLimits,
-        deps.agentLimits,
-        deps.agentId,
-      ),
-    );
-  }
-  log(formatExitSummary(agentSession));
-
-  removeShutdownHandlers();
 }
 
 // ── Batch Poll Coordinator ────────────────────────────────────
@@ -2018,45 +2022,47 @@ export async function startBatchAgents(
 
   log(`${agentStates.length} agent instance(s) running in batch mode. Press Ctrl+C to stop.\n`);
 
-  await batchPollLoop(client, agentStates, {
-    pollIntervalMs,
-    maxConsecutiveErrors: config.maxConsecutiveErrors,
-    signal: abortController.signal,
-    accessibleRepos,
-    githubToken: oauthToken,
-  });
+  try {
+    await batchPollLoop(client, agentStates, {
+      pollIntervalMs,
+      maxConsecutiveErrors: config.maxConsecutiveErrors,
+      signal: abortController.signal,
+      accessibleRepos,
+      githubToken: oauthToken,
+    });
 
-  // Cleanup on shutdown (in parallel, allSettled so one failure doesn't hide others)
-  await Promise.allSettled(
-    agentStates.map(async (state) => {
-      state.routerRelay?.stop();
-      if (state.cleanupTracker && state.cleanupTracker.size > 0) {
-        const swept = await state.cleanupTracker.sweep(cleanupWorktree);
-        if (swept > 0) {
+    // Cleanup on shutdown (in parallel, allSettled so one failure doesn't hide others)
+    await Promise.allSettled(
+      agentStates.map(async (state) => {
+        state.routerRelay?.stop();
+        if (state.cleanupTracker && state.cleanupTracker.size > 0) {
+          const swept = await state.cleanupTracker.sweep(cleanupWorktree);
+          if (swept > 0) {
+            state.logger.log(
+              `${icons.info} Cleaned up ${swept} codebase director${swept === 1 ? 'y' : 'ies'} on shutdown`,
+            );
+          }
+        }
+        if (state.consumptionDeps.usageTracker) {
+          const limits = state.consumptionDeps.usageLimits ?? {
+            maxTasksPerDay: null,
+            maxTokensPerDay: null,
+            maxTokensPerReview: null,
+          };
           state.logger.log(
-            `${icons.info} Cleaned up ${swept} codebase director${swept === 1 ? 'y' : 'ies'} on shutdown`,
+            state.consumptionDeps.usageTracker.formatSummary(
+              limits,
+              state.consumptionDeps.agentLimits,
+              state.consumptionDeps.agentId,
+            ),
           );
         }
-      }
-      if (state.consumptionDeps.usageTracker) {
-        const limits = state.consumptionDeps.usageLimits ?? {
-          maxTasksPerDay: null,
-          maxTokensPerDay: null,
-          maxTokensPerReview: null,
-        };
-        state.logger.log(
-          state.consumptionDeps.usageTracker.formatSummary(
-            limits,
-            state.consumptionDeps.agentLimits,
-            state.consumptionDeps.agentId,
-          ),
-        );
-      }
-      state.logger.log(formatExitSummary(state.agentSession));
-    }),
-  );
-
-  removeShutdownHandlers();
+        state.logger.log(formatExitSummary(state.agentSession));
+      }),
+    );
+  } finally {
+    removeShutdownHandlers();
+  }
 }
 
 /**


### PR DESCRIPTION
Part of #664

## Summary
- Replace bare `abortController.abort()` signal handlers with `registerShutdownHandlers()` that logs the signal, aborts the poll loop, and force-exits after a 5s grace period
- Handles double-signal (e.g. Ctrl+C twice) with immediate forced exit
- Cleans up process listeners after normal shutdown to prevent listener leaks
- Added 6 tests covering all signal handling scenarios

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2681 tests, 78 files)
- [x] `pnpm lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run typecheck` passes
- [x] New tests verify: SIGTERM abort, SIGINT abort, grace period timeout, double-signal force exit, listener cleanup