### PR TITLE
fix: log filtered tasks and bypass diff limit for explicit repos

### DIFF
--- a/packages/cli/src/batch-poll.ts
+++ b/packages/cli/src/batch-poll.ts
@@ -130,6 +130,15 @@ export function buildBatchPollRequest(agents: AgentDescriptor[]): BatchPollReque
  * Filter tasks for a specific agent using its repo config and diff size limit.
  * Mirrors the per-agent filtering in the existing pollLoop.
  */
+export interface FilterTasksOptions {
+  maxDiffSizeKb?: number;
+  diffFailCounts?: Map<string, number>;
+  maxDiffFetchAttempts?: number;
+  accessibleRepos?: ReadonlySet<string>;
+  /** Optional logger for reporting filtered-out tasks. */
+  log?: (msg: string) => void;
+}
+
 export function filterTasksForAgent(
   tasks: PollTask[],
   agent: AgentDescriptor,
@@ -137,10 +146,13 @@ export function filterTasksForAgent(
   diffFailCounts?: Map<string, number>,
   maxDiffFetchAttempts: number = 3,
   accessibleRepos?: ReadonlySet<string>,
+  log?: (msg: string) => void,
 ): PollTask[] {
   return tasks.filter((t) => {
+    const repo = `${t.owner}/${t.repo}`;
     // Filter by verified repo access
-    if (accessibleRepos && !accessibleRepos.has(`${t.owner}/${t.repo}`)) {
+    if (accessibleRepos && !accessibleRepos.has(repo)) {
+      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not in accessible set`);
       return false;
     }
     // Filter by repo config
@@ -148,6 +160,7 @@ export function filterTasksForAgent(
       agent.repoConfig &&
       !isRepoAllowed(agent.repoConfig, t.owner, t.repo, agent.agentOwner, agent.userOrgs)
     ) {
+      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by config (mode=${agent.repoConfig.mode})`);
       return false;
     }
     // Filter by synthesize_repos config
@@ -155,19 +168,26 @@ export function filterTasksForAgent(
       agent.synthesizeRepos &&
       !isRepoAllowed(agent.synthesizeRepos, t.owner, t.repo, agent.agentOwner, agent.userOrgs)
     ) {
+      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by synthesize_repos config`);
       return false;
     }
     // Skip tasks whose diff_size clearly exceeds maxDiffSizeKb
     // 120 bytes/line is the estimated average for unified diff format
+    // Explicitly listed repos bypass this check — if you listed it, you want it reviewed.
+    const isExplicitlyListed = agent.repoConfig?.list?.includes(repo) ?? false;
     if (
+      !isExplicitlyListed &&
       maxDiffSizeKb &&
       t.diff_size != null &&
       (t.diff_size * ESTIMATED_BYTES_PER_DIFF_LINE) / 1024 > maxDiffSizeKb
     ) {
+      const estimatedKb = Math.round((t.diff_size * ESTIMATED_BYTES_PER_DIFF_LINE) / 1024);
+      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — estimated diff ${estimatedKb}KB exceeds max_diff_size_kb (${maxDiffSizeKb}KB)`);
       return false;
     }
     // Skip tasks that have failed diff fetch too many times
     if (diffFailCounts && (diffFailCounts.get(t.task_id) ?? 0) >= maxDiffFetchAttempts) {
+      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — diff fetch failed ${maxDiffFetchAttempts} times`);
       return false;
     }
     return true;

--- a/packages/cli/src/batch-poll.ts
+++ b/packages/cli/src/batch-poll.ts
@@ -152,7 +152,9 @@ export function filterTasksForAgent(
     const repo = `${t.owner}/${t.repo}`;
     // Filter by verified repo access
     if (accessibleRepos && !accessibleRepos.has(repo)) {
-      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not in accessible set`);
+      log?.(
+        `Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not in accessible set`,
+      );
       return false;
     }
     // Filter by repo config
@@ -160,7 +162,9 @@ export function filterTasksForAgent(
       agent.repoConfig &&
       !isRepoAllowed(agent.repoConfig, t.owner, t.repo, agent.agentOwner, agent.userOrgs)
     ) {
-      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by config (mode=${agent.repoConfig.mode})`);
+      log?.(
+        `Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by config (mode=${agent.repoConfig.mode})`,
+      );
       return false;
     }
     // Filter by synthesize_repos config
@@ -168,7 +172,9 @@ export function filterTasksForAgent(
       agent.synthesizeRepos &&
       !isRepoAllowed(agent.synthesizeRepos, t.owner, t.repo, agent.agentOwner, agent.userOrgs)
     ) {
-      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by synthesize_repos config`);
+      log?.(
+        `Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — repo not allowed by synthesize_repos config`,
+      );
       return false;
     }
     // Skip tasks whose diff_size clearly exceeds maxDiffSizeKb
@@ -182,12 +188,16 @@ export function filterTasksForAgent(
       (t.diff_size * ESTIMATED_BYTES_PER_DIFF_LINE) / 1024 > maxDiffSizeKb
     ) {
       const estimatedKb = Math.round((t.diff_size * ESTIMATED_BYTES_PER_DIFF_LINE) / 1024);
-      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — estimated diff ${estimatedKb}KB exceeds max_diff_size_kb (${maxDiffSizeKb}KB)`);
+      log?.(
+        `Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — estimated diff ${estimatedKb}KB exceeds max_diff_size_kb (${maxDiffSizeKb}KB)`,
+      );
       return false;
     }
     // Skip tasks that have failed diff fetch too many times
     if (diffFailCounts && (diffFailCounts.get(t.task_id) ?? 0) >= maxDiffFetchAttempts) {
-      log?.(`Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — diff fetch failed ${maxDiffFetchAttempts} times`);
+      log?.(
+        `Skipping task ${t.task_id.slice(0, 8)}… (${repo} PR#${t.pr_number}) — diff fetch failed ${maxDiffFetchAttempts} times`,
+      );
       return false;
     }
     return true;

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1795,6 +1795,7 @@ export async function batchPollLoop(
           state.diffFailCounts,
           MAX_DIFF_FETCH_ATTEMPTS,
           accessibleRepos,
+          (msg) => state.logger.logWarn(`${icons.warn} ${msg}`),
         );
 
         const task = eligible[0];


### PR DESCRIPTION
## Summary
- `filterTasksForAgent` now logs warnings when tasks are skipped instead of silently dropping them
- Explicitly listed repos in `agents.repos.list` bypass the `max_diff_size_kb` check — if you listed it, you want it reviewed
- Fix bidirectional comment trigger matching (`@opencara review` config now also matches `/opencara review` comments)

## Root cause
Tasks were silently filtered client-side when `diff_size * 120 bytes/line` exceeded `max_diff_size_kb` (default 100KB). A 927-line diff estimated at 108KB was dropped with zero logging, making it impossible to diagnose.

## Test plan
- [x] `pnpm build && pnpm test` — 2908 tests pass
- [x] Verified with debug logging that tasks are now claimed for bank-demo PRs