### PR TITLE
[architect] Add agent_field config to implement and fix sections

### DIFF
--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -1750,6 +1750,114 @@ id = "no-prompt-only-id"
   });
 });
 
+// ── agent_field in implement/fix sections ──
+
+describe('parseOpenCaraConfig — agent_field in implement section', () => {
+  it('parses agent_field from implement section', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[implement]
+prompt = "Implement"
+agent_field = "Agent"
+`) as OpenCaraConfig;
+
+    expect(result.implement!.agent_field).toBe('Agent');
+  });
+
+  it('agent_field is undefined when absent', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[implement]
+prompt = "Implement"
+`) as OpenCaraConfig;
+
+    expect(result.implement!.agent_field).toBeUndefined();
+    expect('agent_field' in result.implement!).toBe(false);
+  });
+
+  it('ignores non-string agent_field', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[implement]
+prompt = "Implement"
+agent_field = 42
+`) as OpenCaraConfig;
+
+    expect(result.implement!.agent_field).toBeUndefined();
+    expect('agent_field' in result.implement!).toBe(false);
+  });
+
+  it('works alongside named agents', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[implement]
+prompt = "Implement"
+agent_field = "Agent"
+
+[[implement.agents]]
+id = "security-auditor"
+prompt = "Focus on security"
+`) as OpenCaraConfig;
+
+    expect(result.implement!.agent_field).toBe('Agent');
+    expect(result.implement!.agents).toHaveLength(1);
+    expect(result.implement!.agents![0].id).toBe('security-auditor');
+  });
+});
+
+describe('parseOpenCaraConfig — agent_field in fix section', () => {
+  it('parses agent_field from fix section', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[fix]
+prompt = "Fix"
+agent_field = "Agent"
+`) as OpenCaraConfig;
+
+    expect(result.fix!.agent_field).toBe('Agent');
+  });
+
+  it('agent_field is undefined when absent', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[fix]
+prompt = "Fix"
+`) as OpenCaraConfig;
+
+    expect(result.fix!.agent_field).toBeUndefined();
+    expect('agent_field' in result.fix!).toBe(false);
+  });
+
+  it('ignores non-string agent_field', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[fix]
+prompt = "Fix"
+agent_field = true
+`) as OpenCaraConfig;
+
+    expect(result.fix!.agent_field).toBeUndefined();
+    expect('agent_field' in result.fix!).toBe(false);
+  });
+
+  it('works alongside named agents', () => {
+    const result = parseOpenCaraConfig(`
+version = 1
+[fix]
+prompt = "Fix"
+agent_field = "Fixer"
+
+[[fix.agents]]
+id = "security-fixer"
+prompt = "Fix security issues"
+`) as OpenCaraConfig;
+
+    expect(result.fix!.agent_field).toBe('Fixer');
+    expect(result.fix!.agents).toHaveLength(1);
+    expect(result.fix!.agents![0].id).toBe('security-fixer');
+  });
+});
+
 describe('resolveNamedAgent', () => {
   const implementConfig: ImplementConfig = {
     enabled: true,

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -86,6 +86,8 @@ export interface ImplementConfig extends FeatureConfig {
   enabled: boolean;
   trigger: TriggerConfig;
   agents?: NamedAgentConfig[];
+  /** GitHub Project field name whose value maps to a named agent ID */
+  agent_field?: string;
 }
 
 /** Fix section config */
@@ -93,6 +95,8 @@ export interface FixConfig extends FeatureConfig {
   enabled: boolean;
   trigger: TriggerConfig;
   agents?: NamedAgentConfig[];
+  /** GitHub Project field name whose value maps to a named agent ID */
+  agent_field?: string;
 }
 
 /** Top-level .opencara.toml config */
@@ -580,11 +584,13 @@ function parseImplementSection(raw: Record<string, unknown>): ImplementConfig {
   const { agents: _slots, ...base } = parseFeatureFields(raw, DEFAULT_IMPLEMENT_FEATURE);
   const triggerRaw = isObject(raw.trigger) ? raw.trigger : undefined;
   const namedAgents = parseNamedAgents(raw.agents);
+  const agentField = typeof raw.agent_field === 'string' ? raw.agent_field : undefined;
   return {
     ...base,
     enabled: typeof raw.enabled === 'boolean' ? raw.enabled : true,
     trigger: parseTriggerSection(triggerRaw, DEFAULT_IMPLEMENT_TRIGGER),
     ...(namedAgents ? { agents: namedAgents } : {}),
+    ...(agentField ? { agent_field: agentField } : {}),
   };
 }
 
@@ -602,11 +608,13 @@ function parseFixSection(raw: Record<string, unknown>): FixConfig {
   const { agents: _slots, ...base } = parseFeatureFields(raw, DEFAULT_FIX_FEATURE);
   const triggerRaw = isObject(raw.trigger) ? raw.trigger : undefined;
   const namedAgents = parseNamedAgents(raw.agents);
+  const agentField = typeof raw.agent_field === 'string' ? raw.agent_field : undefined;
   return {
     ...base,
     enabled: typeof raw.enabled === 'boolean' ? raw.enabled : true,
     trigger: parseTriggerSection(triggerRaw, DEFAULT_FIX_TRIGGER),
     ...(namedAgents ? { agents: namedAgents } : {}),
+    ...(agentField ? { agent_field: agentField } : {}),
   };
 }
 


### PR DESCRIPTION
Part of #680

## Summary
- Added `agent_field?: string` to `ImplementConfig` and `FixConfig` interfaces
- Updated `parseImplementSection()` and `parseFixSection()` to parse the optional string field
- Added tests for presence, absence, invalid type, and coexistence with named agents

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` passes (2734 tests, 78 files)
- [ ] Bot review