### PR TITLE
[server-dev] Handle issue review triggers in webhook handler

### DIFF
--- a/packages/server/src/__tests__/trigger-modes.test.ts
+++ b/packages/server/src/__tests__/trigger-modes.test.ts
@@ -22,7 +22,7 @@ import { MemoryDataStore } from '../store/memory.js';
 import { createApp } from '../index.js';
 import { resetRateLimits } from '../middleware/rate-limit.js';
 import { resetTimeoutThrottle } from '../routes/tasks.js';
-import { parseTriageCommand } from '../routes/webhook.js';
+import { parseTriageCommand, parseIssueReviewCommand } from '../routes/webhook.js';
 
 // ── Helpers ────────────────────────────────────────────────────
 
@@ -128,6 +128,9 @@ class TestGitHubService implements GitHubService {
     number: number;
   } | null> {
     return this.resolveProjectItemResult;
+  }
+  async readProjectFieldValue(): Promise<string | null> {
+    return null;
   }
 }
 
@@ -318,6 +321,17 @@ const DEFAULT_FIX_CONFIG = {
   preferredTools: [] as string[],
   modelDiversityGraceMs: 30_000,
   trigger: { comment: '/opencara fix' },
+};
+
+const DEFAULT_ISSUE_REVIEW_CONFIG = {
+  enabled: true,
+  prompt: 'Review this issue for clarity, completeness, and actionability.',
+  agentCount: 2,
+  timeout: '5m',
+  preferredModels: [] as string[],
+  preferredTools: [] as string[],
+  modelDiversityGraceMs: 30_000,
+  trigger: { comment: '/opencara review-issue' },
 };
 
 // ── Tests ──────────────────────────────────────────────────────
@@ -1605,6 +1619,578 @@ describe('Unified trigger modes', () => {
       const prTasks = await store.listTasks();
       expect(prTasks).toHaveLength(1);
       expect(prTasks[0].feature).toBe('review');
+    });
+  });
+
+  // ── parseIssueReviewCommand ───────────────────────────────────
+
+  describe('parseIssueReviewCommand', () => {
+    it('parses /opencara review-issue', () => {
+      expect(parseIssueReviewCommand('/opencara review-issue')).toEqual({});
+    });
+
+    it('parses @opencara review-issue', () => {
+      expect(parseIssueReviewCommand('@opencara review-issue')).toEqual({});
+    });
+
+    it('parses /opencara review (bare)', () => {
+      expect(parseIssueReviewCommand('/opencara review')).toEqual({});
+    });
+
+    it('parses @opencara review (bare)', () => {
+      expect(parseIssueReviewCommand('@opencara review')).toEqual({});
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseIssueReviewCommand('/OpenCara Review-Issue')).toEqual({});
+      expect(parseIssueReviewCommand('/OPENCARA REVIEW')).toEqual({});
+    });
+
+    it('handles leading/trailing whitespace', () => {
+      expect(parseIssueReviewCommand('  /opencara review-issue  ')).toEqual({});
+      expect(parseIssueReviewCommand('  /opencara review  ')).toEqual({});
+    });
+
+    it('returns null for non-review commands', () => {
+      expect(parseIssueReviewCommand('/opencara triage')).toBeNull();
+      expect(parseIssueReviewCommand('/opencara go')).toBeNull();
+      expect(parseIssueReviewCommand('/opencara fix')).toBeNull();
+      expect(parseIssueReviewCommand('hello world')).toBeNull();
+      expect(parseIssueReviewCommand('')).toBeNull();
+    });
+
+    it('returns null for review with extra arguments', () => {
+      expect(parseIssueReviewCommand('/opencara review-issue extra')).toBeNull();
+      expect(parseIssueReviewCommand('/opencara review extra')).toBeNull();
+    });
+  });
+
+  // ── Issue Review Triggers ──────────────────────────────────────
+
+  describe('Issue review triggers', () => {
+    it('comment trigger: /opencara review-issue creates issue_review task group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { comment: '/opencara review-issue' },
+        },
+      };
+
+      const payload = makeIssueCommentPayload('/opencara review-issue');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+      expect(tasks[0].issue_number).toBe(10);
+      expect(tasks[0].issue_title).toBe('Test issue #10');
+    });
+
+    it('comment trigger: /opencara review on issue creates issue_review tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig(),
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { comment: '/opencara review-issue' },
+        },
+      };
+
+      const payload = makeIssueCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+    });
+
+    it('comment trigger on PR still creates review tasks (no regression)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        review: makeReviewConfig({
+          trigger: { comment: '/opencara review' },
+        }),
+        issue_review: DEFAULT_ISSUE_REVIEW_CONFIG,
+      };
+
+      const payload = makePrCommentPayload('/opencara review');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      // PR comment should create review tasks, NOT issue_review
+      expect(tasks.every((t) => t.feature === 'review')).toBe(true);
+    });
+
+    it('comment trigger ignored for untrusted users', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { comment: '/opencara review-issue' },
+        },
+      };
+
+      const payload = makeIssueCommentPayload('/opencara review-issue', {
+        comment: {
+          body: '/opencara review-issue',
+          user: { login: 'stranger' },
+          author_association: 'NONE',
+        },
+      });
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('comment trigger ignored when issue_review disabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          enabled: false,
+          trigger: { comment: '/opencara review-issue' },
+        },
+      };
+
+      const payload = makeIssueCommentPayload('/opencara review-issue');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('comment trigger ignored when comment trigger not enabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          // No comment in trigger → not enabled
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = makeIssueCommentPayload('/opencara review-issue');
+      const res = await sendWebhook(app, 'issue_comment', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('event trigger: issues.opened creates issue_review task group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'New feature request',
+          body: 'Please add feature X',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+      expect(tasks[0].issue_number).toBe(15);
+      expect(tasks[0].issue_title).toBe('New feature request');
+      expect(tasks[0].issue_body).toBe('Please add feature X');
+      expect(tasks[0].issue_author).toBe('alice');
+    });
+
+    it('event trigger: issues.edited creates issue_review task group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { events: ['opened', 'edited'] },
+        },
+      };
+
+      const payload = {
+        action: 'edited',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'Updated feature request',
+          body: 'Please add feature Y',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+    });
+
+    it('event trigger: no tasks when issue_review not in config', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        // No issue_review section
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'New feature request',
+          body: 'Please add feature X',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('event trigger: no tasks when issue_review disabled', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          enabled: false,
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'New feature request',
+          body: 'Please add feature X',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('event trigger: skips PR events (issues with pull_request field)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 42,
+          html_url: 'https://github.com/acme/widget/pull/42',
+          title: 'PR title',
+          body: 'PR body',
+          user: { login: 'alice' },
+          pull_request: { url: 'https://api.github.com/repos/acme/widget/pulls/42' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('label trigger: creates issue_review task group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { label: 'needs-review' },
+        },
+      };
+
+      const payload = makeIssueLabelPayload('needs-review');
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+      expect(tasks[0].issue_number).toBe(10);
+    });
+
+    it('label trigger: no tasks when label does not match', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { label: 'needs-review' },
+        },
+      };
+
+      const payload = makeIssueLabelPayload('other-label');
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('status trigger: creates issue_review task group', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { status: 'Needs Review' },
+        },
+      };
+
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 20,
+      };
+
+      const payload = makeProjectsV2ItemPayload('Needs Review');
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks.length).toBeGreaterThan(0);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+      expect(tasks[0].issue_number).toBe(20);
+    });
+
+    it('status trigger: no tasks for PR items', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { status: 'Needs Review' },
+        },
+      };
+
+      github.resolveProjectItemResult = {
+        type: 'PullRequest',
+        owner: 'acme',
+        repo: 'widget',
+        number: 42,
+      };
+
+      const payload = makeProjectsV2ItemPayload('Needs Review');
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('status trigger: no tasks when status does not match', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { status: 'Needs Review' },
+        },
+      };
+
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 20,
+      };
+
+      const payload = makeProjectsV2ItemPayload('In Progress');
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('issue_review tasks have correct task_type (issue_review)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          agentCount: 1, // single agent → task_type should be issue_review
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'Test issue',
+          body: 'Body',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].task_type).toBe('issue_review');
+    });
+
+    it('multi-agent issue_review creates worker + summary tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          agentCount: 3, // 3 agents → 2 worker tasks (issue_review type)
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'Test issue',
+          body: 'Body',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      // agentCount=3 → taskCount = 3-1 = 2 worker tasks
+      expect(tasks).toHaveLength(2);
+      expect(tasks.every((t) => t.feature === 'issue_review')).toBe(true);
+      expect(tasks.every((t) => t.task_type === 'issue_review')).toBe(true);
+    });
+
+    it('combined triggers: event + triage both create tasks', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        triage: {
+          ...DEFAULT_TRIAGE_CONFIG,
+          trigger: { events: ['opened'] },
+        },
+        issue_review: {
+          ...DEFAULT_ISSUE_REVIEW_CONFIG,
+          trigger: { events: ['opened'] },
+        },
+      };
+
+      const payload = {
+        action: 'opened',
+        installation: { id: 999 },
+        repository: {
+          owner: { login: 'acme' },
+          name: 'widget',
+          default_branch: 'main',
+          private: false,
+        },
+        issue: {
+          number: 15,
+          html_url: 'https://github.com/acme/widget/issues/15',
+          title: 'New issue',
+          body: 'Body',
+          user: { login: 'alice' },
+          labels: [],
+        },
+      };
+
+      const res = await sendWebhook(app, 'issues', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      const features = tasks.map((t) => t.feature);
+      expect(features).toContain('triage');
+      expect(features).toContain('issue_review');
     });
   });
 });

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -644,6 +644,53 @@ async function handleFixSummaryResult(
 }
 
 /**
+ * Handle issue review summary result — post comment on the issue with
+ * "OpenCara Issue Review" title and contributor attribution.
+ */
+async function handleIssueReviewSummaryResult(
+  store: DataStore,
+  github: GitHubService,
+  task: ReviewTask,
+  groupId: string,
+  reviewText: string,
+  logger: Logger,
+): Promise<void> {
+  if (!task.issue_number) {
+    throw new Error(`Issue review result but no issue_number on task ${task.id}`);
+  }
+
+  // Collect unique contributors from all claims in the group
+  let contributors: string[] = [];
+  try {
+    const groupTasks = await store.getTasksByGroup(groupId);
+    for (const gt of groupTasks) {
+      const claims = await store.getClaims(gt.id);
+      for (const c of claims) {
+        if (c.github_username) contributors.push(c.github_username);
+      }
+    }
+    contributors = [...new Set(contributors)];
+  } catch {
+    // Non-fatal — post review without contributor attribution
+  }
+
+  const token = await github.getInstallationToken(task.github_installation_id);
+  const commentBody = wrapReviewComment(
+    reviewText.trim(),
+    contributors.length > 0 ? contributors : undefined,
+    'OpenCara Issue Review',
+  );
+  await github.postPrComment(task.owner, task.repo, task.issue_number, commentBody, token);
+
+  logger.info('Issue review result posted to GitHub', {
+    taskId: task.id,
+    owner: task.owner,
+    repo: task.repo,
+    issueNumber: task.issue_number,
+  });
+}
+
+/**
  * Post a fallback consolidated review to GitHub when all summary retries are exhausted.
  * Uses the timeout-style format: individual reviews concatenated.
  */
@@ -1585,6 +1632,16 @@ export function taskRoutes() {
               task,
               task.group_id,
               fix_report as FixReport | undefined,
+              review_text,
+              logger,
+            );
+            break;
+          case 'issue_review':
+            await handleIssueReviewSummaryResult(
+              store,
+              github,
+              task,
+              task.group_id,
               review_text,
               logger,
             );

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -195,6 +195,7 @@ const FEATURE_ROLE_MAP: Partial<Record<Feature, TaskRole>> = {
   triage: 'issue_triage',
   implement: 'implement',
   fix: 'fix',
+  issue_review: 'issue_review',
 };
 
 /**
@@ -421,7 +422,7 @@ async function createPrTaskGroups(
 }
 
 /**
- * Create task groups for an issue event: triage + dedup.issues.
+ * Create task groups for an issue event: triage + dedup.issues + issue_review.
  */
 async function createIssueTaskGroups(
   store: DataStore,
@@ -501,6 +502,30 @@ async function createIssueTaskGroups(
           : {}),
       },
       primaryCreated, // true if triage group was created → skip dedup
+    );
+  }
+
+  // Issue review task group (event trigger)
+  if (
+    fullConfig.issue_review?.enabled &&
+    isEventTriggerEnabled(fullConfig.issue_review.trigger) &&
+    fullConfig.issue_review.trigger.events!.includes(action)
+  ) {
+    const issueReviewConfig = fullConfig.issue_review;
+    const irBaseTask = {
+      ...baseTask,
+      review_count: issueReviewConfig.agentCount,
+      timeout_at: Date.now() + parseTimeoutMs(issueReviewConfig.timeout),
+      queue: (issueReviewConfig.agentCount > 1 ? 'review' : 'summary') as ReviewTask['queue'],
+    };
+    await createTaskGroup(
+      store,
+      'issue_review',
+      issueReviewConfig,
+      irBaseTask,
+      logger,
+      issueFields,
+      primaryCreated,
     );
   }
 }
@@ -996,8 +1021,12 @@ export async function handleIssueEvent(
     isEventTriggerEnabled(fullConfig.triage.trigger) &&
     fullConfig.triage.trigger.events!.includes(action);
   const dedupIssuesEnabled = fullConfig.dedup?.issues?.enabled;
+  const issueReviewEnabled =
+    fullConfig.issue_review?.enabled &&
+    isEventTriggerEnabled(fullConfig.issue_review.trigger) &&
+    fullConfig.issue_review.trigger.events!.includes(action);
 
-  if (!triageEnabled && !dedupIssuesEnabled) {
+  if (!triageEnabled && !dedupIssuesEnabled && !issueReviewEnabled) {
     logger.info('No issue features enabled — skipping', {
       owner,
       repo,
@@ -1260,6 +1289,21 @@ export function parseTriageCommand(body: string): { targetModel?: string } | nul
   return { targetModel: match[1] || undefined };
 }
 
+/**
+ * Parse an issue review command from a comment body.
+ * Matches `/opencara review-issue` or `@opencara review-issue`.
+ * Also matches `/opencara review` or `@opencara review` (when used on issues).
+ * Returns an empty object if matched, null if not.
+ */
+export function parseIssueReviewCommand(body: string): Record<string, never> | null {
+  const trimmed = body.trim();
+  // Match /opencara review-issue or @opencara review-issue
+  if (/^[/@]opencara\s+review-issue\s*$/i.test(trimmed)) return {};
+  // Match /opencara review or @opencara review (bare, no subcommand)
+  if (/^[/@]opencara\s+review\s*$/i.test(trimmed)) return {};
+  return null;
+}
+
 async function handleIssueComment(
   github: GitHubService,
   store: DataStore,
@@ -1273,7 +1317,7 @@ async function handleIssueComment(
     return new Response('OK', { status: 200 });
   }
 
-  // Issue-only commands: go and triage (not valid on PRs)
+  // Issue-only commands: go, triage, and issue review (not valid on PRs)
   if (!issue.pull_request) {
     const goCmd = parseGoCommand(comment.body);
     if (goCmd) {
@@ -1304,6 +1348,22 @@ async function handleIssueComment(
         repository.default_branch ?? 'main',
         comment,
         triageCmd,
+        repository.private ?? false,
+        logger,
+      );
+    }
+
+    const issueReviewCmd = parseIssueReviewCommand(comment.body);
+    if (issueReviewCmd) {
+      return handleIssueReviewCommand(
+        github,
+        store,
+        installation.id,
+        repository.owner.login,
+        repository.name,
+        issue.number,
+        repository.default_branch ?? 'main',
+        comment,
         repository.private ?? false,
         logger,
       );
@@ -2034,6 +2094,145 @@ async function handleTriageCommand(
   return new Response('OK', { status: 200 });
 }
 
+/**
+ * Handle `/opencara review-issue` or `/opencara review` command on an issue comment.
+ * Creates an issue_review task group with issue context.
+ */
+async function handleIssueReviewCommand(
+  github: GitHubService,
+  store: DataStore,
+  installationId: number,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  defaultBranch: string,
+  comment: IssueCommentPayload['comment'],
+  isPrivate: boolean,
+  logger: Logger,
+): Promise<Response> {
+  if (!TRUSTED_ASSOCIATIONS.has(comment.author_association)) {
+    logger.info('Issue review command ignored — not a trusted contributor', {
+      owner,
+      repo,
+      issueNumber,
+      user: comment.user.login,
+      association: comment.author_association,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  logger.info('Issue review command received', {
+    user: comment.user.login,
+    owner,
+    repo,
+    issueNumber,
+  });
+
+  let token: string;
+  try {
+    token = await github.getInstallationToken(installationId);
+  } catch (err) {
+    logger.error('Failed to get installation token', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const { config: fullConfig, parseError } = await github.loadOpenCaraConfig(
+    owner,
+    repo,
+    defaultBranch,
+    token,
+  );
+
+  if (parseError) {
+    logger.info('Aborting issue review command due to .opencara.toml parse error', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  if (!fullConfig.issue_review?.enabled) {
+    logger.info('Issue review command ignored — [issue_review].enabled is not true', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  if (!isCommentTriggerEnabled(fullConfig.issue_review.trigger)) {
+    logger.info('Issue review command ignored — comment trigger not enabled', {
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('OK', { status: 200 });
+  }
+
+  // Fetch issue details from GitHub API
+  let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
+  try {
+    issue = await github.fetchIssueDetails(owner, repo, issueNumber, token);
+  } catch (err) {
+    logger.error('Failed to fetch issue details', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+  if (!issue) {
+    logger.error('Issue not found', { owner, repo, issueNumber });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  const issueReviewConfig = fullConfig.issue_review;
+  const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+  const timeoutMs = parseTimeoutMs(issueReviewConfig.timeout);
+
+  const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+    owner,
+    repo,
+    pr_number: 0,
+    pr_url: '',
+    diff_url: '',
+    base_ref: '',
+    head_ref: '',
+    review_count: issueReviewConfig.agentCount,
+    timeout_at: Date.now() + timeoutMs,
+    status: 'pending',
+    queue: issueReviewConfig.agentCount > 1 ? 'review' : 'summary',
+    github_installation_id: installationId,
+    private: isPrivate,
+    config: reviewConfig,
+    created_at: Date.now(),
+  };
+
+  try {
+    await createTaskGroup(store, 'issue_review', issueReviewConfig, baseTask, logger, {
+      issue_number: issue.number,
+      issue_url: issue.html_url,
+      issue_title: issue.title,
+      issue_body: issue.body ?? undefined,
+      issue_author: issue.user.login,
+    });
+  } catch (err) {
+    logger.error('Failed to create issue review task group', {
+      error: err instanceof Error ? err.message : String(err),
+      owner,
+      repo,
+      issueNumber,
+    });
+    return new Response('Service Unavailable', { status: 503 });
+  }
+
+  return new Response('OK', { status: 200 });
+}
+
 // ── Label Trigger Handlers ──────────────────────────────────────
 
 /**
@@ -2432,6 +2631,40 @@ async function handleIssueLabelTrigger(
     );
   }
 
+  // Issue review label trigger
+  if (
+    fullConfig.issue_review?.enabled &&
+    isLabelTriggerEnabled(fullConfig.issue_review.trigger) &&
+    fullConfig.issue_review.trigger.label === addedLabel
+  ) {
+    logger.info('Issue review label trigger matched', {
+      owner,
+      repo,
+      issueNumber: issue.number,
+      label: addedLabel,
+    });
+
+    const issueReviewConfig = fullConfig.issue_review;
+    const irTimeoutMs = parseTimeoutMs(issueReviewConfig.timeout);
+    const irBaseTask = {
+      ...baseTask,
+      review_count: issueReviewConfig.agentCount,
+      timeout_at: Date.now() + irTimeoutMs,
+      queue: (issueReviewConfig.agentCount > 1 ? 'review' : 'summary') as ReviewTask['queue'],
+    };
+
+    const groupId = await createTaskGroup(
+      store,
+      'issue_review',
+      issueReviewConfig,
+      irBaseTask,
+      logger,
+      issueFields,
+      created,
+    );
+    if (groupId !== null) created = true;
+  }
+
   if (!created) {
     logger.info('Issue label did not match any trigger — no tasks created', {
       owner,
@@ -2624,6 +2857,75 @@ async function handleProjectsV2Item(
       });
     } catch (err) {
       logger.error('Failed to create implement task group from status trigger', {
+        error: err instanceof Error ? err.message : String(err),
+        owner,
+        repo,
+        issueNumber: number,
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+  }
+
+  // Issue review status trigger (issues only)
+  if (
+    type === 'Issue' &&
+    fullConfig.issue_review?.enabled &&
+    isStatusTriggerEnabled(fullConfig.issue_review.trigger) &&
+    fullConfig.issue_review.trigger.status === newStatus
+  ) {
+    logger.info('Issue review status trigger matched', {
+      owner,
+      repo,
+      issueNumber: number,
+      status: newStatus,
+    });
+
+    let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
+    try {
+      issue = await github.fetchIssueDetails(owner, repo, number, token);
+    } catch (err) {
+      logger.error('Failed to fetch issue details for issue review status trigger', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+    if (!issue) {
+      logger.error('Issue not found for issue review status trigger', { owner, repo, number });
+      return new Response('Service Unavailable', { status: 503 });
+    }
+
+    const reviewConfig = fullConfig.review ?? DEFAULT_REVIEW_CONFIG;
+    const issueReviewConfig = fullConfig.issue_review;
+    const timeoutMs = parseTimeoutMs(issueReviewConfig.timeout);
+
+    const baseTask: Omit<ReviewTask, 'id' | 'prompt' | 'task_type' | 'feature' | 'group_id'> = {
+      owner,
+      repo,
+      pr_number: 0,
+      pr_url: '',
+      diff_url: '',
+      base_ref: '',
+      head_ref: '',
+      review_count: issueReviewConfig.agentCount,
+      timeout_at: Date.now() + timeoutMs,
+      status: 'pending',
+      queue: issueReviewConfig.agentCount > 1 ? 'review' : 'summary',
+      github_installation_id: installation.id,
+      private: false,
+      config: reviewConfig,
+      created_at: Date.now(),
+    };
+
+    try {
+      await createTaskGroup(store, 'issue_review', issueReviewConfig, baseTask, logger, {
+        issue_number: issue.number,
+        issue_url: issue.html_url,
+        issue_title: issue.title,
+        issue_body: issue.body ?? undefined,
+        issue_author: issue.user.login,
+      });
+    } catch (err) {
+      logger.error('Failed to create issue review task group from status trigger', {
         error: err instanceof Error ? err.message : String(err),
         owner,
         repo,


### PR DESCRIPTION
Part of #687

## Summary
- Add issue_review task group creation for all trigger paths: comment (`/opencara review-issue`, `/opencara review` on issues), event (`issues.opened`/`issues.edited`), label, and status triggers
- Add `handleIssueReviewSummaryResult` in tasks.ts to post "OpenCara Issue Review" comment with contributor attribution
- Add `parseIssueReviewCommand` to parse both `/opencara review-issue` and `/opencara review` on issues
- PR review behavior unchanged (no regression)

## Test plan
- Comment trigger creates issue_review task group on issues
- `/opencara review` on PRs still creates PR review (no regression)
- Event trigger on issues.opened/edited creates task group
- Label trigger creates task group
- Status trigger creates task group
- Disabled/absent issue_review config -> no task group created
- Untrusted users ignored
- Multi-agent issue_review creates correct number of worker tasks
- Combined triggers (triage + issue_review) both create tasks
- All 2792 tests pass