### PR TITLE
[server-dev] Fix status trigger: string-to-object comparison never matches

### DIFF
--- a/packages/server/src/__tests__/agent-field-resolve.test.ts
+++ b/packages/server/src/__tests__/agent-field-resolve.test.ts
@@ -277,6 +277,10 @@ function makePRLabelPayload(labelName: string, overrides: Record<string, unknown
   };
 }
 
+function makeStatusFieldValue(name: string) {
+  return { id: `id-${name.toLowerCase().replace(/\s+/g, '-')}`, name };
+}
+
 function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, unknown> = {}) {
   return {
     action: 'edited',
@@ -285,8 +289,8 @@ function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, u
     changes: {
       field_value: {
         field_name: 'Status',
-        from: 'Backlog',
-        to: statusTo,
+        from: makeStatusFieldValue('Backlog'),
+        to: makeStatusFieldValue(statusTo),
       },
     },
     ...overrides,

--- a/packages/server/src/__tests__/trigger-modes.test.ts
+++ b/packages/server/src/__tests__/trigger-modes.test.ts
@@ -199,6 +199,10 @@ function makeIssueLabelPayload(labelName: string, overrides: Record<string, unkn
   };
 }
 
+function makeStatusFieldValue(name: string) {
+  return { id: `id-${name.toLowerCase().replace(/\s+/g, '-')}`, name };
+}
+
 function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, unknown> = {}) {
   return {
     action: 'edited',
@@ -207,8 +211,8 @@ function makeProjectsV2ItemPayload(statusTo: string, overrides: Record<string, u
     changes: {
       field_value: {
         field_name: 'Status',
-        from: 'Backlog',
-        to: statusTo,
+        from: makeStatusFieldValue('Backlog'),
+        to: makeStatusFieldValue(statusTo),
       },
     },
     ...overrides,
@@ -1144,6 +1148,70 @@ describe('Unified trigger modes', () => {
 
     it('ignores when no installation', async () => {
       const payload = makeProjectsV2ItemPayload('Ready', { installation: undefined });
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+      expect(await store.listTasks()).toHaveLength(0);
+    });
+
+    it('matches status using object with extra fields (color, description)', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const payload = {
+        action: 'edited',
+        installation: { id: 999 },
+        projects_v2_item: { content_node_id: 'node123' },
+        changes: {
+          field_value: {
+            field_name: 'Status',
+            from: { id: 'f1', name: 'Backlog', color: 'GRAY', description: 'Not started' },
+            to: { id: 'f2', name: 'Ready', color: 'GREEN', description: 'Ready to work' },
+          },
+        },
+      };
+
+      const res = await sendWebhook(app, 'projects_v2_item', payload, env);
+      expect(res.status).toBe(200);
+
+      const tasks = await store.listTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].feature).toBe('implement');
+      expect(tasks[0].task_type).toBe('implement');
+    });
+
+    it('does not match when object name differs from trigger status', async () => {
+      github.openCaraConfig = {
+        version: 1,
+        implement: DEFAULT_IMPLEMENT_CONFIG,
+      };
+      github.resolveProjectItemResult = {
+        type: 'Issue',
+        owner: 'acme',
+        repo: 'widget',
+        number: 10,
+      };
+
+      const payload = {
+        action: 'edited',
+        installation: { id: 999 },
+        projects_v2_item: { content_node_id: 'node123' },
+        changes: {
+          field_value: {
+            field_name: 'Status',
+            from: { id: 'f1', name: 'Backlog' },
+            to: { id: 'f2', name: 'In Progress' },
+          },
+        },
+      };
+
       const res = await sendWebhook(app, 'projects_v2_item', payload, env);
       expect(res.status).toBe(200);
       expect(await store.listTasks()).toHaveLength(0);

--- a/packages/server/src/routes/webhook.ts
+++ b/packages/server/src/routes/webhook.ts
@@ -109,6 +109,13 @@ interface IssuePayload {
   label?: { name: string };
 }
 
+interface ProjectFieldValueOption {
+  id: string;
+  name: string;
+  color?: string;
+  description?: string;
+}
+
 interface ProjectsV2ItemPayload {
   action: string;
   installation?: { id: number };
@@ -118,8 +125,8 @@ interface ProjectsV2ItemPayload {
   changes?: {
     field_value?: {
       field_name: string;
-      from?: string | null;
-      to?: string | null;
+      from?: ProjectFieldValueOption | null;
+      to?: ProjectFieldValueOption | null;
     };
   };
 }
@@ -2768,13 +2775,13 @@ async function handleProjectsV2Item(
     type === 'Issue' &&
     fullConfig.implement?.enabled &&
     isStatusTriggerEnabled(fullConfig.implement.trigger) &&
-    fullConfig.implement.trigger.status === newStatus
+    fullConfig.implement.trigger.status === newStatus.name
   ) {
     logger.info('Implement status trigger matched', {
       owner,
       repo,
       issueNumber: number,
-      status: newStatus,
+      status: newStatus.name,
     });
 
     let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;
@@ -2879,13 +2886,13 @@ async function handleProjectsV2Item(
     type === 'Issue' &&
     fullConfig.issue_review?.enabled &&
     isStatusTriggerEnabled(fullConfig.issue_review.trigger) &&
-    fullConfig.issue_review.trigger.status === newStatus
+    fullConfig.issue_review.trigger.status === newStatus.name
   ) {
     logger.info('Issue review status trigger matched', {
       owner,
       repo,
       issueNumber: number,
-      status: newStatus,
+      status: newStatus.name,
     });
 
     let issue: Awaited<ReturnType<GitHubService['fetchIssueDetails']>>;


### PR DESCRIPTION
Part of #699

## Summary
- Fixed `handleProjectsV2Item()` status trigger comparisons that compared a string (`trigger.status`) against an object (`fieldChange.to`), which always evaluated to `false`
- Changed `=== newStatus` to `=== newStatus.name` for both `implement` and `issue_review` status triggers
- Updated `ProjectsV2ItemPayload` type to correctly type `field_value.to` and `field_value.from` as `{id, name, color?, description?}` objects instead of strings
- Updated test helpers in both `trigger-modes.test.ts` and `agent-field-resolve.test.ts` to use object-shaped status values
- Added new tests verifying status trigger matching with full object format (including `color` and `description` fields)

## Test plan
- [x] All 2846 existing tests pass
- [x] New test: status trigger matches when `to` is object with extra fields (color, description)
- [x] New test: status trigger does not match when object name differs from trigger status
- [x] Build, lint, format, and typecheck all pass