### PR TITLE
[cli-dev] Fix bare clone default branch detection

### DIFF
--- a/packages/cli/src/__tests__/implement.test.ts
+++ b/packages/cli/src/__tests__/implement.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PollTask } from '@opencara/shared';
 import type { ToolExecutorResult } from '../tool-executor.js';
 import {
@@ -10,6 +14,9 @@ import {
   parseImplementOutput,
   executeImplement,
   executeImplementTask,
+  detectDefaultBranch,
+  resolveStartRef,
+  checkoutForImplement,
   MAX_ISSUE_BODY_BYTES,
   type ImplementExecutorDeps,
 } from '../implement.js';
@@ -643,5 +650,149 @@ describe('executeImplementTask', () => {
       expect.stringContaining('issue-42'),
       expect.any(String),
     );
+  });
+});
+
+// ── Bare clone branch detection (real git repos) ────────────────
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/** Create a normal (non-bare) git repo with one commit on the given branch. */
+function createSourceRepo(dir: string, branch: string = 'main'): void {
+  fs.mkdirSync(dir, { recursive: true });
+  git(['init', '-b', branch], dir);
+  git(['config', 'user.email', 'test@test.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  fs.writeFileSync(path.join(dir, 'README.md'), '# test');
+  git(['add', '.'], dir);
+  git(['commit', '-m', 'init'], dir);
+}
+
+describe('detectDefaultBranch', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocara-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects "main" in a bare clone', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const bareDir = path.join(tmpDir, 'bare.git');
+    createSourceRepo(srcDir, 'main');
+    git(['clone', '--bare', srcDir, bareDir], tmpDir);
+
+    expect(detectDefaultBranch(bareDir)).toBe('main');
+  });
+
+  it('detects "master" in a bare clone with master branch', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const bareDir = path.join(tmpDir, 'bare.git');
+    createSourceRepo(srcDir, 'master');
+    git(['clone', '--bare', srcDir, bareDir], tmpDir);
+
+    expect(detectDefaultBranch(bareDir)).toBe('master');
+  });
+
+  it('detects "main" in a non-bare clone with remote tracking', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const cloneDir = path.join(tmpDir, 'clone');
+    createSourceRepo(srcDir, 'main');
+    git(['clone', srcDir, cloneDir], tmpDir);
+
+    expect(detectDefaultBranch(cloneDir)).toBe('main');
+  });
+
+  it('throws when neither main nor master exists', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const bareDir = path.join(tmpDir, 'bare.git');
+    createSourceRepo(srcDir, 'develop');
+    git(['clone', '--bare', srcDir, bareDir], tmpDir);
+
+    expect(() => detectDefaultBranch(bareDir)).toThrow('Cannot determine default branch');
+  });
+});
+
+describe('resolveStartRef', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocara-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns origin/<branch> for non-bare clones', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const cloneDir = path.join(tmpDir, 'clone');
+    createSourceRepo(srcDir, 'main');
+    git(['clone', srcDir, cloneDir], tmpDir);
+
+    expect(resolveStartRef(cloneDir, 'main')).toBe('origin/main');
+  });
+
+  it('returns branch name for bare clones (no origin/ prefix)', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const bareDir = path.join(tmpDir, 'bare.git');
+    createSourceRepo(srcDir, 'main');
+    git(['clone', '--bare', srcDir, bareDir], tmpDir);
+
+    expect(resolveStartRef(bareDir, 'main')).toBe('main');
+  });
+});
+
+describe('checkoutForImplement (bare clone integration)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocara-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates worktree from bare clone with main branch', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    createSourceRepo(srcDir, 'main');
+
+    // Simulate bare clone structure that checkoutForImplement creates
+    const baseDir = path.join(tmpDir, 'repos');
+    const bareDir = path.join(baseDir, 'acme', 'widgets.git');
+    fs.mkdirSync(path.join(baseDir, 'acme'), { recursive: true });
+    git(['clone', '--bare', '--filter=blob:none', srcDir, bareDir], tmpDir);
+
+    const result = checkoutForImplement('acme', 'widgets', 42, 'opencara/issue-42-test', baseDir);
+
+    expect(result.bareRepoPath).toBe(bareDir);
+    expect(result.worktreePath).toContain('implement-42');
+    expect(fs.existsSync(path.join(result.worktreePath, 'README.md'))).toBe(true);
+
+    // Verify worktree is on the correct branch
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], result.worktreePath).trim();
+    expect(branch).toBe('opencara/issue-42-test');
+  });
+
+  it('creates worktree from bare clone with master branch', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    createSourceRepo(srcDir, 'master');
+
+    const baseDir = path.join(tmpDir, 'repos');
+    const bareDir = path.join(baseDir, 'acme', 'widgets.git');
+    fs.mkdirSync(path.join(baseDir, 'acme'), { recursive: true });
+    git(['clone', '--bare', '--filter=blob:none', srcDir, bareDir], tmpDir);
+
+    const result = checkoutForImplement('acme', 'widgets', 99, 'opencara/issue-99-test', baseDir);
+
+    expect(fs.existsSync(path.join(result.worktreePath, 'README.md'))).toBe(true);
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], result.worktreePath).trim();
+    expect(branch).toBe('opencara/issue-99-test');
   });
 });

--- a/packages/cli/src/implement.ts
+++ b/packages/cli/src/implement.ts
@@ -151,6 +151,46 @@ function ghExec(args: string[], cwd?: string): string {
   }
 }
 
+/**
+ * Detect the default branch by trying known ref paths.
+ * Non-bare repos use origin/main, origin/master; bare clones use refs/heads/main, refs/heads/master.
+ */
+export function detectDefaultBranch(repoPath: string): string {
+  // Non-bare clone refs (remote tracking branches)
+  const candidates: Array<{ ref: string; branch: string }> = [
+    { ref: 'origin/main', branch: 'main' },
+    { ref: 'origin/master', branch: 'master' },
+    // Bare clone refs (local branches — no remote tracking in bare repos)
+    { ref: 'refs/heads/main', branch: 'main' },
+    { ref: 'refs/heads/master', branch: 'master' },
+  ];
+
+  for (const { ref, branch } of candidates) {
+    try {
+      gitExec(['rev-parse', '--verify', ref], repoPath);
+      return branch;
+    } catch {
+      // Try next candidate
+    }
+  }
+
+  throw new Error('Cannot determine default branch — neither main nor master exists');
+}
+
+/**
+ * Resolve the start-point ref for worktree creation.
+ * Prefers origin/<branch> (non-bare), falls back to refs/heads/<branch> (bare clone).
+ */
+export function resolveStartRef(repoPath: string, branch: string): string {
+  try {
+    gitExec(['rev-parse', '--verify', `origin/${branch}`], repoPath);
+    return `origin/${branch}`;
+  } catch {
+    // Bare clone — use local ref
+    return branch;
+  }
+}
+
 export interface ImplementCheckoutResult {
   /** Absolute path to the worktree directory */
   worktreePath: string;
@@ -199,7 +239,8 @@ export function checkoutForImplement(
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
   gitExec([...credArgs, 'fetch', '--force', 'origin'], bareRepoPath);
 
-  // Determine default branch (usually main or master)
+  // Determine default branch (usually main or master).
+  // In bare clones, refs live under refs/heads/ (not refs/remotes/origin/).
   let defaultBranch: string;
   try {
     defaultBranch = gitExec(
@@ -209,21 +250,13 @@ export function checkoutForImplement(
     // Strip "origin/" prefix if present
     defaultBranch = defaultBranch.replace(/^origin\//, '');
   } catch {
-    // Fallback: try main, then master
-    try {
-      gitExec(['rev-parse', '--verify', 'origin/main'], bareRepoPath);
-      defaultBranch = 'main';
-    } catch {
-      try {
-        gitExec(['rev-parse', '--verify', 'origin/master'], bareRepoPath);
-        defaultBranch = 'master';
-      } catch {
-        throw new Error(
-          'Cannot determine default branch — neither origin/main nor origin/master exists',
-        );
-      }
-    }
+    // Fallback: try origin/main, origin/master (non-bare), then refs/heads/ (bare)
+    defaultBranch = detectDefaultBranch(bareRepoPath);
   }
+
+  // Resolve the start point ref for worktree creation.
+  // In bare clones, origin/<branch> doesn't exist — use refs/heads/<branch> instead.
+  const startRef = resolveStartRef(bareRepoPath, defaultBranch);
 
   // Create worktree with new branch from default branch
   const worktreeBase = path.join(path.dirname(bareRepoPath), `${repo}-worktrees`);
@@ -248,10 +281,7 @@ export function checkoutForImplement(
   }
 
   fs.mkdirSync(worktreeBase, { recursive: true });
-  gitExec(
-    ['worktree', 'add', '-b', branchName, worktreePath, `origin/${defaultBranch}`],
-    bareRepoPath,
-  );
+  gitExec(['worktree', 'add', '-b', branchName, worktreePath, startRef], bareRepoPath);
 
   return { worktreePath, bareRepoPath };
 }


### PR DESCRIPTION
Part of #701

## Summary
- Fix `checkoutForImplement()` to detect default branch in bare clones by also checking `refs/heads/main` and `refs/heads/master` (bare clones don't have `refs/remotes/origin/` refs)
- Fix worktree creation to use the correct start-point ref (`origin/<branch>` for non-bare, `<branch>` for bare)
- Extract `detectDefaultBranch()` and `resolveStartRef()` as testable helpers
- Add integration tests using real git repos: bare clone detection (main/master), non-bare detection, error case, resolveStartRef for both repo types, and full `checkoutForImplement` end-to-end with bare clones

## Test plan
- [x] All 2854 existing tests pass
- [x] New tests cover bare clone with main branch, bare clone with master branch, non-bare clone, missing default branch error
- [x] Integration tests verify real `checkoutForImplement` flow with bare-cloned repos
- [x] Build, lint, format, typecheck all pass