### PR TITLE
Implement #698: [cli-dev] Make command test timeout configurable in config.toml

### DIFF
--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -594,7 +594,7 @@ describe('agent poll loop', () => {
     await vi.advanceTimersByTimeAsync(1000);
     await promise;
 
-    expect(testCommand).toHaveBeenCalledWith('echo test');
+    expect(testCommand).toHaveBeenCalledWith('echo test', undefined);
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Testing command...'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Command test ok (1.2s)'));
   });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1311,7 +1311,7 @@ tool = "qwen"
       const config = loadConfig();
       expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('command_test_timeout must be a duration string'),
+        expect.stringContaining('command_test_timeout must be a positive duration'),
       );
       warnSpy.mockRestore();
     });
@@ -1353,6 +1353,23 @@ tool = "qwen"
 
       const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
       expect(content).toContain('command_test_timeout = "2m"');
+    });
+
+    it('saveConfig writes non-round values as whole seconds', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        codebaseDir: null,
+        codebaseTtl: null,
+        commandTestTimeoutMs: 90_000,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      // 90s is not evenly divisible by 60_000 — should serialize as "90s", not "1.5m"
+      expect(content).toContain('command_test_timeout = "90s"');
     });
 
     it('saveConfig omits command_test_timeout when default', () => {

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -19,6 +19,7 @@ import {
   ensureConfigDir,
   resolveCodebaseDir,
   resolveFilePath,
+  parseDurationMs,
   RepoConfigError,
   ConfigValidationError,
   CONFIG_DIR,
@@ -27,6 +28,7 @@ import {
   DEFAULT_MAX_DIFF_SIZE_KB,
   DEFAULT_MAX_CONSECUTIVE_ERRORS,
   DEFAULT_MAX_REPO_SIZE_MB,
+  DEFAULT_COMMAND_TEST_TIMEOUT_MS,
 } from '../config.js';
 
 describe('config', () => {
@@ -1250,6 +1252,126 @@ tool = "qwen"
     });
   });
 
+  describe('command_test_timeout config', () => {
+    it('defaults to 10s when not set', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
+    });
+
+    it('parses seconds duration string', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('command_test_timeout = "30s"\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(30_000);
+    });
+
+    it('parses minutes duration string', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('command_test_timeout = "1m"\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(60_000);
+    });
+
+    it('warns and uses default for invalid duration string', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('command_test_timeout = "invalid"\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('command_test_timeout must be a duration string'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('warns and uses default for numeric value', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('command_test_timeout = 30\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('command_test_timeout must be a duration string'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('warns and uses default for "0s"', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('command_test_timeout = "0s"\n');
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('command_test_timeout must be a duration string'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('defaults to 10s when config file does not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const config = loadConfig();
+      expect(config.commandTestTimeoutMs).toBe(DEFAULT_COMMAND_TEST_TIMEOUT_MS);
+    });
+
+    it('saveConfig writes command_test_timeout when non-default (seconds)', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        codebaseDir: null,
+        codebaseTtl: null,
+        commandTestTimeoutMs: 30_000,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('command_test_timeout = "30s"');
+    });
+
+    it('saveConfig writes command_test_timeout in minutes when >= 60s', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        codebaseDir: null,
+        codebaseTtl: null,
+        commandTestTimeoutMs: 120_000,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).toContain('command_test_timeout = "2m"');
+    });
+
+    it('saveConfig omits command_test_timeout when default', () => {
+      saveConfig({
+        platformUrl: DEFAULT_PLATFORM_URL,
+        maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+        maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+        codebaseDir: null,
+        codebaseTtl: null,
+        commandTestTimeoutMs: DEFAULT_COMMAND_TEST_TIMEOUT_MS,
+        agentCommand: null,
+        agents: null,
+      });
+
+      const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(content).not.toContain('command_test_timeout');
+    });
+  });
+
   describe('auth_file config', () => {
     it('parses auth_file with tilde expansion', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -1392,6 +1514,38 @@ tool = "qwen"
 
     it('returns null for empty string agent dir with null global', () => {
       expect(resolveCodebaseDir('', null)).toBeNull();
+    });
+  });
+
+  describe('parseDurationMs', () => {
+    it('parses seconds', () => {
+      expect(parseDurationMs('10s')).toBe(10_000);
+      expect(parseDurationMs('30s')).toBe(30_000);
+      expect(parseDurationMs('1s')).toBe(1_000);
+    });
+
+    it('parses minutes', () => {
+      expect(parseDurationMs('1m')).toBe(60_000);
+      expect(parseDurationMs('5m')).toBe(300_000);
+    });
+
+    it('returns null for invalid strings', () => {
+      expect(parseDurationMs('invalid')).toBeNull();
+      expect(parseDurationMs('10')).toBeNull();
+      expect(parseDurationMs('10ms')).toBeNull();
+      expect(parseDurationMs('1h')).toBeNull();
+      expect(parseDurationMs('')).toBeNull();
+    });
+
+    it('returns null for non-string values', () => {
+      expect(parseDurationMs(10)).toBeNull();
+      expect(parseDurationMs(null)).toBeNull();
+      expect(parseDurationMs(undefined)).toBeNull();
+    });
+
+    it('parses zero correctly', () => {
+      expect(parseDurationMs('0s')).toBe(0);
+      expect(parseDurationMs('0m')).toBe(0);
     });
   });
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1498,6 +1498,7 @@ export async function startAgent(
     verbose?: boolean;
     agentOwner?: string;
     userOrgs?: ReadonlySet<string>;
+    commandTestTimeoutMs?: number;
   },
 ): Promise<void> {
   const client = new ApiClient(platformUrl, {
@@ -1544,7 +1545,7 @@ export async function startAgent(
   // Skip in router mode (stdin/stdout relay) since there's no local command to test.
   if (reviewDeps.commandTemplate && !options?.routerRelay) {
     log('Testing command...');
-    const result = await testCommand(reviewDeps.commandTemplate);
+    const result = await testCommand(reviewDeps.commandTemplate, options?.commandTestTimeoutMs);
     if (result.ok) {
       log(`${icons.success} Command test ok (${(result.elapsedMs / 1000).toFixed(1)}s)`);
     } else {
@@ -2035,7 +2036,7 @@ export async function startBatchAgents(
       .filter((state) => state.reviewDeps.commandTemplate && !state.routerRelay)
       .map(async (state) => {
         state.logger.log('Testing command...');
-        const result = await testCommand(state.reviewDeps.commandTemplate!);
+        const result = await testCommand(state.reviewDeps.commandTemplate!, config.commandTestTimeoutMs);
         if (result.ok) {
           state.logger.log(
             `${icons.success} Command test ok (${(result.elapsedMs / 1000).toFixed(1)}s)`,
@@ -2211,6 +2212,7 @@ export async function startAgentRouter(): Promise<void> {
       usageLimits: config.usageLimits,
       versionOverride,
       codebaseTtl: config.codebaseTtl,
+      commandTestTimeoutMs: config.commandTestTimeoutMs,
     },
   );
 
@@ -2327,6 +2329,7 @@ function startAgentByIndex(
         verbose,
         agentOwner,
         userOrgs,
+        commandTestTimeoutMs: config.commandTestTimeoutMs,
       },
     ).finally(() => {
       routerRelay?.stop();

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -2036,7 +2036,10 @@ export async function startBatchAgents(
       .filter((state) => state.reviewDeps.commandTemplate && !state.routerRelay)
       .map(async (state) => {
         state.logger.log('Testing command...');
-        const result = await testCommand(state.reviewDeps.commandTemplate!, config.commandTestTimeoutMs);
+        const result = await testCommand(
+          state.reviewDeps.commandTemplate!,
+          config.commandTestTimeoutMs,
+        );
         if (result.ok) {
           state.logger.log(
             `${icons.success} Command test ok (${(result.elapsedMs / 1000).toFixed(1)}s)`,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -455,9 +455,15 @@ export function loadConfig(): CliConfig {
     commandTestTimeoutMs: (() => {
       if (data.command_test_timeout === undefined) return DEFAULT_COMMAND_TEST_TIMEOUT_MS;
       const ms = parseDurationMs(data.command_test_timeout);
-      if (ms === null || ms <= 0) {
+      if (ms === null) {
         console.warn(
           `\u26a0 Config warning: command_test_timeout must be a duration string like "10s" or "1m", got "${data.command_test_timeout}", using default (${DEFAULT_COMMAND_TEST_TIMEOUT_MS / 1000}s)`,
+        );
+        return DEFAULT_COMMAND_TEST_TIMEOUT_MS;
+      }
+      if (ms <= 0) {
+        console.warn(
+          `\u26a0 Config warning: command_test_timeout must be a positive duration, got "${data.command_test_timeout}", using default (${DEFAULT_COMMAND_TEST_TIMEOUT_MS / 1000}s)`,
         );
         return DEFAULT_COMMAND_TEST_TIMEOUT_MS;
       }
@@ -501,9 +507,10 @@ export function saveConfig(config: CliConfig): void {
     data.max_repo_size_mb = config.maxRepoSizeMb;
   }
   if (config.commandTestTimeoutMs !== DEFAULT_COMMAND_TEST_TIMEOUT_MS) {
-    data.command_test_timeout = config.commandTestTimeoutMs >= 60_000
-      ? `${config.commandTestTimeoutMs / 60_000}m`
-      : `${config.commandTestTimeoutMs / 1000}s`;
+    data.command_test_timeout =
+      config.commandTestTimeoutMs % 60_000 === 0
+        ? `${config.commandTestTimeoutMs / 60_000}m`
+        : `${Math.round(config.commandTestTimeoutMs / 1000)}s`;
   }
   if (config.agentCommand) {
     data.agent_command = config.agentCommand;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -37,6 +37,7 @@ export interface CliConfig {
   maxRepoSizeMb: number;
   codebaseDir: string | null;
   codebaseTtl: string | null;
+  commandTestTimeoutMs: number;
   agentCommand: string | null;
   agents: LocalAgentConfig[] | null; // null = key absent = old server-side behavior
   usageLimits: UsageLimits;
@@ -57,6 +58,20 @@ export function ensureConfigDir(): void {
 export const DEFAULT_MAX_DIFF_SIZE_KB = 100;
 export const DEFAULT_MAX_CONSECUTIVE_ERRORS = 10;
 export const DEFAULT_MAX_REPO_SIZE_MB = 100;
+export const DEFAULT_COMMAND_TEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Parse a duration string like "10s", "30s", or "1m" into milliseconds.
+ * Returns null if the value is not a valid duration string.
+ */
+export function parseDurationMs(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const secMatch = value.match(/^(\d+)s$/);
+  if (secMatch) return parseInt(secMatch[1], 10) * 1000;
+  const minMatch = value.match(/^(\d+)m$/);
+  if (minMatch) return parseInt(minMatch[1], 10) * 60_000;
+  return null;
+}
 
 const VALID_REPO_MODES: RepoFilterMode[] = ['public', 'private', 'whitelist', 'blacklist'];
 const REPO_PATTERN = /^[^/]+\/[^/]+$/;
@@ -344,6 +359,7 @@ export function loadConfig(): CliConfig {
     maxRepoSizeMb: DEFAULT_MAX_REPO_SIZE_MB,
     codebaseDir: null,
     codebaseTtl: null,
+    commandTestTimeoutMs: DEFAULT_COMMAND_TEST_TIMEOUT_MS,
     agentCommand: null,
     agents: null,
     usageLimits: {
@@ -436,6 +452,17 @@ export function loadConfig(): CliConfig {
         : DEFAULT_MAX_REPO_SIZE_MB),
     codebaseDir: typeof data.codebase_dir === 'string' ? data.codebase_dir : null,
     codebaseTtl: typeof data.codebase_ttl === 'string' ? data.codebase_ttl : null,
+    commandTestTimeoutMs: (() => {
+      if (data.command_test_timeout === undefined) return DEFAULT_COMMAND_TEST_TIMEOUT_MS;
+      const ms = parseDurationMs(data.command_test_timeout);
+      if (ms === null || ms <= 0) {
+        console.warn(
+          `\u26a0 Config warning: command_test_timeout must be a duration string like "10s" or "1m", got "${data.command_test_timeout}", using default (${DEFAULT_COMMAND_TEST_TIMEOUT_MS / 1000}s)`,
+        );
+        return DEFAULT_COMMAND_TEST_TIMEOUT_MS;
+      }
+      return ms;
+    })(),
     agentCommand: typeof data.agent_command === 'string' ? data.agent_command : null,
     agents: parseAgents(data),
     usageLimits: {
@@ -472,6 +499,11 @@ export function saveConfig(config: CliConfig): void {
   }
   if (config.maxRepoSizeMb !== DEFAULT_MAX_REPO_SIZE_MB) {
     data.max_repo_size_mb = config.maxRepoSizeMb;
+  }
+  if (config.commandTestTimeoutMs !== DEFAULT_COMMAND_TEST_TIMEOUT_MS) {
+    data.command_test_timeout = config.commandTestTimeoutMs >= 60_000
+      ? `${config.commandTestTimeoutMs / 60_000}m`
+      : `${config.commandTestTimeoutMs / 1000}s`;
   }
   if (config.agentCommand) {
     data.agent_command = config.agentCommand;

--- a/packages/cli/src/tool-executor.ts
+++ b/packages/cli/src/tool-executor.ts
@@ -400,7 +400,7 @@ export function executeTool(
 }
 
 const TEST_COMMAND_PROMPT = 'Respond with: OK';
-const TEST_COMMAND_TIMEOUT_MS = 10_000;
+const DEFAULT_TEST_COMMAND_TIMEOUT_MS = 10_000;
 
 export interface TestCommandResult {
   ok: boolean;
@@ -411,11 +411,15 @@ export interface TestCommandResult {
 /**
  * Dry-run a command template with a tiny test prompt to verify it works.
  * Returns success/failure + elapsed time. Never throws.
+ * @param timeoutMs — override the default 10s timeout (e.g. from config.toml command_test_timeout)
  */
-export async function testCommand(commandTemplate: string): Promise<TestCommandResult> {
+export async function testCommand(
+  commandTemplate: string,
+  timeoutMs: number = DEFAULT_TEST_COMMAND_TIMEOUT_MS,
+): Promise<TestCommandResult> {
   const start = Date.now();
   try {
-    await executeTool(commandTemplate, TEST_COMMAND_PROMPT, TEST_COMMAND_TIMEOUT_MS);
+    await executeTool(commandTemplate, TEST_COMMAND_PROMPT, timeoutMs);
     return { ok: true, elapsedMs: Date.now() - start };
   } catch (err) {
     const elapsed = Date.now() - start;
@@ -423,7 +427,7 @@ export async function testCommand(commandTemplate: string): Promise<TestCommandR
       return {
         ok: false,
         elapsedMs: elapsed,
-        error: `command timed out after ${TEST_COMMAND_TIMEOUT_MS / 1000}s`,
+        error: `command timed out after ${timeoutMs / 1000}s`,
       };
     }
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Part of #698

## Summary
Made command test timeout configurable via `command_test_timeout` field in config.toml. Added `parseDurationMs()` utility for parsing duration strings like "10s" and "1m". The `testCommand()` function now accepts an optional timeout parameter (defaults to 10s for backward compatibility). All three agent entry points (startAgent, startBatchAgents, startAgentRouter) pass the configured timeout through.

---
*Automated by OpenCara implement agent*