### PR TITLE
feat: stdout liveness timeout for stuck tool detection

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -119,6 +119,7 @@ command = "qwen --model qwen3.5-plus -y"
 # thinking = "high"
 # roles = ["review"]               # Only review, never synthesize
 # codebase_dir = "~/.opencara/repos/claude"
+# liveness_timeout = 300            # Kill if no stdout for 300s (default: 300, 0 = disable)
 #
 # # Repo filtering: control which repos this agent reviews
 # [agents.repos]

--- a/packages/cli/src/__tests__/review.test.ts
+++ b/packages/cli/src/__tests__/review.test.ts
@@ -375,6 +375,7 @@ describe('executeReview', () => {
       expect.any(AbortSignal),
       undefined,
       undefined,
+      undefined,
     );
     // Prompt should contain both system and user content
     const prompt = mockRunTool.mock.calls[0][1];

--- a/packages/cli/src/__tests__/summary.test.ts
+++ b/packages/cli/src/__tests__/summary.test.ts
@@ -387,6 +387,7 @@ describe('executeSummary', () => {
       expect.any(AbortSignal),
       undefined,
       undefined,
+      undefined,
     );
   });
 

--- a/packages/cli/src/__tests__/tool-executor.test.ts
+++ b/packages/cli/src/__tests__/tool-executor.test.ts
@@ -7,6 +7,7 @@ import {
   estimateTokens,
   ToolTimeoutError,
   SIGKILL_GRACE_MS,
+  STDOUT_LIVENESS_TIMEOUT_MS,
 } from '../tool-executor.js';
 
 import EventEmitter from 'node:events';
@@ -552,6 +553,204 @@ describe('executeTool', () => {
       // Advance past grace period — SIGKILL should NOT be sent
       vi.advanceTimersByTime(SIGKILL_GRACE_MS);
       expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+    });
+  });
+
+  describe('stdout liveness timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('kills process when no stdout for livenessTimeoutMs', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const livenessMs = 30_000;
+      const promise = executeTool(
+        'stuck-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+      );
+
+      // Advance past liveness timeout — SIGTERM fires
+      vi.advanceTimersByTime(livenessMs);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      // Process exits with SIGTERM
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+
+      await expect(promise).rejects.toThrow(ToolTimeoutError);
+      await expect(promise).rejects.toThrow(/no stdout for 30s/);
+    });
+
+    it('resets liveness timer on stdout data', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const livenessMs = 30_000;
+      const promise = executeTool(
+        'alive-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+      );
+
+      // Advance 20s (before liveness fires)
+      vi.advanceTimersByTime(20_000);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Emit stdout — resets timer
+      child.stdout.emit('data', Buffer.from('partial output'));
+
+      // Advance another 20s (40s total, but only 20s since last stdout)
+      vi.advanceTimersByTime(20_000);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Advance past the reset liveness window (30s since last stdout)
+      vi.advanceTimersByTime(10_000);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+      await expect(promise).rejects.toThrow(ToolTimeoutError);
+    });
+
+    it('does NOT reset liveness timer on stderr-only data', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const livenessMs = 30_000;
+      const promise = executeTool(
+        'stderr-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+      );
+
+      // Advance 20s
+      vi.advanceTimersByTime(20_000);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Emit stderr only — should NOT reset liveness
+      child.stderr.emit('data', Buffer.from('retrying... 429'));
+
+      // Advance past original liveness window
+      vi.advanceTimersByTime(10_000);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+      await expect(promise).rejects.toThrow(/no stdout for 30s/);
+    });
+
+    it('uses default liveness timeout when not specified', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      // No livenessTimeoutMs arg — uses STDOUT_LIVENESS_TIMEOUT_MS default
+      const promise = executeTool('default-tool', 'test', 600_000);
+
+      // Advance past default liveness
+      vi.advanceTimersByTime(STDOUT_LIVENESS_TIMEOUT_MS);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+      await expect(promise).rejects.toThrow(/no stdout for 300s/);
+    });
+
+    it('disabled when livenessTimeoutMs is 0', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const promise = executeTool(
+        'no-liveness',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+      );
+
+      // Advance past default liveness — should NOT kill
+      vi.advanceTimersByTime(STDOUT_LIVENESS_TIMEOUT_MS + 10_000);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Complete normally
+      emitOutput(child, { stdout: 'done', code: 0 });
+      const result = await promise;
+      expect(result.stdout).toBe('done');
+    });
+
+    it('liveness fires before main timeout', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const mainTimeout = 600_000;
+      const livenessMs = 30_000;
+      const promise = executeTool(
+        'stuck-tool',
+        'test',
+        mainTimeout,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+      );
+
+      // Advance past liveness (well before main timeout)
+      vi.advanceTimersByTime(livenessMs);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+
+      // Should report liveness kill, not main timeout
+      await expect(promise).rejects.toThrow(/no stdout for 30s/);
+      await expect(promise).rejects.not.toThrow(/timed out after/);
+    });
+
+    it('coexists with main timeout — main fires when liveness is reset', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const mainTimeout = 60_000;
+      const livenessMs = 30_000;
+      const promise = executeTool(
+        'slow-tool',
+        'test',
+        mainTimeout,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+      );
+
+      // Keep resetting liveness with stdout every 20s
+      vi.advanceTimersByTime(20_000);
+      child.stdout.emit('data', Buffer.from('chunk1'));
+      vi.advanceTimersByTime(20_000);
+      child.stdout.emit('data', Buffer.from('chunk2'));
+
+      // Now at 40s — advance past main timeout (60s)
+      vi.advanceTimersByTime(20_000);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+
+      // Should report main timeout, not liveness
+      await expect(promise).rejects.toThrow(/timed out after 60s/);
     });
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1969,6 +1969,8 @@ export async function startBatchAgents(
       maxDiffSizeKb: config.maxDiffSizeKb,
       maxRepoSizeMb: config.maxRepoSizeMb,
       codebaseDir,
+      livenessTimeoutMs:
+        agentConfig.livenessTimeout != null ? agentConfig.livenessTimeout * 1000 : undefined,
     };
 
     // Share session stats and usage tracker across instances of the same agent config
@@ -2164,6 +2166,8 @@ export async function startAgentRouter(): Promise<void> {
     maxDiffSizeKb: config.maxDiffSizeKb,
     maxRepoSizeMb: config.maxRepoSizeMb,
     codebaseDir,
+    livenessTimeoutMs:
+      agentConfig?.livenessTimeout != null ? agentConfig.livenessTimeout * 1000 : undefined,
   };
 
   const session = createSessionTracker();
@@ -2265,6 +2269,8 @@ function startAgentByIndex(
     maxDiffSizeKb: config.maxDiffSizeKb,
     maxRepoSizeMb: config.maxRepoSizeMb,
     codebaseDir,
+    livenessTimeoutMs:
+      agentConfig?.livenessTimeout != null ? agentConfig.livenessTimeout * 1000 : undefined,
   };
 
   const model = agentConfig?.model ?? 'unknown';

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -20,6 +20,7 @@ export interface LocalAgentConfig {
   repos?: RepoConfig;
   instances?: number;
   maxTasksPerDay?: number | null;
+  livenessTimeout?: number;
 }
 
 export interface UsageLimits {
@@ -226,6 +227,21 @@ function parseAgents(data: Record<string, unknown>): LocalAgentConfig[] | null {
         );
       } else {
         agent.maxTasksPerDay = v;
+      }
+    }
+    if (typeof obj.liveness_timeout === 'number') {
+      if (obj.liveness_timeout === 0) {
+        // Explicit 0 disables liveness timeout
+        agent.livenessTimeout = 0;
+      } else {
+        const v = parsePositiveInt(obj.liveness_timeout);
+        if (v === null) {
+          console.warn(
+            `\u26a0 Config warning: agents[${i}].liveness_timeout must be a non-negative integer (seconds), got ${obj.liveness_timeout}. Value ignored.`,
+          );
+        } else {
+          agent.livenessTimeout = v;
+        }
       }
     }
     const repoConfig = parseRepoConfig(obj, i);

--- a/packages/cli/src/review.ts
+++ b/packages/cli/src/review.ts
@@ -125,6 +125,7 @@ export interface ReviewExecutorDeps {
   maxDiffSizeKb: number;
   maxRepoSizeMb?: number;
   codebaseDir?: string | null;
+  livenessTimeoutMs?: number;
 }
 
 export async function executeReview(
@@ -137,6 +138,7 @@ export async function executeReview(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<ReviewResponse> {
   const diffSizeKb = Buffer.byteLength(req.diffContent, 'utf-8') / 1024;
@@ -169,6 +171,7 @@ export async function executeReview(
       abortController.signal,
       undefined,
       deps.codebaseDir ?? undefined,
+      deps.livenessTimeoutMs,
     );
 
     const { verdict, review } = extractVerdict(result.stdout);

--- a/packages/cli/src/summary.ts
+++ b/packages/cli/src/summary.ts
@@ -130,6 +130,7 @@ export async function executeSummary(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<SummaryResponse> {
   const inputSize = calculateInputSize(req.prompt, req.reviews, req.diffContent, req.contextBlock);
@@ -167,6 +168,7 @@ export async function executeSummary(
       abortController.signal,
       undefined,
       deps.codebaseDir ?? undefined,
+      deps.livenessTimeoutMs,
     );
 
     const { verdict, review } = extractVerdict(result.stdout);

--- a/packages/cli/src/tool-executor.ts
+++ b/packages/cli/src/tool-executor.ts
@@ -33,6 +33,9 @@ export const SIGKILL_GRACE_MS = 5_000;
 /** Minimum stdout length to treat a non-zero exit as a partial success */
 const MIN_PARTIAL_RESULT_LENGTH = 50;
 
+/** Default stdout liveness timeout (ms). Kill process if no stdout for this long. */
+export const STDOUT_LIVENESS_TIMEOUT_MS = 300_000;
+
 /** Maximum stderr length included in error/warning messages */
 const MAX_STDERR_LENGTH = 1000;
 
@@ -206,6 +209,7 @@ export function executeTool(
   signal?: AbortSignal,
   vars?: Record<string, string>,
   cwd?: string,
+  livenessTimeoutMs?: number,
 ): Promise<ToolExecutorResult> {
   const promptViaArg = commandTemplate.includes('${PROMPT}');
   const allVars: Record<string, string> = { ...vars, PROMPT: prompt };
@@ -231,6 +235,11 @@ export function executeTool(
     let stderr = '';
     let settled = false;
     let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
+    let killedByLiveness = false;
+
+    // Resolve effective liveness timeout: undefined → default, 0 → disabled
+    const effectiveLivenessMs =
+      livenessTimeoutMs === undefined ? STDOUT_LIVENESS_TIMEOUT_MS : livenessTimeoutMs;
 
     function scheduleKillEscalation(): void {
       child.kill('SIGTERM');
@@ -247,8 +256,29 @@ export function executeTool(
     // Timeout handling via manual timer since spawn doesn't support timeout
     const timer = setTimeout(scheduleKillEscalation, timeoutMs);
 
+    // Stdout liveness timer: kill if no stdout for effectiveLivenessMs
+    let livenessTimer: ReturnType<typeof setTimeout> | undefined;
+    if (effectiveLivenessMs > 0) {
+      livenessTimer = setTimeout(() => {
+        if (!settled) {
+          killedByLiveness = true;
+          scheduleKillEscalation();
+        }
+      }, effectiveLivenessMs);
+    }
+
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
+      // Reset liveness timer on stdout activity
+      if (livenessTimer) {
+        clearTimeout(livenessTimer);
+        livenessTimer = setTimeout(() => {
+          if (!settled) {
+            killedByLiveness = true;
+            scheduleKillEscalation();
+          }
+        }, effectiveLivenessMs);
+      }
     });
 
     child.stderr?.on('data', (chunk: Buffer) => {
@@ -270,6 +300,7 @@ export function executeTool(
 
     function cleanup(): void {
       clearTimeout(timer);
+      if (livenessTimer) clearTimeout(livenessTimer);
       if (sigkillTimer) clearTimeout(sigkillTimer);
       if (onAbort && signal) {
         signal.removeEventListener('abort', onAbort);
@@ -298,11 +329,19 @@ export function executeTool(
       }
 
       if (sig === 'SIGTERM' || sig === 'SIGKILL') {
-        reject(
-          new ToolTimeoutError(
-            `Tool "${command}" timed out after ${Math.round(timeoutMs / 1000)}s`,
-          ),
-        );
+        if (killedByLiveness) {
+          reject(
+            new ToolTimeoutError(
+              `Tool "${command}" killed: no stdout for ${Math.round(effectiveLivenessMs / 1000)}s (process may be stuck)`,
+            ),
+          );
+        } else {
+          reject(
+            new ToolTimeoutError(
+              `Tool "${command}" timed out after ${Math.round(timeoutMs / 1000)}s`,
+            ),
+          );
+        }
         return;
       }
 

--- a/packages/cli/src/tool-executor.ts
+++ b/packages/cli/src/tool-executor.ts
@@ -241,7 +241,11 @@ export function executeTool(
     const effectiveLivenessMs =
       livenessTimeoutMs === undefined ? STDOUT_LIVENESS_TIMEOUT_MS : livenessTimeoutMs;
 
+    let killScheduled = false;
+
     function scheduleKillEscalation(): void {
+      if (killScheduled) return;
+      killScheduled = true;
       child.kill('SIGTERM');
       // Clear any existing SIGKILL timer to prevent leaks
       if (sigkillTimer) clearTimeout(sigkillTimer);


### PR DESCRIPTION
## Summary
- Add stdout-based liveness timeout to `executeTool` — kills processes that produce no stdout for N seconds (default 5 min), detecting stuck tools like Gemini 429 retry loops
- Configurable per agent via `liveness_timeout` in `config.toml` (seconds, 0 to disable)
- Distinct error message (`no stdout for Ns — process may be stuck`) vs regular timeout, enabling faster error reporting to the platform

## Test plan
- [x] 7 new tests: kill on no stdout, timer reset on stdout, no reset on stderr, default timeout, disable with 0, liveness-before-main, main-fires-when-liveness-reset
- [x] All 2888 tests pass
- [x] Build, lint, format, typecheck all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)