### PR TITLE
feat: model-family matching for preferred_models and target_model

### DIFF
--- a/docs/src/content/docs/features/implement-fix.md
+++ b/docs/src/content/docs/features/implement-fix.md
@@ -76,7 +76,7 @@ Slash Command → Webhook → Server creates task in D1
 ```
 
 - **Case-insensitive** — `/OpenCara GO claude` works.
-- The optional `[model]` parameter sets `target_model` on the task, which causes the platform to prefer agents running that specific model.
+- The optional `[model]` parameter sets `target_model` on the task, which causes the platform to prefer agents running that specific model. Matching uses the same family-prefix rules as `preferred_models` — e.g. `claude-opus` matches any `claude-opus-*` variant.
 - Parsed by the `parseGoCommand()` function using the regex: `^[/@]opencara\s+go(?:\s+(\S+))?\s*$`
 
 **Examples:**

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -104,14 +104,14 @@ preferred_tools = ["claude", "codex"]
 model_diversity_grace = "30s"
 ```
 
-| Field                   | Type     | Default      | Description                                                                                                                                    |
-| ----------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `prompt`                | string   | _(required)_ | Instructions sent to review agents. Be specific about your tech stack and what matters.                                                        |
-| `agent_count`           | number   | `1`          | Number of review agents (1–10). When > 1, individual reviews are collected, then a synthesizer merges them into a single consolidated comment. |
-| `timeout`               | string   | `"10m"`      | How long to wait for review slots to fill (`1m`–`30m`).                                                                                        |
-| `preferred_models`      | string[] | `[]`         | Preferred AI models. Matching agents are selected first when claiming slots.                                                                   |
-| `preferred_tools`       | string[] | `[]`         | Preferred AI tool types (e.g., `claude`, `codex`, `gemini`, `qwen`).                                                                           |
-| `model_diversity_grace` | string   | `"30s"`      | Grace period for model diversity preference. See [Model Diversity Grace Period](#model-diversity-grace-period).                                |
+| Field                   | Type     | Default      | Description                                                                                                                                                                                                        |
+| ----------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `prompt`                | string   | _(required)_ | Instructions sent to review agents. Be specific about your tech stack and what matters.                                                                                                                            |
+| `agent_count`           | number   | `1`          | Number of review agents (1–10). When > 1, individual reviews are collected, then a synthesizer merges them into a single consolidated comment.                                                                     |
+| `timeout`               | string   | `"10m"`      | How long to wait for review slots to fill (`1m`–`30m`).                                                                                                                                                            |
+| `preferred_models`      | string[] | `[]`         | Preferred AI models. Matching agents are selected first when claiming slots. Entries match exactly or as a family prefix — e.g. `claude-opus` matches `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-7[1m]`. |
+| `preferred_tools`       | string[] | `[]`         | Preferred AI tool types (e.g., `claude`, `codex`, `gemini`, `qwen`).                                                                                                                                               |
+| `model_diversity_grace` | string   | `"30s"`      | Grace period for model diversity preference. See [Model Diversity Grace Period](#model-diversity-grace-period).                                                                                                    |
 
 ---
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -15,7 +15,7 @@ import type {
   BatchPollResponse,
   RepoConfig,
 } from '@opencara/shared';
-import { isRepoAllowed, isEntityMatch, isDedupRole } from '@opencara/shared';
+import { isRepoAllowed, isEntityMatch, isDedupRole, anyModelMatches } from '@opencara/shared';
 import type { Env, AppVariables } from '../types.js';
 import type { DataStore } from '../store/interface.js';
 import type { GitHubService } from '../github/service.js';
@@ -80,7 +80,7 @@ function isReviewPreferredAgent(
 ): boolean {
   const { preferredModels, preferredTools } = config;
   if (preferredModels.length === 0 && preferredTools.length === 0) return true;
-  if (model && preferredModels.includes(model)) return true;
+  if (anyModelMatches(preferredModels, model)) return true;
   if (tool && preferredTools.includes(tool)) return true;
   return false;
 }
@@ -111,7 +111,7 @@ function isTargetModelVisible(
   effectiveGraceMs?: number,
 ): boolean {
   if (!task.target_model) return true; // no preference — visible to all
-  if (model && model.toLowerCase() === task.target_model.toLowerCase()) return true; // model matches
+  if (anyModelMatches([task.target_model], model)) return true; // model matches (exact or family prefix)
   const graceMs = effectiveGraceMs ?? TARGET_MODEL_GRACE_PERIOD_MS;
   return Date.now() - task.created_at >= graceMs;
 }
@@ -165,7 +165,7 @@ function isSummaryVisibleToAgent(
   if (preferred.length > 0 && preferred.some((p) => isEntityMatch(p, agentId))) return true;
 
   // Check model-based preference
-  if (preferredModels.length > 0 && model && preferredModels.includes(model)) return true;
+  if (preferredModels.length > 0 && anyModelMatches(preferredModels, model)) return true;
 
   // Non-preferred agent: check if grace period has elapsed since summary phase started.
   // Use reviews_completed_at (when all reviews finished and summary became claimable)

--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -4,6 +4,8 @@ import {
   parseReviewConfig,
   parseEntityList,
   isEntityMatch,
+  modelMatchesPattern,
+  anyModelMatches,
   isEventTriggerEnabled,
   isCommentTriggerEnabled,
   isLabelTriggerEnabled,
@@ -850,6 +852,64 @@ describe('isEntityMatch', () => {
 
   it('handles entry with no fields', () => {
     expect(isEntityMatch({}, 'a1', 'alice')).toBe(false);
+  });
+});
+
+describe('modelMatchesPattern', () => {
+  it('matches exact model name', () => {
+    expect(modelMatchesPattern('claude-opus-4-6', 'claude-opus-4-6')).toBe(true);
+  });
+
+  it('matches family prefix at dash boundary', () => {
+    expect(modelMatchesPattern('claude-opus', 'claude-opus-4-6')).toBe(true);
+    expect(modelMatchesPattern('claude-opus', 'claude-opus-4-7')).toBe(true);
+  });
+
+  it('matches family prefix at bracket boundary', () => {
+    expect(modelMatchesPattern('claude-opus-4-6', 'claude-opus-4-6[1m]')).toBe(true);
+    expect(modelMatchesPattern('claude-opus', 'claude-opus-4-7[1m]')).toBe(true);
+  });
+
+  it('matches family prefix at dot boundary', () => {
+    expect(modelMatchesPattern('gpt-5', 'gpt-5.4')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(modelMatchesPattern('Claude-Opus', 'claude-opus-4-6')).toBe(true);
+    expect(modelMatchesPattern('claude-opus', 'CLAUDE-OPUS-4-6')).toBe(true);
+  });
+
+  it('does not match unrelated families', () => {
+    expect(modelMatchesPattern('claude-opus', 'claude-sonnet-4-6')).toBe(false);
+    expect(modelMatchesPattern('claude-opus-4-6', 'claude-opus-4-7')).toBe(false);
+    expect(modelMatchesPattern('gpt-5', 'gpt-4o')).toBe(false);
+  });
+
+  it('does not match when pattern is not a clean prefix', () => {
+    // "claude-op" is a prefix of "claude-opus" but the next char is "u", not a boundary
+    expect(modelMatchesPattern('claude-op', 'claude-opus-4-6')).toBe(false);
+  });
+
+  it('does not match when model is a prefix of pattern', () => {
+    expect(modelMatchesPattern('claude-opus-4-6', 'claude-opus')).toBe(false);
+  });
+});
+
+describe('anyModelMatches', () => {
+  it('returns false for empty pattern list', () => {
+    expect(anyModelMatches([], 'claude-opus-4-6')).toBe(false);
+  });
+
+  it('returns false when model is undefined', () => {
+    expect(anyModelMatches(['claude-opus'], undefined)).toBe(false);
+  });
+
+  it('returns true when any pattern matches', () => {
+    expect(anyModelMatches(['claude-sonnet', 'claude-opus'], 'claude-opus-4-7')).toBe(true);
+  });
+
+  it('returns false when no pattern matches', () => {
+    expect(anyModelMatches(['claude-sonnet', 'gpt-5'], 'claude-opus-4-7')).toBe(false);
   });
 });
 

--- a/packages/shared/src/__tests__/review-config.test.ts
+++ b/packages/shared/src/__tests__/review-config.test.ts
@@ -893,6 +893,11 @@ describe('modelMatchesPattern', () => {
   it('does not match when model is a prefix of pattern', () => {
     expect(modelMatchesPattern('claude-opus-4-6', 'claude-opus')).toBe(false);
   });
+
+  it('treats empty pattern as never matching', () => {
+    expect(modelMatchesPattern('', 'claude-opus-4-6')).toBe(false);
+    expect(modelMatchesPattern('', '')).toBe(false);
+  });
 });
 
 describe('anyModelMatches', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -77,6 +77,8 @@ export {
   parseReviewConfig,
   parseEntityList,
   isEntityMatch,
+  modelMatchesPattern,
+  anyModelMatches,
   parseTriggerSection,
   isEventTriggerEnabled,
   isCommentTriggerEnabled,

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -186,6 +186,7 @@ export function isEntityMatch(
  *   "gpt-5"            matches "gpt-5.4", "gpt-5-codex"
  */
 export function modelMatchesPattern(pattern: string, model: string): boolean {
+  if (!pattern) return false;
   const p = pattern.toLowerCase();
   const m = model.toLowerCase();
   if (p === m) return true;

--- a/packages/shared/src/review-config.ts
+++ b/packages/shared/src/review-config.ts
@@ -172,6 +172,34 @@ export function isEntityMatch(
   return false;
 }
 
+/**
+ * Check if a model-name pattern matches an actual model identifier.
+ *
+ * Supports exact match and "family" prefixes: a pattern matches the model if
+ * it equals the model, or is a prefix of the model that ends at a version
+ * boundary (`-`, `.`, or `[`). Matching is case-insensitive.
+ *
+ * Examples:
+ *   "claude-opus"      matches "claude-opus-4-6", "claude-opus-4-7[1m]"
+ *   "claude-opus-4-6"  matches "claude-opus-4-6", "claude-opus-4-6[1m]"
+ *                      but NOT "claude-opus-4-7"
+ *   "gpt-5"            matches "gpt-5.4", "gpt-5-codex"
+ */
+export function modelMatchesPattern(pattern: string, model: string): boolean {
+  const p = pattern.toLowerCase();
+  const m = model.toLowerCase();
+  if (p === m) return true;
+  if (!m.startsWith(p)) return false;
+  const next = m.charAt(p.length);
+  return next === '-' || next === '.' || next === '[';
+}
+
+/** Whether any of the given patterns matches the model (empty list = no match). */
+export function anyModelMatches(patterns: readonly string[], model: string | undefined): boolean {
+  if (!model) return false;
+  return patterns.some((p) => modelMatchesPattern(p, model));
+}
+
 function parseTimeout(value: unknown): string {
   if (typeof value !== 'string') return '10m';
   const match = value.match(/^(\d+)m$/);


### PR DESCRIPTION
## Summary
Adds a `modelMatchesPattern(pattern, model)` helper that lets `preferred_models` / `target_model` entries match either an exact model name or a family prefix ending at a version boundary (`-`, `.`, `[`). The three server call sites that previously used strict string equality now use the helper.

Motivation: bumping Opus from `claude-opus-4-6` to `claude-opus-4-7` silently dropped it from the preferred list in every `.opencara.toml`, stalling summary/review routing until the grace window elapsed (see PR #722 for the immediate config patch).

## Matching rules
| Pattern | Matches | Does not match |
|---|---|---|
| `claude-opus` | `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-7[1m]` | `claude-sonnet-4-6` |
| `claude-opus-4-6` | `claude-opus-4-6`, `claude-opus-4-6[1m]` | `claude-opus-4-7` |
| `gpt-5` | `gpt-5.4`, `gpt-5-codex` | `gpt-4o` |

Backward-compatible — any existing full model name keeps working exactly as before.

## Changes
- `packages/shared/src/review-config.ts` — new `modelMatchesPattern` + `anyModelMatches` helpers (exported from `@opencara/shared`).
- `packages/server/src/routes/tasks.ts` — `isReviewPreferredAgent`, `isTargetModelVisible`, `isSummaryVisibleToAgent` now use the helper.
- `packages/shared/src/__tests__/review-config.test.ts` — tests for exact, family-prefix, case-insensitive, and boundary behavior.
- `docs/src/content/docs/guides/configuration.md` — one-line note under `preferred_models`.

## Test plan
- [x] `pnpm build`
- [x] `pnpm test` (2920 passing, 12 new)
- [x] `pnpm lint`
- [x] `pnpm run format:check`
- [x] `pnpm run typecheck`
- [ ] After deploy, confirm `preferred_models = ["claude-opus"]` works end-to-end (summary claim without grace delay).

Generated with [Claude Code](https://claude.ai/code)