### PR TITLE
[server-dev] Fix eligibility: issue_review role uses reviewer config

### DIFF
--- a/packages/server/src/__tests__/eligibility.test.ts
+++ b/packages/server/src/__tests__/eligibility.test.ts
@@ -237,6 +237,57 @@ describe('isAgentEligibleForRole', () => {
     });
   });
 
+  describe('issue_review role uses reviewer config', () => {
+    it('allows any agent with default (empty) reviewer config', () => {
+      const result = isAgentEligibleForRole(baseConfig, 'issue_review', 'agent-xyz');
+      expect(result.eligible).toBe(true);
+    });
+
+    it('respects reviewer whitelist for issue_review', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [{ agent: 'agent-abc' }],
+        },
+      };
+      expect(isAgentEligibleForRole(config, 'issue_review', 'agent-abc').eligible).toBe(true);
+      expect(isAgentEligibleForRole(config, 'issue_review', 'agent-other').eligible).toBe(false);
+    });
+
+    it('respects reviewer blacklist for issue_review', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          blacklist: [{ agent: 'agent-bad' }],
+        },
+      };
+      const result = isAgentEligibleForRole(config, 'issue_review', 'agent-bad');
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('blacklisted');
+    });
+
+    it('does not use summarizer config for issue_review', () => {
+      const config = {
+        ...baseConfig,
+        reviewer: {
+          ...baseConfig.reviewer,
+          whitelist: [],
+          blacklist: [],
+        },
+        summarizer: {
+          whitelist: [{ agent: 'agent-synth' }],
+          blacklist: [],
+          preferred: [],
+        },
+      };
+      // With summarizer whitelist restricting to agent-synth, issue_review should
+      // still be open (uses reviewer config which has no restrictions)
+      expect(isAgentEligibleForRole(config, 'issue_review', 'agent-other').eligible).toBe(true);
+    });
+  });
+
   describe('user-only entries are filtered out during parsing', () => {
     it('allows all agents when whitelist had only user entries (filtered to empty)', () => {
       // After parsing, user-only entries are stripped, so whitelist is empty → open access

--- a/packages/server/src/eligibility.ts
+++ b/packages/server/src/eligibility.ts
@@ -57,7 +57,8 @@ export function isAgentEligibleForRole(
   agentId: string,
   githubUsername?: string,
 ): { eligible: boolean; reason?: string } {
-  const roleConfig = role === 'review' ? config.reviewer : config.summarizer;
+  const roleConfig =
+    role === 'review' || role === 'issue_review' ? config.reviewer : config.summarizer;
   const { whitelist, blacklist } = roleConfig;
 
   // Blacklist check — deny takes priority


### PR DESCRIPTION
Part of #696

## Summary
- Fixed `isAgentEligibleForRole()` in `eligibility.ts` where the `issue_review` role fell through to `config.summarizer` rules instead of using `config.reviewer`
- Added `issue_review` to the reviewer branch of the role config selection
- Added 4 test cases covering issue_review eligibility (default open, whitelist, blacklist, summarizer isolation)

## Test plan
- [x] Existing eligibility tests pass (no regression)
- [x] New tests verify issue_review uses reviewer whitelist/blacklist
- [x] New test confirms issue_review is NOT affected by summarizer config
- [x] Full build and test suite passes (2844 tests, 81 files)