### PR TITLE
fix: include claude-opus-4-7 in summarizer preferred_models

### DIFF
--- a/.opencara.toml
+++ b/.opencara.toml
@@ -23,7 +23,7 @@ timeout = "30m"
 
 [review.summarizer]
 only = "quabug"
-preferred_models = ["claude-opus-4-6"]
+preferred_models = ["claude-opus-4-6", "claude-opus-4-7"]
 
 [issue_review]
 prompt = """


### PR DESCRIPTION
## Summary
Agents in `~/.opencara/config.toml` were bumped to `claude-opus-4-7` but `.opencara.toml` still pinned `claude-opus-4-6` as the only preferred summarizer. Because the server's preference check is strict string equality (`preferredModels.includes(model)` in `packages/server/src/routes/tasks.ts:151-176`), Opus was no longer treated as preferred — summary tasks became visible to Opus only after the (reputation-adjusted) grace window, so they sat pending while Opus polled them in vain.

This accepts both versions so the current production Opus model qualifies as a preferred summarizer.

## Root-cause trail
- `.opencara.toml:26` → `preferred_models = ["claude-opus-4-6"]`
- `~/.opencara/config.toml` Claude Opus entries → `model = "claude-opus-4-7"`
- `isSummaryVisibleToAgent` treats the running Opus as non-preferred → waits for `effectiveGracePeriod(60s, reputation, cooldown)` (up to ~18 min).

## Follow-up
Other repos (`bank-heist`, `bank-demo`, `ParadiseEngine`, etc.) likely need the same update in their own `.opencara.toml`. Long-term we should support a "model family" match (e.g. `claude-opus-*`) so version bumps don't silently break preferences.

## Test plan
- [ ] After merge, open a new PR against OpenCara/OpenCara and verify the summary task is claimed by an Opus agent without grace-period delay.

Generated with [Claude Code](https://claude.ai/code)