### PR TITLE
[cli-dev] Fix private mode to check collaborator access

### DIFF
--- a/packages/shared/src/__tests__/coverage-gaps.test.ts
+++ b/packages/shared/src/__tests__/coverage-gaps.test.ts
@@ -53,7 +53,7 @@ describe('isRepoAllowed edge cases', () => {
     const config = { mode: 'private' as const, list: ['my-org/allowed-repo'] };
     expect(isRepoAllowed(config, 'my-org', 'allowed-repo', 'alice', orgs)).toBe(true);
     expect(isRepoAllowed(config, 'my-org', 'other-repo', 'alice', orgs)).toBe(false);
-    // Not accessible org — rejected even if in list
+    // Explicitly-listed repo under non-org owner — allowed (collaborator access)
     expect(
       isRepoAllowed(
         { mode: 'private', list: ['unknown-org/repo'] },
@@ -62,7 +62,7 @@ describe('isRepoAllowed edge cases', () => {
         'alice',
         orgs,
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('mode=private with list and own repos', () => {
@@ -73,6 +73,20 @@ describe('isRepoAllowed edge cases', () => {
 
   it('mode=private without list allows all own repos', () => {
     expect(isRepoAllowed({ mode: 'private' }, 'alice', 'any-repo', 'alice')).toBe(true);
+  });
+
+  it('mode=private with list allows collaborator repos (not org member)', () => {
+    // User is not an org member but has collaborator access — explicitly-listed repos pass
+    const config = { mode: 'private' as const, list: ['external-org/collab-repo'] };
+    expect(isRepoAllowed(config, 'external-org', 'collab-repo', 'alice')).toBe(true);
+    // Repo not in list is still rejected
+    expect(isRepoAllowed(config, 'external-org', 'other-repo', 'alice')).toBe(false);
+  });
+
+  it('mode=private with list allows collaborator repos even with empty userOrgs', () => {
+    const emptyOrgs = new Set<string>();
+    const config = { mode: 'private' as const, list: ['external-org/collab-repo'] };
+    expect(isRepoAllowed(config, 'external-org', 'collab-repo', 'alice', emptyOrgs)).toBe(true);
   });
 
   it('mode=private with empty list allows all accessible repos', () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -232,18 +232,18 @@ export function isRepoAllowed(
     case 'public':
       return true;
     case 'private': {
-      // GitHub owner names are case-insensitive — normalize for comparison
-      const normalizedTarget = targetOwner.toLowerCase();
-      const normalizedOwner = agentOwner?.toLowerCase();
-      const hasAccess =
-        normalizedOwner === normalizedTarget ||
-        (userOrgs != null && userOrgs.has(normalizedTarget));
-      if (!hasAccess) return false;
-      // list absent or empty — no further restriction; allow all accessible repos
+      // Explicitly-listed repos are always allowed — actual access is verified
+      // by verifyRepoAccess() which checks GET /repos/{owner}/{repo}.
+      // This ensures collaborator-access repos (not org members) are included.
       if (repoConfig.list && repoConfig.list.length > 0) {
         return repoConfig.list.includes(fullRepo);
       }
-      return true;
+      // No explicit list — fall back to org/owner heuristic
+      const normalizedTarget = targetOwner.toLowerCase();
+      const normalizedOwner = agentOwner?.toLowerCase();
+      return (
+        normalizedOwner === normalizedTarget || (userOrgs != null && userOrgs.has(normalizedTarget))
+      );
     }
     case 'whitelist':
       return (repoConfig.list ?? []).includes(fullRepo);


### PR DESCRIPTION
Part of #718

## Summary
- Fixed `isRepoAllowed()` in `packages/shared/src/types.ts` to check the explicit repo list **before** the org membership heuristic when `mode='private'`
- Previously, repos under non-org owners were rejected even if explicitly listed in `agents.repos.list` — this silently excluded collaborator-access repos
- The org/owner heuristic now only applies when no explicit list is configured (unlisted repos)
- Actual GitHub API access is already verified by `verifyRepoAccess()` which calls `GET /repos/{owner}/{repo}`
- Updated existing test expectation and added new tests for collaborator-access scenarios

## Test plan
- Existing test for "not accessible org — rejected even if in list" updated to expect `true` (the fix)
- New test: `mode=private with list allows collaborator repos (not org member)` — verifies listed repos pass, unlisted repos still rejected
- New test: `mode=private with list allows collaborator repos even with empty userOrgs` — verifies behavior with empty org set
- All 2908 existing tests pass
- Build, lint, format, and typecheck all pass