### PR TITLE
feat: feature-specific titles for implement/fix GitHub comments

### DIFF
--- a/packages/server/src/__tests__/coverage-gaps.test.ts
+++ b/packages/server/src/__tests__/coverage-gaps.test.ts
@@ -136,6 +136,40 @@ describe('review-formatter edge cases', () => {
     expect(result).toContain('**Contributors**: @carol');
     expect(result).toContain('Triage result');
   });
+
+  it('formatTimeoutComment uses "Go timed out" for implement feature', async () => {
+    const { formatTimeoutComment } = await import('../review-formatter.js');
+    const result = formatTimeoutComment(15, [], 'implement');
+    expect(result).toContain('## OpenCara Go');
+    expect(result).toContain('> Go timed out after 15 minutes.');
+    expect(result).not.toContain('Review timed out');
+  });
+
+  it('formatTimeoutComment uses "Fix timed out" for fix feature', async () => {
+    const { formatTimeoutComment } = await import('../review-formatter.js');
+    const result = formatTimeoutComment(20, [], 'fix');
+    expect(result).toContain('## OpenCara Fix');
+    expect(result).toContain('> Fix timed out after 20 minutes.');
+    expect(result).not.toContain('Review timed out');
+  });
+
+  it('formatTimeoutComment defaults to "Review timed out" when no feature', async () => {
+    const { formatTimeoutComment } = await import('../review-formatter.js');
+    const result = formatTimeoutComment(10, []);
+    expect(result).toContain('## OpenCara Review');
+    expect(result).toContain('> Review timed out after 10 minutes.');
+  });
+
+  it('formatTimeoutComment with partial reviews uses feature-specific header', async () => {
+    const { formatTimeoutComment } = await import('../review-formatter.js');
+    const result = formatTimeoutComment(
+      15,
+      [{ model: 'claude', tool: 'cli', verdict: 'approve', review_text: 'Partial' }],
+      'implement',
+    );
+    expect(result).toContain('## OpenCara Go');
+    expect(result).toContain('> Go timed out after 15 minutes. 1 partial review(s) collected.');
+  });
 });
 
 // ── github/config.ts ─────────────────────────────────────────

--- a/packages/server/src/review-formatter.ts
+++ b/packages/server/src/review-formatter.ts
@@ -1,6 +1,24 @@
-import type { ReviewVerdict } from '@opencara/shared';
+import type { Feature, ReviewVerdict } from '@opencara/shared';
 
-const REVIEW_HEADER = '## OpenCara Review';
+const FEATURE_HEADERS: Record<Feature, string> = {
+  review: '## OpenCara Review',
+  implement: '## OpenCara Go',
+  fix: '## OpenCara Fix',
+  issue_review: '## OpenCara Issue Review',
+  dedup_pr: '## OpenCara Review',
+  dedup_issue: '## OpenCara Review',
+  triage: '## OpenCara Review',
+};
+
+const FEATURE_TIMEOUT_LABELS: Record<Feature, string> = {
+  review: 'Review',
+  implement: 'Go',
+  fix: 'Fix',
+  issue_review: 'Review',
+  dedup_pr: 'Review',
+  dedup_issue: 'Review',
+  triage: 'Review',
+};
 const REVIEW_FOOTER =
   '<sub>Reviewed by <a href="https://github.com/apps/opencara">OpenCara</a></sub>';
 
@@ -42,14 +60,20 @@ export function wrapReviewComment(
  * Format a consolidated timeout comment containing all partial reviews
  * and the timeout message in a single GitHub comment.
  */
-export function formatTimeoutComment(timeoutMinutes: number, reviews: TimeoutReview[]): string {
-  const parts: string[] = [REVIEW_HEADER, ''];
+export function formatTimeoutComment(
+  timeoutMinutes: number,
+  reviews: TimeoutReview[],
+  feature?: Feature,
+): string {
+  const header = FEATURE_HEADERS[feature ?? 'review'];
+  const label = FEATURE_TIMEOUT_LABELS[feature ?? 'review'];
+  const parts: string[] = [header, ''];
 
   if (reviews.length === 0) {
-    parts.push(`> Review timed out after ${timeoutMinutes} minutes.`);
+    parts.push(`> ${label} timed out after ${timeoutMinutes} minutes.`);
   } else {
     parts.push(
-      `> Review timed out after ${timeoutMinutes} minutes. ${reviews.length} partial review(s) collected.`,
+      `> ${label} timed out after ${timeoutMinutes} minutes. ${reviews.length} partial review(s) collected.`,
     );
 
     for (let i = 0; i < reviews.length; i++) {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -280,7 +280,7 @@ export async function checkTimeouts(
       try {
         const token = await github.getInstallationToken(task.github_installation_id);
         const timeoutMinutes = Math.round((task.timeout_at - task.created_at) / 60000);
-        const body = formatTimeoutComment(timeoutMinutes, allReviews);
+        const body = formatTimeoutComment(timeoutMinutes, allReviews, task.feature);
         // Post to issue_number for issue tasks, pr_number for PR tasks
         const commentTarget = task.pr_number > 0 ? task.pr_number : task.issue_number;
         if (commentTarget) {
@@ -322,7 +322,7 @@ export async function checkTimeouts(
           review_text: claim.review_text!,
         }));
 
-        const body = formatTimeoutComment(timeoutMinutes, reviews);
+        const body = formatTimeoutComment(timeoutMinutes, reviews, task.feature);
         // Post to issue_number for issue tasks, pr_number for PR tasks
         const commentTarget = task.pr_number > 0 ? task.pr_number : task.issue_number;
         if (commentTarget) {
@@ -600,7 +600,7 @@ async function handleImplementSummaryResult(
   }
 
   const token = await github.getInstallationToken(task.github_installation_id);
-  const commentBody = wrapReviewComment(reviewText.trim());
+  const commentBody = wrapReviewComment(reviewText.trim(), undefined, 'OpenCara Go');
   await github.postPrComment(task.owner, task.repo, task.issue_number, commentBody, token);
 
   logger.info('Implement result posted to GitHub', {
@@ -630,7 +630,7 @@ async function handleFixSummaryResult(
   }
 
   const token = await github.getInstallationToken(task.github_installation_id);
-  const commentBody = wrapReviewComment(reviewText.trim());
+  const commentBody = wrapReviewComment(reviewText.trim(), undefined, 'OpenCara Fix');
   await github.postPrComment(task.owner, task.repo, task.pr_number, commentBody, token);
 
   logger.info('Fix result posted to PR', {
@@ -712,7 +712,7 @@ async function postFallbackConsolidatedReview(
       review_text: c.review_text!,
     }));
 
-    const body = formatTimeoutComment(timeoutMinutes, reviews);
+    const body = formatTimeoutComment(timeoutMinutes, reviews, task.feature);
     await github.postPrComment(task.owner, task.repo, task.pr_number, body, token);
 
     logger.info('Fallback consolidated review posted', {


### PR DESCRIPTION
Part of #708

## Summary
- Implement results now display "OpenCara Go" header instead of generic "OpenCara Review"
- Fix results now display "OpenCara Fix" header
- Timeout comments use feature-appropriate headers and labels (e.g., "Go timed out" instead of "Review timed out")
- Added `FEATURE_HEADERS` and `FEATURE_TIMEOUT_LABELS` maps keyed by `Feature` type
- 5 new tests covering feature-specific formatting

Supersedes #709 (stale/conflicting, reimplemented cleanly from main)

## Test plan
- [x] All 2908 tests pass
- [x] Build, lint, format, typecheck all green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>