### PR TITLE
Implement #710: [cli-dev, HIGH] Implement checkout creates branch from stale main in bare clone

### DIFF
--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -134,6 +134,17 @@ describe('repo-cache', () => {
       expect(args).toContain('fetch');
       expect(args).not.toContain('-c');
     });
+
+    it('force-updates refs/heads/main to prevent stale branch base', () => {
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      fetchPRRef('/tmp/repos/acme/widgets.git', 42, true);
+
+      const call = vi.mocked(execFileSync).mock.calls[0];
+      const args = call[1] as string[];
+      expect(args).toContain('main:refs/heads/main');
+      expect(args).toContain('--force');
+    });
   });
 
   describe('addWorktree', () => {
@@ -342,8 +353,9 @@ describe('repo-cache', () => {
       // Verify bare clone
       expect(calls[1][1]).toContain('--bare');
 
-      // Verify fetch
+      // Verify fetch includes both PR ref and main force-update
       expect(calls[2][1]).toContain('pull/42/head');
+      expect(calls[2][1]).toContain('main:refs/heads/main');
 
       // Verify worktree add
       expect(calls[3][1]).toContain('worktree');

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -96,14 +96,20 @@ export function ensureBareClone(
 }
 
 /**
- * Fetch a PR ref into the bare repo.
+ * Fetch a PR ref into the bare repo and force-update refs/heads/main.
+ *
+ * In a bare clone, `git fetch origin` does NOT update refs/heads/main when
+ * another worktree has that branch checked out. Explicitly fetching
+ * `main:refs/heads/main` with --force ensures new branches always start
+ * from the latest remote main, preventing stale-base merge conflicts.
+ *
  * Uses credential helper when gh is available.
  */
 export function fetchPRRef(bareRepoPath: string, prNumber: number, ghAvailable: boolean): void {
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
   gitExec(
     'git',
-    [...credArgs, 'fetch', '--force', 'origin', `pull/${prNumber}/head`],
+    [...credArgs, 'fetch', '--force', 'origin', 'main:refs/heads/main', `pull/${prNumber}/head`],
     bareRepoPath,
   );
 }


### PR DESCRIPTION
Part of #710

## Summary
Fixed stale main ref in bare clone by adding 'main:refs/heads/main' refspec to the git fetch command in fetchPRRef(). In a bare clone where another worktree has main checked out, plain 'git fetch origin' does not update refs/heads/main. The fix explicitly force-updates it in the same fetch call that retrieves the PR ref. Added a dedicated test for the new refspec and updated the checkoutWorktree integration test to verify it.

---
*Automated by OpenCara implement agent*