### PR TITLE
[server-dev] Resolve agent ID from project board field for implement/fix tasks

### DIFF
--- a/packages/server/src/__tests__/agent-field-resolve.test.ts
+++ b/packages/server/src/__tests__/agent-field-resolve.test.ts
@@ -1,0 +1,889 @@
+/**
+ * Tests for agent_field resolution — reading a project board field value
+ * to resolve a named agent for implement/fix tasks.
+ *
+ * Covers:
+ * - Explicit agent ID overrides field value
+ * - Field value resolves to named agent
+ * - Empty/missing field falls back to default config
+ * - Invalid field value posts error comment
+ * - agent_field not configured → no project query made
+ * - All trigger paths: comment, label, status
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  DEFAULT_REVIEW_CONFIG,
+  DEFAULT_OPENCARA_CONFIG,
+  type OpenCaraConfig,
+  type ReviewConfig,
+  type ReviewSectionConfig,
+} from '@opencara/shared';
+import type { GitHubService, PrDetails, IssueDetails } from '../github/service.js';
+import { MemoryDataStore } from '../store/memory.js';
+import { createApp } from '../index.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+function getMockEnv() {
+  return {
+    GITHUB_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_ID: '12345',
+    GITHUB_APP_PRIVATE_KEY: 'unused-in-mock',
+    WEB_URL: 'https://test.opencara.com',
+  };
+}
+
+class TestGitHubService implements GitHubService {
+  openCaraConfig: OpenCaraConfig = DEFAULT_OPENCARA_CONFIG;
+  openCaraConfigParseError = false;
+  reviewConfig: ReviewConfig = DEFAULT_REVIEW_CONFIG;
+  reviewConfigParseError = false;
+  fetchPrResult: PrDetails | null = {
+    number: 1,
+    html_url: 'https://github.com/acme/widget/pull/1',
+    diff_url: 'https://github.com/acme/widget/pull/1.diff',
+    base: { ref: 'main' },
+    head: { ref: 'feat/test', sha: 'abc123' },
+    user: { login: 'pr-author' },
+    draft: false,
+    labels: [],
+  };
+  resolveProjectItemResult: {
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null = null;
+
+  /** Configurable return value for readProjectFieldValue */
+  projectFieldValue: string | null = null;
+  readProjectFieldValueSpy = vi.fn<
+    [string, string, number, string, string],
+    Promise<string | null>
+  >();
+
+  /** Spy for createIssueComment to check error messages */
+  createIssueCommentSpy = vi.fn<[string, string, number, string, string], Promise<number>>();
+
+  async getInstallationToken(): Promise<string> {
+    return 'ghs_mock_token';
+  }
+  async postPrComment(): Promise<{ html_url: string; comment_id: number }> {
+    return { html_url: 'https://github.com/test/repo/pull/1#comment-mock', comment_id: 12345 };
+  }
+  async getCommentReactions(): Promise<Array<{ user_id: number; content: string }>> {
+    return [];
+  }
+  async fetchPrDetails(): Promise<PrDetails | null> {
+    return this.fetchPrResult;
+  }
+  async loadReviewConfig(): Promise<{ config: ReviewConfig; parseError: boolean }> {
+    return { config: this.reviewConfig, parseError: this.reviewConfigParseError };
+  }
+  async loadOpenCaraConfig(): Promise<{ config: OpenCaraConfig; parseError: boolean }> {
+    return { config: this.openCaraConfig, parseError: this.openCaraConfigParseError };
+  }
+  async fetchPrReviewComments(): Promise<string> {
+    return '[mock-reviewer] src/index.ts:10\nPlease fix this bug';
+  }
+  async updateIssue(): Promise<void> {}
+  async fetchIssueBody(): Promise<string | null> {
+    return null;
+  }
+  async fetchIssueDetails(
+    _owner: string,
+    _repo: string,
+    number: number,
+  ): Promise<IssueDetails | null> {
+    return {
+      number,
+      html_url: `https://github.com/acme/widget/issues/${number}`,
+      title: `Test issue #${number}`,
+      body: 'Test issue body content',
+      user: { login: 'alice' },
+    };
+  }
+  async createIssue(): Promise<number> {
+    return 0;
+  }
+  async listIssueComments(): Promise<Array<{ id: number; body: string }>> {
+    return [];
+  }
+  async createIssueComment(
+    owner: string,
+    repo: string,
+    number: number,
+    body: string,
+    token: string,
+  ): Promise<number> {
+    this.createIssueCommentSpy(owner, repo, number, body, token);
+    return 0;
+  }
+  async updateIssueComment(): Promise<void> {}
+  async resolveProjectItemContent(): Promise<{
+    type: 'Issue' | 'PullRequest';
+    owner: string;
+    repo: string;
+    number: number;
+  } | null> {
+    return this.resolveProjectItemResult;
+  }
+  async readProjectFieldValue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fieldName: string,
+    token: string,
+  ): Promise<string | null> {
+    this.readProjectFieldValueSpy(owner, repo, issueNumber, fieldName, token);
+    return this.projectFieldValue;
+  }
+}
+
+async function sendWebhook(
+  app: ReturnType<typeof createApp>,
+  event: string,
+  payload: unknown,
+  env: ReturnType<typeof getMockEnv>,
+) {
+  const body = JSON.stringify(payload);
+  const signature = await signPayload(body, WEBHOOK_SECRET);
+  return app.request(
+    '/webhook/github',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': signature,
+        'X-GitHub-Event': event,
+      },
+      body,
+    },
+    env,
+  );
+}
+
+function makeReviewConfig(overrides: Partial<ReviewSectionConfig> = {}): ReviewSectionConfig {
+  return { ...DEFAULT_REVIEW_CONFIG, ...overrides };
+}
+
+function makeIssueCommentPayload(commentBody: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 10,
+    },
+    comment: {
+      body: commentBody,
+      user: { login: 'alice' },
+      author_association: 'OWNER',
+    },
+    ...overrides,
+  };
+}
+
+function makePrCommentPayload(commentBody: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'created',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 42,
+      pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/42' },
+    },
+    comment: {
+      body: commentBody,
+      user: { login: 'alice' },
+      author_association: 'OWNER',
+    },
+    ...overrides,
+  };
+}
+
+function makeIssueLabelPayload(labelName: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'labeled',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    issue: {
+      number: 10,
+      html_url: 'https://github.com/acme/widget/issues/10',
+      title: 'Bug: something is broken',
+      body: 'Steps to reproduce...',
+      user: { login: 'alice' },
+      labels: [{ name: labelName }],
+    },
+    label: { name: labelName },
+    ...overrides,
+  };
+}
+
+function makePRLabelPayload(labelName: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'labeled',
+    installation: { id: 999 },
+    repository: {
+      owner: { login: 'acme' },
+      name: 'widget',
+      default_branch: 'main',
+      private: false,
+    },
+    pull_request: {
+      number: 42,
+      html_url: 'https://github.com/acme/widget/pull/42',
+      diff_url: 'https://github.com/acme/widget/pull/42.diff',
+      base: { ref: 'main' },
+      head: { ref: 'feat/test', sha: 'abc123' },
+      draft: false,
+      labels: [{ name: labelName }],
+    },
+    label: { name: labelName },
+    ...overrides,
+  };
+}
+
+function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'edited',
+    installation: { id: 999 },
+    projects_v2_item: { content_node_id: 'node123' },
+    changes: {
+      field_value: {
+        field_name: 'Status',
+        from: 'Backlog',
+        to: statusTo,
+      },
+    },
+    ...overrides,
+  };
+}
+
+const IMPLEMENT_CONFIG_WITH_AGENTS = {
+  enabled: true,
+  prompt: 'Implement the requested changes.',
+  agentCount: 1,
+  timeout: '10m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  trigger: { comment: '/opencara go', status: 'Ready' },
+  agents: [
+    {
+      id: 'security-auditor',
+      prompt: 'Security audit this.',
+      model: 'claude-opus',
+      tool: 'claude',
+    },
+    { id: 'perf-reviewer', prompt: 'Performance review.', model: 'gpt-5', tool: 'codex' },
+  ],
+  agent_field: 'Agent',
+};
+
+const FIX_CONFIG_WITH_AGENTS = {
+  enabled: true,
+  prompt: 'Fix the review comments.',
+  agentCount: 1,
+  timeout: '10m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  trigger: { comment: '/opencara fix', label: 'opencara:fix' },
+  agents: [
+    { id: 'security-auditor', prompt: 'Security fix audit.', model: 'claude-opus', tool: 'claude' },
+    { id: 'perf-reviewer', prompt: 'Performance fix.', model: 'gpt-5', tool: 'codex' },
+  ],
+  agent_field: 'Agent',
+};
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('Agent field resolution', () => {
+  let store: MemoryDataStore;
+  let github: TestGitHubService;
+  let app: ReturnType<typeof createApp>;
+  let env: ReturnType<typeof getMockEnv>;
+
+  beforeEach(() => {
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    github = new TestGitHubService();
+    app = createApp(store, github);
+    env = getMockEnv();
+  });
+
+  // ── /opencara go (comment trigger) ─────────────────────────
+
+  describe('/opencara go — comment trigger', () => {
+    it('explicit agent ID takes priority over field value', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer'; // field says perf-reviewer
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go security-auditor'), // command says security-auditor
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      // readProjectFieldValue should NOT be called when explicit agent is given
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].config.prompt).toBe('Security audit this.');
+      expect(tasks[0].config.preferredModels).toEqual(['claude-opus']);
+    });
+
+    it('field value resolves to named agent when no explicit agent', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'security-auditor';
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalledWith(
+        'acme',
+        'widget',
+        10,
+        'Agent',
+        'ghs_mock_token',
+      );
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Security audit this.');
+      expect(tasks[0].config.preferredModels).toEqual(['claude-opus']);
+      expect(tasks[0].config.preferredTools).toEqual(['claude']);
+    });
+
+    it('empty/missing field falls back to default config', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = null; // field is empty
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Implement the requested changes.');
+      expect(tasks[0].config.preferredModels).toEqual([]);
+    });
+
+    it('invalid field value posts error comment', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'nonexistent-agent';
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      // Should post error comment
+      expect(github.createIssueCommentSpy).toHaveBeenCalled();
+      const commentBody = github.createIssueCommentSpy.mock.calls[0][3];
+      expect(commentBody).toContain('nonexistent-agent');
+      expect(commentBody).toContain('does not match any configured agent');
+      expect(commentBody).toContain('security-auditor, perf-reviewer');
+
+      // No task should be created
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('agent_field not configured — no project query made', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: {
+          ...IMPLEMENT_CONFIG_WITH_AGENTS,
+          agent_field: undefined, // no agent_field
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makeIssueCommentPayload('/opencara go'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Implement the requested changes.');
+    });
+  });
+
+  // ── /opencara fix (comment trigger) ────────────────────────
+
+  describe('/opencara fix — comment trigger', () => {
+    it('explicit agent ID takes priority over field value', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer';
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara fix security-auditor'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('fix');
+      expect(tasks[0].config.prompt).toBe('Security fix audit.');
+    });
+
+    it('field value resolves to named agent when no explicit agent', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer';
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara fix'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalledWith(
+        'acme',
+        'widget',
+        42,
+        'Agent',
+        'ghs_mock_token',
+      );
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Performance fix.');
+      expect(tasks[0].config.preferredModels).toEqual(['gpt-5']);
+    });
+
+    it('empty field falls back to default fix config', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = null;
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara fix'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Fix the review comments.');
+    });
+
+    it('invalid field value posts error comment for fix', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'unknown-agent';
+
+      const res = await sendWebhook(
+        app,
+        'issue_comment',
+        makePrCommentPayload('/opencara fix'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.createIssueCommentSpy).toHaveBeenCalled();
+      const commentBody = github.createIssueCommentSpy.mock.calls[0][3];
+      expect(commentBody).toContain('unknown-agent');
+      expect(commentBody).toContain('does not match any configured agent');
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+  });
+
+  // ── Issue label triggers ───────────────────────────────────
+
+  describe('Issue label triggers', () => {
+    it('field value resolves agent on exact label match (no agent:xxx)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: {
+          ...IMPLEMENT_CONFIG_WITH_AGENTS,
+          trigger: { comment: '/opencara go', label: 'opencara:implement' },
+        },
+      };
+      github.projectFieldValue = 'security-auditor';
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        makeIssueLabelPayload('opencara:implement'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalledWith(
+        'acme',
+        'widget',
+        10,
+        'Agent',
+        'ghs_mock_token',
+      );
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].config.prompt).toBe('Security audit this.');
+    });
+
+    it('agent:xxx label takes priority over field value', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'security-auditor';
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        makeIssueLabelPayload('agent:perf-reviewer'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      // readProjectFieldValue should NOT be called when agent:xxx label is used
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Performance review.');
+    });
+
+    it('invalid field value posts error on label trigger', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: {
+          ...IMPLEMENT_CONFIG_WITH_AGENTS,
+          trigger: { comment: '/opencara go', label: 'opencara:implement' },
+        },
+      };
+      github.projectFieldValue = 'bad-agent';
+
+      const res = await sendWebhook(
+        app,
+        'issues',
+        makeIssueLabelPayload('opencara:implement'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.createIssueCommentSpy).toHaveBeenCalled();
+      const commentBody = github.createIssueCommentSpy.mock.calls[0][3];
+      expect(commentBody).toContain('bad-agent');
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+  });
+
+  // ── PR label triggers ──────────────────────────────────────
+
+  describe('PR label triggers', () => {
+    it('field value resolves agent on exact fix label match', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer';
+
+      const res = await sendWebhook(app, 'pull_request', makePRLabelPayload('opencara:fix'), env);
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalledWith(
+        'acme',
+        'widget',
+        42,
+        'Agent',
+        'ghs_mock_token',
+      );
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('fix');
+      expect(tasks[0].config.prompt).toBe('Performance fix.');
+    });
+
+    it('agent:xxx label takes priority over fix field value', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        fix: FIX_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer';
+
+      const res = await sendWebhook(
+        app,
+        'pull_request',
+        makePRLabelPayload('agent:security-auditor'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Security fix audit.');
+    });
+  });
+
+  // ── Status triggers ────────────────────────────────────────
+
+  describe('Status triggers (projects_v2_item)', () => {
+    it('field value resolves agent on status trigger', async () => {
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'perf-reviewer';
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).toHaveBeenCalledWith(
+        'acme',
+        'widget',
+        10,
+        'Agent',
+        'ghs_mock_token',
+      );
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].config.prompt).toBe('Performance review.');
+      expect(tasks[0].config.preferredModels).toEqual(['gpt-5']);
+    });
+
+    it('empty field falls back to default on status trigger', async () => {
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = null;
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Implement the requested changes.');
+      expect(tasks[0].config.preferredModels).toEqual([]);
+    });
+
+    it('invalid field value posts error on status trigger', async () => {
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'nonexistent';
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.createIssueCommentSpy).toHaveBeenCalled();
+      const commentBody = github.createIssueCommentSpy.mock.calls[0][3];
+      expect(commentBody).toContain('nonexistent');
+      expect(commentBody).toContain('does not match any configured agent');
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('no agent_field config — no project query on status trigger', async () => {
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: {
+          ...IMPLEMENT_CONFIG_WITH_AGENTS,
+          agent_field: undefined,
+        },
+      };
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      expect(github.readProjectFieldValueSpy).not.toHaveBeenCalled();
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].config.prompt).toBe('Implement the requested changes.');
+    });
+
+    it('status trigger passes target_model from resolved agent', async () => {
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        implement: IMPLEMENT_CONFIG_WITH_AGENTS,
+      };
+      github.projectFieldValue = 'security-auditor';
+
+      const res = await sendWebhook(
+        app,
+        'projects_v2_item',
+        makeProjectsV2ItemPayload('Ready'),
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].target_model).toBe('claude-opus');
+    });
+  });
+});

--- a/packages/server/src/__tests__/helpers/github-mock.ts
+++ b/packages/server/src/__tests__/helpers/github-mock.ts
@@ -332,6 +332,22 @@ export class MockGitHubService implements GitHubService {
     return this.resolveProjectItemResult;
   }
 
+  projectFieldValue: string | null = null;
+
+  async readProjectFieldValue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fieldName: string,
+    token: string,
+  ): Promise<string | null> {
+    this.calls.push({
+      method: 'readProjectFieldValue',
+      args: { owner, repo, issueNumber, fieldName, token },
+    });
+    return this.projectFieldValue;
+  }
+
   /** Count postPrComment calls (convenience for assertions). */
   get commentCount(): number {
     return this.calls.filter((c) => c.method === 'postPrComment').length;

--- a/packages/server/src/github/service.ts
+++ b/packages/server/src/github/service.ts
@@ -137,6 +137,19 @@ export interface GitHubService {
     nodeId: string,
     token: string,
   ): Promise<{ type: 'Issue' | 'PullRequest'; owner: string; repo: string; number: number } | null>;
+
+  /**
+   * Read a custom project field value from an issue's or PR's project item
+   * via the GitHub Projects V2 GraphQL API.
+   * Returns the field's text/single-select value, or null if not found.
+   */
+  readProjectFieldValue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fieldName: string,
+    token: string,
+  ): Promise<string | null>;
 }
 
 /**
@@ -496,6 +509,118 @@ export class RealGitHubService implements GitHubService {
       number: node.number,
     };
   }
+
+  async readProjectFieldValue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fieldName: string,
+    token: string,
+  ): Promise<string | null> {
+    // Use GraphQL to find the issue's project items and read the named field value.
+    // The query traverses: repository → issue → projectItems → fieldValues,
+    // looking for a field matching fieldName.
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          issueOrPullRequest(number: $number) {
+            ... on Issue {
+              projectItems(first: 10) {
+                nodes {
+                  fieldValues(first: 20) {
+                    nodes {
+                      ... on ProjectV2ItemFieldTextValue {
+                        text
+                        field { ... on ProjectV2Field { name } }
+                      }
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                        field { ... on ProjectV2SingleSelectField { name } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ... on PullRequest {
+              projectItems(first: 10) {
+                nodes {
+                  fieldValues(first: 20) {
+                    nodes {
+                      ... on ProjectV2ItemFieldTextValue {
+                        text
+                        field { ... on ProjectV2Field { name } }
+                      }
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                        field { ... on ProjectV2SingleSelectField { name } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const response = await githubFetch('https://api.github.com/graphql', {
+      method: 'POST',
+      token,
+      body: JSON.stringify({
+        query,
+        variables: { owner, repo, number: issueNumber },
+      }),
+    });
+
+    if (!response.ok) {
+      this.logger.warn('GraphQL query failed for project field value', {
+        status: response.status,
+        owner,
+        repo,
+        issueNumber,
+        fieldName,
+      });
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      data?: {
+        repository?: {
+          issueOrPullRequest?: {
+            projectItems?: {
+              nodes: Array<{
+                fieldValues: {
+                  nodes: Array<{
+                    text?: string;
+                    name?: string;
+                    field?: { name: string };
+                  }>;
+                };
+              }>;
+            };
+          };
+        };
+      };
+    };
+
+    const projectItems = data.data?.repository?.issueOrPullRequest?.projectItems?.nodes;
+    if (!projectItems) return null;
+
+    // Search across all project items for the named field
+    for (const item of projectItems) {
+      for (const fieldValue of item.fieldValues.nodes) {
+        if (fieldValue.field?.name === fieldName) {
+          // Text fields use .text, single-select fields use .name
+          const value = fieldValue.text ?? fieldValue.name;
+          if (value && value.trim().length > 0) return value.trim();
+        }
+      }
+    }
+
+    return null;
+  }
 }
 
 /**
@@ -678,6 +803,21 @@ export class NoOpGitHubService implements GitHubService {
     number: number;
   } | null> {
     this.logger.info('Dev mode — returning null for project item content', { nodeId });
+    return null;
+  }
+
+  async readProjectFieldValue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+    fieldName: string,
+  ): Promise<string | null> {
+    this.logger.info('Dev mode — returning null for project field value', {
+      owner,
+      repo,
+      issueNumber,
+      fieldName,
+    });
     return null;
   }
 }

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -6,6 +6,7 @@ import type {
   Feature,
   TaskRole,
   ReviewTask,
+  NamedAgentConfig,
 } from '@opencara/shared';
 import {
   DEFAULT_REVIEW_CONFIG,
@@ -1161,6 +1162,65 @@ export function parseAgentLabel(label: string): string | undefined {
 }
 
 /**
+ * Resolve a named agent from the project board field value.
+ * Used as a fallback when no explicit agent ID is provided via command or label.
+ *
+ * Returns:
+ * - { agent, error: false } if field value resolves to a named agent
+ * - { agent: undefined, error: false } if field is empty/not set (use default)
+ * - { agent: undefined, error: true } if field value doesn't match any agent (caller should post error)
+ * - { agent: undefined, error: false, fieldValue: undefined } if agent_field is not configured
+ */
+async function resolveAgentFromProjectField(
+  github: GitHubService,
+  config: { agents?: NamedAgentConfig[]; agent_field?: string },
+  owner: string,
+  repo: string,
+  issueOrPrNumber: number,
+  token: string,
+  logger: Logger,
+): Promise<{
+  agent: NamedAgentConfig | undefined;
+  error: boolean;
+  fieldValue: string | undefined;
+}> {
+  if (!config.agent_field) {
+    return { agent: undefined, error: false, fieldValue: undefined };
+  }
+
+  let fieldValue: string | null;
+  try {
+    fieldValue = await github.readProjectFieldValue(
+      owner,
+      repo,
+      issueOrPrNumber,
+      config.agent_field,
+      token,
+    );
+  } catch (err) {
+    logger.warn('Failed to read project field value', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      number: issueOrPrNumber,
+      fieldName: config.agent_field,
+    });
+    return { agent: undefined, error: false, fieldValue: undefined };
+  }
+
+  if (!fieldValue) {
+    return { agent: undefined, error: false, fieldValue: undefined };
+  }
+
+  const agent = resolveNamedAgent(config, fieldValue);
+  if (!agent) {
+    return { agent: undefined, error: true, fieldValue };
+  }
+
+  return { agent, error: false, fieldValue };
+}
+
+/**
  * Parse a triage command from a comment body.
  * Matches `/opencara triage [model]` or `@opencara triage [model]`.
  * Returns the optional target model, or null if not a triage command.
@@ -1406,8 +1466,8 @@ async function handleFixCommand(
 
   const fixConfig = fullConfig.fix;
 
-  // Resolve named agent if specified
-  const agent = fixCmd.targetAgent ? resolveNamedAgent(fixConfig, fixCmd.targetAgent) : undefined;
+  // Resolve named agent: explicit command argument takes priority
+  let agent = fixCmd.targetAgent ? resolveNamedAgent(fixConfig, fixCmd.targetAgent) : undefined;
 
   if (fixCmd.targetAgent && !agent) {
     await github.createIssueComment(
@@ -1418,6 +1478,33 @@ async function handleFixCommand(
       token,
     );
     return new Response('OK', { status: 200 });
+  }
+
+  // Fallback: if no explicit agent, try project board field
+  if (!fixCmd.targetAgent && fixConfig.agent_field) {
+    const fieldResult = await resolveAgentFromProjectField(
+      github,
+      fixConfig,
+      owner,
+      repo,
+      prNumber,
+      token,
+      logger,
+    );
+    if (fieldResult.error) {
+      const availableIds = fixConfig.agents?.map((a) => a.id).join(', ') ?? 'none';
+      await github.createIssueComment(
+        owner,
+        repo,
+        prNumber,
+        `⚠️ Project field "${fixConfig.agent_field}" value \`${fieldResult.fieldValue}\` does not match any configured agent. Available: ${availableIds}`,
+        token,
+      );
+      return new Response('OK', { status: 200 });
+    }
+    if (fieldResult.agent) {
+      agent = fieldResult.agent;
+    }
   }
 
   logger.info('Fix command received', {
@@ -1586,10 +1673,8 @@ async function handleGoCommand(
 
   const implementConfig = fullConfig.implement;
 
-  // Resolve named agent if specified
-  const agent = goCmd.targetAgent
-    ? resolveNamedAgent(implementConfig, goCmd.targetAgent)
-    : undefined;
+  // Resolve named agent: explicit command argument takes priority
+  let agent = goCmd.targetAgent ? resolveNamedAgent(implementConfig, goCmd.targetAgent) : undefined;
 
   if (goCmd.targetAgent && !agent) {
     await github.createIssueComment(
@@ -1600,6 +1685,33 @@ async function handleGoCommand(
       token,
     );
     return new Response('OK', { status: 200 });
+  }
+
+  // Fallback: if no explicit agent, try project board field
+  if (!goCmd.targetAgent && implementConfig.agent_field) {
+    const fieldResult = await resolveAgentFromProjectField(
+      github,
+      implementConfig,
+      owner,
+      repo,
+      issueNumber,
+      token,
+      logger,
+    );
+    if (fieldResult.error) {
+      const availableIds = implementConfig.agents?.map((a) => a.id).join(', ') ?? 'none';
+      await github.createIssueComment(
+        owner,
+        repo,
+        issueNumber,
+        `⚠️ Project field "${implementConfig.agent_field}" value \`${fieldResult.fieldValue}\` does not match any configured agent. Available: ${availableIds}`,
+        token,
+      );
+      return new Response('OK', { status: 200 });
+    }
+    if (fieldResult.agent) {
+      agent = fieldResult.agent;
+    }
   }
 
   // Fetch issue details from GitHub API
@@ -1903,7 +2015,7 @@ async function handlePrLabelTrigger(
     const fixConfig = fullConfig.fix;
 
     // Resolve named agent from label
-    const agent = agentIdFromLabel ? resolveNamedAgent(fixConfig, agentIdFromLabel) : undefined;
+    let agent = agentIdFromLabel ? resolveNamedAgent(fixConfig, agentIdFromLabel) : undefined;
 
     if (agentIdFromLabel && !agent && !isExactFixLabelMatch) {
       logger.warn('agent:xxx label does not match any configured fix agent', {
@@ -1918,6 +2030,33 @@ async function handlePrLabelTrigger(
         token,
       );
       return new Response('OK', { status: 200 });
+    }
+
+    // Fallback: if no agent from label, try project board field
+    if (!agent && !agentIdFromLabel && fixConfig.agent_field) {
+      const fieldResult = await resolveAgentFromProjectField(
+        github,
+        fixConfig,
+        owner,
+        repo,
+        prNumber,
+        token,
+        logger,
+      );
+      if (fieldResult.error) {
+        const availableIds = fixConfig.agents?.map((a) => a.id).join(', ') ?? 'none';
+        await github.createIssueComment(
+          owner,
+          repo,
+          prNumber,
+          `⚠️ Project field "${fixConfig.agent_field}" value \`${fieldResult.fieldValue}\` does not match any configured agent. Available: ${availableIds}`,
+          token,
+        );
+        return new Response('OK', { status: 200 });
+      }
+      if (fieldResult.agent) {
+        agent = fieldResult.agent;
+      }
     }
 
     logger.info('Fix label trigger matched', {
@@ -2023,9 +2162,7 @@ async function handleIssueLabelTrigger(
     const implementConfig = fullConfig.implement;
 
     // Resolve named agent from label
-    const agent = agentIdFromLabel
-      ? resolveNamedAgent(implementConfig, agentIdFromLabel)
-      : undefined;
+    let agent = agentIdFromLabel ? resolveNamedAgent(implementConfig, agentIdFromLabel) : undefined;
 
     if (agentIdFromLabel && !agent && !isExactLabelMatch) {
       logger.warn('agent:xxx label does not match any configured implement agent', {
@@ -2040,6 +2177,33 @@ async function handleIssueLabelTrigger(
         token,
       );
       return new Response('OK', { status: 200 });
+    }
+
+    // Fallback: if no agent from label, try project board field
+    if (!agent && !agentIdFromLabel && implementConfig.agent_field) {
+      const fieldResult = await resolveAgentFromProjectField(
+        github,
+        implementConfig,
+        owner,
+        repo,
+        issue.number,
+        token,
+        logger,
+      );
+      if (fieldResult.error) {
+        const availableIds = implementConfig.agents?.map((a) => a.id).join(', ') ?? 'none';
+        await github.createIssueComment(
+          owner,
+          repo,
+          issue.number,
+          `⚠️ Project field "${implementConfig.agent_field}" value \`${fieldResult.fieldValue}\` does not match any configured agent. Available: ${availableIds}`,
+          token,
+        );
+        return new Response('OK', { status: 200 });
+      }
+      if (fieldResult.agent) {
+        agent = fieldResult.agent;
+      }
     }
 
     logger.info('Implement label trigger matched', {
@@ -2243,13 +2407,44 @@ async function handleProjectsV2Item(
     const implementConfig = fullConfig.implement;
     const timeoutMs = parseTimeoutMs(implementConfig.timeout);
 
+    // Resolve agent from project board field if configured
+    let agent: NamedAgentConfig | undefined;
+    if (implementConfig.agent_field) {
+      const fieldResult = await resolveAgentFromProjectField(
+        github,
+        implementConfig,
+        owner,
+        repo,
+        number,
+        token,
+        logger,
+      );
+      if (fieldResult.error) {
+        const availableIds = implementConfig.agents?.map((a) => a.id).join(', ') ?? 'none';
+        await github.createIssueComment(
+          owner,
+          repo,
+          number,
+          `⚠️ Project field "${implementConfig.agent_field}" value \`${fieldResult.fieldValue}\` does not match any configured agent. Available: ${availableIds}`,
+          token,
+        );
+        return new Response('OK', { status: 200 });
+      }
+      agent = fieldResult.agent;
+    }
+
+    const agentPrompt = agent?.prompt ?? implementConfig.prompt;
+    const agentPreferredModels = agent?.model ? [agent.model] : implementConfig.preferredModels;
+    const agentPreferredTools = agent?.tool ? [agent.tool] : implementConfig.preferredTools;
+    const targetModel = agent?.model;
+
     const implementTaskConfig: ReviewConfig = {
       ...reviewConfig,
       agentCount: implementConfig.agentCount,
       timeout: implementConfig.timeout,
-      preferredModels: implementConfig.preferredModels,
-      preferredTools: implementConfig.preferredTools,
-      prompt: implementConfig.prompt,
+      preferredModels: agentPreferredModels,
+      preferredTools: agentPreferredTools,
+      prompt: agentPrompt,
       modelDiversityGraceMs: implementConfig.modelDiversityGraceMs,
     };
 
@@ -2278,6 +2473,7 @@ async function handleProjectsV2Item(
         issue_title: issue.title,
         issue_body: issue.body ?? undefined,
         issue_author: issue.user.login,
+        ...(targetModel ? { target_model: targetModel } : {}),
       });
     } catch (err) {
       logger.error('Failed to create implement task group from status trigger', {


### PR DESCRIPTION
Part of #681

## Summary
- Added `readProjectFieldValue()` to `GitHubService` interface and both implementations (`RealGitHubService` with GraphQL, `NoOpGitHubService` returns null)
- Added `resolveAgentFromProjectField()` helper to avoid code duplication across trigger handlers
- Updated all implement/fix trigger paths (comment, label, status) to fall back to `agent_field` project lookup when no explicit agent is specified
- Priority order: explicit command arg > `agent:xxx` label > `agent_field` value > default config
- Invalid field values post an error comment listing available agent IDs
- Empty/missing field values gracefully fall back to default config

## Test plan
- 16 new tests in `agent-field-resolve.test.ts` covering:
  - Explicit agent overrides field value (go and fix commands)
  - Field value resolves to named agent (all trigger paths)
  - Empty/missing field falls back to default config
  - Invalid field value posts error comment
  - `agent_field` not configured = no project query made
  - `agent:xxx` label takes priority over field value
  - Status trigger passes `target_model` from resolved agent
- All 2753 existing tests pass
- Build, lint, typecheck, format all pass