### PR TITLE
feat(server): per-agent reliability + weighted-random dispatch

### DIFF
--- a/packages/server/migrations/0018_agent_reliability.sql
+++ b/packages/server/migrations/0018_agent_reliability.sql
@@ -1,0 +1,15 @@
+-- Agent reliability events — rolling window of success/error outcomes per agent.
+-- Used to weight agents in the batch-poll dispatch shuffle so agents that have
+-- been failing recently are less likely to be assigned new tasks. Events age out
+-- after RELIABILITY_WINDOW_MS, so a broken agent recovers naturally once its
+-- failures fall off the window.
+
+CREATE TABLE agent_reliability_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK(outcome IN ('success', 'error')),
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_reliability_agent_time
+  ON agent_reliability_events(agent_id, created_at);

--- a/packages/server/src/__tests__/agent-reliability.test.ts
+++ b/packages/server/src/__tests__/agent-reliability.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { stubOAuthFetch, OAUTH_HEADERS } from './test-oauth-helper.js';
+import { DEFAULT_REVIEW_CONFIG, type ReviewTask } from '@opencara/shared';
+import { MemoryDataStore } from '../store/memory.js';
+import { createApp } from '../index.js';
+import { resetTimeoutThrottle } from '../routes/tasks.js';
+import { resetRateLimits } from '../middleware/rate-limit.js';
+import { RELIABILITY_WINDOW_MS } from '../store/constants.js';
+
+function makeTask(overrides: Partial<ReviewTask> = {}): ReviewTask {
+  return {
+    id: 'task-1',
+    owner: 'test-org',
+    repo: 'test-repo',
+    pr_number: 1,
+    pr_url: 'https://github.com/test-org/test-repo/pull/1',
+    diff_url: 'https://github.com/test-org/test-repo/pull/1.diff',
+    base_ref: 'main',
+    head_ref: 'feature',
+    review_count: 1,
+    prompt: 'Review this PR',
+    timeout_at: Date.now() + 600_000,
+    status: 'reviewing',
+    queue: 'summary',
+    github_installation_id: 123,
+    private: false,
+    config: DEFAULT_REVIEW_CONFIG,
+    created_at: Date.now(),
+    task_type: 'review',
+    feature: 'review',
+    group_id: 'group-1',
+    ...overrides,
+  };
+}
+
+const mockEnv = {
+  GITHUB_WEBHOOK_SECRET: 'test-secret',
+  GITHUB_APP_ID: '12345',
+  GITHUB_APP_PRIVATE_KEY: 'test-key',
+  WEB_URL: 'https://test.com',
+  GITHUB_CLIENT_ID: 'cid',
+  GITHUB_CLIENT_SECRET: 'csecret',
+};
+
+describe('Agent reliability — outcome recording', () => {
+  let store: MemoryDataStore;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    stubOAuthFetch();
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    app = createApp(store);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function request(method: string, path: string, body?: unknown) {
+    return app.request(
+      path,
+      {
+        method,
+        headers: { 'Content-Type': 'application/json', ...OAUTH_HEADERS },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      },
+      mockEnv,
+    );
+  }
+
+  it('records a success event when an agent submits a result', async () => {
+    await store.createTask(makeTask({ task_type: 'review', status: 'reviewing' }));
+    await store.createClaim({
+      id: 'task-1:agent-A:review',
+      task_id: 'task-1',
+      agent_id: 'agent-A',
+      role: 'review',
+      status: 'pending',
+      created_at: Date.now(),
+    });
+
+    const res = await request('POST', '/api/tasks/task-1/result', {
+      agent_id: 'agent-A',
+      type: 'review',
+      review_text: 'Looks good!',
+      verdict: 'approve',
+      tokens_used: 100,
+    });
+    expect(res.status).toBe(200);
+
+    const events = await store.getAgentReliabilityEventsBatch(
+      ['agent-A'],
+      Date.now() - RELIABILITY_WINDOW_MS,
+    );
+    const list = events.get('agent-A') ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0].outcome).toBe('success');
+  });
+
+  it('records an error event when an agent reports a tool error', async () => {
+    await store.createTask(makeTask({ task_type: 'review', status: 'reviewing' }));
+    await store.createClaim({
+      id: 'task-1:agent-B:review',
+      task_id: 'task-1',
+      agent_id: 'agent-B',
+      role: 'review',
+      status: 'pending',
+      created_at: Date.now(),
+    });
+
+    const res = await request('POST', '/api/tasks/task-1/error', {
+      agent_id: 'agent-B',
+      error: 'Tool crashed',
+    });
+    expect(res.status).toBe(200);
+
+    const events = await store.getAgentReliabilityEventsBatch(
+      ['agent-B'],
+      Date.now() - RELIABILITY_WINDOW_MS,
+    );
+    const list = events.get('agent-B') ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0].outcome).toBe('error');
+  });
+
+  it('getAgentReliabilityEventsBatch filters by timestamp window', async () => {
+    const oldIso = new Date(Date.now() - 2 * RELIABILITY_WINDOW_MS).toISOString();
+    const newIso = new Date().toISOString();
+    await store.recordAgentReliabilityEvent('agent-C', 'error', oldIso);
+    await store.recordAgentReliabilityEvent('agent-C', 'success', newIso);
+
+    const events = await store.getAgentReliabilityEventsBatch(
+      ['agent-C'],
+      Date.now() - RELIABILITY_WINDOW_MS,
+    );
+    const list = events.get('agent-C') ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0].outcome).toBe('success');
+  });
+});
+
+describe('Agent reliability — weighted dispatch', () => {
+  let store: MemoryDataStore;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    stubOAuthFetch();
+    resetTimeoutThrottle();
+    resetRateLimits();
+    store = new MemoryDataStore();
+    app = createApp(store);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function batchPoll(body: unknown) {
+    return app.request(
+      '/api/tasks/poll/batch',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...OAUTH_HEADERS },
+        body: JSON.stringify(body),
+      },
+      mockEnv,
+    );
+  }
+
+  it('prefers a high-reliability agent over a zero-reliability agent', async () => {
+    // agent-bad has only errors in the window → reliability = 0 → shuffle score = 0.
+    const now = new Date().toISOString();
+    for (let i = 0; i < 5; i++) {
+      await store.recordAgentReliabilityEvent('agent-bad', 'error', now);
+    }
+    // agent-good has only successes → reliability = 1.
+    await store.recordAgentReliabilityEvent('agent-good', 'success', now);
+
+    // One pending task, both agents accept role 'review' on a public repo.
+    await store.createTask(
+      makeTask({
+        id: 'only-task',
+        status: 'pending',
+        queue: 'review',
+        task_type: 'review',
+      }),
+    );
+
+    // Deterministic Math.random so score = weight * constant.
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    try {
+      const res = await batchPoll({
+        agents: [
+          { agent_name: 'agent-bad', roles: ['review'], model: 'm1', tool: 't1' },
+          { agent_name: 'agent-good', roles: ['review'], model: 'm2', tool: 't2' },
+        ],
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        assignments: Record<string, { tasks: Array<{ task_id: string }> }>;
+      };
+      expect(body.assignments['agent-good'].tasks).toHaveLength(1);
+      expect(body.assignments['agent-bad'].tasks).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('an agent with no history still gets a neutral weight (not zero)', async () => {
+    // agent-fresh has no events → reliability defaults to 1.0.
+    await store.createTask(
+      makeTask({
+        id: 'only-task',
+        status: 'pending',
+        queue: 'review',
+        task_type: 'review',
+      }),
+    );
+
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    try {
+      const res = await batchPoll({
+        agents: [{ agent_name: 'agent-fresh', roles: ['review'], model: 'm', tool: 't' }],
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        assignments: Record<string, { tasks: Array<{ task_id: string }> }>;
+      };
+      expect(body.assignments['agent-fresh'].tasks).toHaveLength(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/__tests__/reliability.test.ts
+++ b/packages/server/src/__tests__/reliability.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { computeReliability, type ReliabilityEvent } from '../reliability.js';
+
+function event(outcome: 'success' | 'error'): ReliabilityEvent {
+  return { outcome, created_at: new Date().toISOString() };
+}
+
+describe('computeReliability', () => {
+  it('returns 1.0 for an empty history (no cold-start penalty)', () => {
+    expect(computeReliability([])).toBe(1.0);
+  });
+
+  it('returns 1.0 when all events succeeded', () => {
+    expect(computeReliability([event('success'), event('success'), event('success')])).toBe(1.0);
+  });
+
+  it('returns 0 when every event failed (no floor)', () => {
+    expect(computeReliability([event('error'), event('error'), event('error')])).toBe(0);
+  });
+
+  it('returns the success ratio for mixed outcomes', () => {
+    expect(
+      computeReliability([event('success'), event('success'), event('error'), event('error')]),
+    ).toBe(0.5);
+  });
+
+  it('handles a single event', () => {
+    expect(computeReliability([event('success')])).toBe(1.0);
+    expect(computeReliability([event('error')])).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/reputation-eligibility.test.ts
+++ b/packages/server/src/__tests__/reputation-eligibility.test.ts
@@ -3,12 +3,7 @@ import { stubOAuthFetch, OAUTH_HEADERS } from './test-oauth-helper.js';
 import { DEFAULT_REVIEW_CONFIG, type ReviewTask } from '@opencara/shared';
 import { MemoryDataStore } from '../store/memory.js';
 import { createApp } from '../index.js';
-import {
-  resetTimeoutThrottle,
-  PREFERRED_REVIEW_GRACE_PERIOD_MS,
-  PREFERRED_SYNTH_GRACE_PERIOD_MS,
-  TARGET_MODEL_GRACE_PERIOD_MS,
-} from '../routes/tasks.js';
+import { resetTimeoutThrottle, PREFERRED_REVIEW_GRACE_PERIOD_MS } from '../routes/tasks.js';
 import { resetRateLimits } from '../middleware/rate-limit.js';
 import { AGENT_REJECTION_THRESHOLD } from '../store/constants.js';
 import { computeAgentReputation, effectiveGracePeriod } from '../reputation.js';
@@ -129,153 +124,18 @@ describe('Reputation-based eligibility integration', () => {
     );
   }
 
-  // ── Grace period multiplier tests ─────────────────────────────
-
-  describe('grace period — reputation multiplier on worker tasks', () => {
-    it('proven good agent sees worker task earlier than default grace period', async () => {
-      // Create many upvotes so Wilson >= 0.7 → multiplier = 0.5
-      const events = makeReputationEvents('good-agent', 50, 5);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
-      // Verify Wilson score is in the "good" range
-      const repEvents = await store.getAgentReputationEvents('good-agent', 0);
-      const score = computeAgentReputation(repEvents);
-      expect(score).toBeGreaterThanOrEqual(0.7);
-
-      // Effective grace = 30s * 0.5 * 1.0 = 15s
-      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, score, null);
-      expect(effGrace).toBeLessThan(PREFERRED_REVIEW_GRACE_PERIOD_MS);
-
-      // Create a task with preferred models that DON'T match this agent
-      // Created 20s ago — past the effective grace (15s) but within default (30s)
-      await store.createTask(
-        makeTask({
-          id: 'review-1',
-          task_type: 'review',
-          config: {
-            ...DEFAULT_REVIEW_CONFIG,
-            preferredModels: ['gpt-5.4'],
-            preferredTools: [],
-          },
-          created_at: Date.now() - 20_000, // 20s ago
-        }),
-      );
-
-      resetRateLimits();
-      const res = await request('POST', '/api/tasks/poll', {
-        agent_id: 'good-agent',
-        model: 'claude-4',
-        tool: 'claude',
-      });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tasks: unknown[] };
-      // Good agent should see the task (effective grace 15s < 20s elapsed)
-      expect(body.tasks).toHaveLength(1);
-    });
-
-    it('neutral agent does not see worker task during default grace period', async () => {
-      // No reputation events → cold start Wilson ~0.15 → penalty multiplier
-      // But let's create a "neutral" agent with score ~0.5
-      const events = makeReputationEvents('neutral-agent', 20, 10);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
-      const repEvents = await store.getAgentReputationEvents('neutral-agent', 0);
-      const score = computeAgentReputation(repEvents);
-      // Score should be near neutral (0.4-0.7)
-      expect(score).toBeGreaterThanOrEqual(0.4);
-      expect(score).toBeLessThan(0.7);
-
-      // Effective grace = 30s * 1.0 * 1.0 = 30s (default)
-      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, score, null);
-      expect(effGrace).toBe(PREFERRED_REVIEW_GRACE_PERIOD_MS);
-
-      // Task created 20s ago — within default grace period
-      await store.createTask(
-        makeTask({
-          id: 'review-1',
-          task_type: 'review',
-          config: {
-            ...DEFAULT_REVIEW_CONFIG,
-            preferredModels: ['gpt-5.4'],
-            preferredTools: [],
-          },
-          created_at: Date.now() - 20_000,
-        }),
-      );
-
-      resetRateLimits();
-      const res = await request('POST', '/api/tasks/poll', {
-        agent_id: 'neutral-agent',
-        model: 'claude-4',
-        tool: 'claude',
-      });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tasks: unknown[] };
-      // Neutral agent should NOT see the task (30s grace > 20s elapsed)
-      expect(body.tasks).toHaveLength(0);
-    });
-
-    it('bad agent gets extended grace period (soft-blocking)', async () => {
-      // Create downvotes to push Wilson below 0.4 → penalty multiplier
-      const events = makeReputationEvents('bad-agent', 5, 50);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
-      const repEvents = await store.getAgentReputationEvents('bad-agent', 0);
-      const score = computeAgentReputation(repEvents);
-      expect(score).toBeLessThan(0.4);
-
-      // Effective grace should be significantly longer than base
-      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, score, null);
-      expect(effGrace).toBeGreaterThan(PREFERRED_REVIEW_GRACE_PERIOD_MS * 2);
-
-      // Task created 60s ago — past default grace (30s) but within extended grace
-      await store.createTask(
-        makeTask({
-          id: 'review-1',
-          task_type: 'review',
-          config: {
-            ...DEFAULT_REVIEW_CONFIG,
-            preferredModels: ['gpt-5.4'],
-            preferredTools: [],
-          },
-          created_at: Date.now() - 60_000,
-        }),
-      );
-
-      resetRateLimits();
-      const res = await request('POST', '/api/tasks/poll', {
-        agent_id: 'bad-agent',
-        model: 'claude-4',
-        tool: 'claude',
-      });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tasks: unknown[] };
-      // Bad agent should NOT see the task (extended grace > 60s elapsed)
-      expect(body.tasks).toHaveLength(0);
-    });
-  });
+  // ── Grace period cooldown tests ──────────────────────────────
+  //
+  // Reputation no longer extends the visibility grace window — it now
+  // contributes to the weighted-random shuffle in batch-poll dispatch
+  // (see src/routes/tasks.ts). What remains here is the cooldown
+  // multiplier, which still extends grace for agents that recently
+  // completed a review (prevents back-to-back same-agent claims).
 
   describe('grace period — cooldown multiplier', () => {
-    it('agent that just completed a review gets extended grace period', async () => {
-      // Create a neutral-scored agent
-      const events = makeReputationEvents('recent-agent', 20, 10);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
+    it('agent that just completed a review does not see a preferred-mismatch task during extended grace', async () => {
       // Record a completed claim to simulate recent review (2 minutes ago)
-      await store.createTask(
-        makeTask({
-          id: 'old-task',
-          status: 'completed',
-        }),
-      );
+      await store.createTask(makeTask({ id: 'old-task', status: 'completed' }));
       await store.createClaim({
         id: 'old-task:recent-agent:review',
         task_id: 'old-task',
@@ -285,11 +145,9 @@ describe('Reputation-based eligibility integration', () => {
         created_at: Date.now() - 2 * 60_000, // 2 min ago
       });
 
-      // Effective grace = 30s * 1.0 (neutral) * 2.0 (cooldown) = 60s
-      const repEvents = await store.getAgentReputationEvents('recent-agent', 0);
-      const score = computeAgentReputation(repEvents);
+      // Effective grace = 30s * 2.0 (cooldown) = 60s
       const lastCompleted = await store.getAgentLastCompletedClaimAt('recent-agent');
-      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, score, lastCompleted);
+      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, lastCompleted);
       expect(effGrace).toBe(PREFERRED_REVIEW_GRACE_PERIOD_MS * 2); // 60s
 
       // Task created 45s ago — past default (30s) but within cooldown-extended (60s)
@@ -318,109 +176,42 @@ describe('Reputation-based eligibility integration', () => {
       expect(body.tasks).toHaveLength(0);
     });
 
-    it('combined bad reputation + just reviewed = very long grace period', async () => {
-      const events = makeReputationEvents('very-bad-recent', 5, 50);
+    it('reputation no longer affects grace visibility', async () => {
+      // Very-bad-reputation agent — used to get a huge grace multiplier.
+      const events = makeReputationEvents('bad-rep', 5, 50);
       for (const e of events) {
         await store.recordReputationEvent(e);
       }
-
-      // Recent completed claim (2 min ago)
-      await store.createTask(makeTask({ id: 'old-task-2', status: 'completed' }));
-      await store.createClaim({
-        id: 'old-task-2:very-bad-recent:review',
-        task_id: 'old-task-2',
-        agent_id: 'very-bad-recent',
-        role: 'review',
-        status: 'completed',
-        created_at: Date.now() - 2 * 60_000,
-      });
-
-      const repEvents = await store.getAgentReputationEvents('very-bad-recent', 0);
+      const repEvents = await store.getAgentReputationEvents('bad-rep', 0);
       const score = computeAgentReputation(repEvents);
-      const lastCompleted = await store.getAgentLastCompletedClaimAt('very-bad-recent');
-      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, score, lastCompleted);
+      expect(score).toBeLessThan(0.4);
 
-      // Bad score (~0.06 → ~6.5x) * cooldown (2.0) → ~13x base → ~390s
-      expect(effGrace).toBeGreaterThan(300_000); // > 5 minutes
-    });
-  });
+      // Grace should be the plain base (no cooldown, no reputation factor).
+      const effGrace = effectiveGracePeriod(PREFERRED_REVIEW_GRACE_PERIOD_MS, null);
+      expect(effGrace).toBe(PREFERRED_REVIEW_GRACE_PERIOD_MS);
 
-  describe('grace period — target_model tasks', () => {
-    it('reputation multiplier applies to target_model grace period', async () => {
-      // Proven good agent
-      const events = makeReputationEvents('good-agent-tm', 50, 5);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
-      const repEvents = await store.getAgentReputationEvents('good-agent-tm', 0);
-      const score = computeAgentReputation(repEvents);
-      const effGrace = effectiveGracePeriod(TARGET_MODEL_GRACE_PERIOD_MS, score, null);
-      // 120s * 0.5 = 60s
-      expect(effGrace).toBeLessThan(TARGET_MODEL_GRACE_PERIOD_MS);
-
-      // Task with target_model that doesn't match, created 90s ago
-      // Past effective grace (60s) but within default (120s)
+      // Task created 45s ago — past default 30s grace → visible.
       await store.createTask(
         makeTask({
-          id: 'impl-1',
-          task_type: 'implement',
-          target_model: 'gpt-5.4',
-          created_at: Date.now() - 90_000,
-        }),
-      );
-
-      resetRateLimits();
-      const res = await request('POST', '/api/tasks/poll', {
-        agent_id: 'good-agent-tm',
-        model: 'claude-4',
-      });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tasks: unknown[] };
-      // Good agent sees it earlier due to reputation boost
-      expect(body.tasks).toHaveLength(1);
-    });
-  });
-
-  describe('grace period — summary tasks', () => {
-    it('reputation multiplier applies to summary grace period', async () => {
-      // Proven good agent
-      const events = makeReputationEvents('good-synth', 50, 5);
-      for (const e of events) {
-        await store.recordReputationEvent(e);
-      }
-
-      const repEvents = await store.getAgentReputationEvents('good-synth', 0);
-      const score = computeAgentReputation(repEvents);
-      const effGrace = effectiveGracePeriod(PREFERRED_SYNTH_GRACE_PERIOD_MS, score, null);
-      // 60s * 0.5 = 30s
-      expect(effGrace).toBeLessThan(PREFERRED_SYNTH_GRACE_PERIOD_MS);
-
-      // Summary task with preferred synthesizer that doesn't match, created 45s ago
-      await store.createTask(
-        makeTask({
-          id: 'summary-1',
-          task_type: 'summary',
+          id: 'review-rep',
+          task_type: 'review',
           config: {
             ...DEFAULT_REVIEW_CONFIG,
-            summarizer: {
-              ...DEFAULT_REVIEW_CONFIG.summarizer,
-              preferred: [{ agent: 'other-agent' }],
-            },
+            preferredModels: ['gpt-5.4'],
+            preferredTools: [],
           },
-          reviews_completed_at: Date.now() - 45_000,
-          created_at: Date.now() - 120_000,
+          created_at: Date.now() - 45_000,
         }),
       );
 
       resetRateLimits();
       const res = await request('POST', '/api/tasks/poll', {
-        agent_id: 'good-synth',
+        agent_id: 'bad-rep',
         model: 'claude-4',
+        tool: 'claude',
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as { tasks: unknown[] };
-      // Good agent sees summary earlier (effective grace 30s < 45s elapsed)
       expect(body.tasks).toHaveLength(1);
     });
   });

--- a/packages/server/src/__tests__/reputation.test.ts
+++ b/packages/server/src/__tests__/reputation.test.ts
@@ -249,32 +249,24 @@ describe('cooldownMultiplier', () => {
 describe('effectiveGracePeriod', () => {
   const BASE = 30_000; // 30s
 
-  it('proven good, idle → 15s', () => {
-    const result = effectiveGracePeriod(BASE, 0.81, Date.now() - 15 * 60_000);
-    expect(result).toBe(15_000); // 30s * 0.5 * 1.0
+  it('idle (fully cooled) → base', () => {
+    const result = effectiveGracePeriod(BASE, Date.now() - 15 * 60_000);
+    expect(result).toBe(30_000); // 30s * 1.0
   });
 
-  it('proven good, just reviewed → 30s', () => {
-    const result = effectiveGracePeriod(BASE, 0.81, Date.now() - 1 * 60_000);
-    expect(result).toBe(30_000); // 30s * 0.5 * 2.0
+  it('just reviewed → doubled', () => {
+    const result = effectiveGracePeriod(BASE, Date.now() - 1 * 60_000);
+    expect(result).toBe(60_000); // 30s * 2.0
   });
 
-  it('neutral, never reviewed → 30s', () => {
-    const result = effectiveGracePeriod(BASE, 0.5, null);
-    expect(result).toBe(30_000); // 30s * 1.0 * 1.0
+  it('never reviewed → base', () => {
+    const result = effectiveGracePeriod(BASE, null);
+    expect(result).toBe(30_000); // 30s * 1.0
   });
 
-  it('bad agent, idle → deprioritized', () => {
-    // 0.20 → multiplier = 3^1 = 3
-    const result = effectiveGracePeriod(BASE, 0.2, Date.now() - 20 * 60_000);
-    expect(result).toBeCloseTo(90_000, -3); // 30s * 3.0 * 1.0
-  });
-
-  it('very bad agent, just reviewed → heavily penalized', () => {
-    // 0.06 → multiplier ≈ 6.47
-    const result = effectiveGracePeriod(BASE, 0.06, Date.now() - 2 * 60_000);
-    // 30s * ~6.47 * 2.0 ≈ ~388s
-    expect(result).toBeGreaterThan(300_000);
+  it('half-cooled (5–10 min) → 1.5×', () => {
+    const result = effectiveGracePeriod(BASE, Date.now() - 7 * 60_000);
+    expect(result).toBe(45_000); // 30s * 1.5
   });
 });
 

--- a/packages/server/src/reliability.ts
+++ b/packages/server/src/reliability.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-agent reliability score, derived from recent success/error outcomes.
+ *
+ * Used as a multiplier (alongside the reputation Wilson score) in the
+ * weighted-random agent shuffle during batch-poll dispatch. An agent that
+ * has been failing recently gets a lower shuffle score and is less likely
+ * to be assigned new tasks. Because events age out of the
+ * RELIABILITY_WINDOW_MS window, a broken agent recovers naturally — no
+ * explicit backoff is needed.
+ */
+
+export interface ReliabilityEvent {
+  outcome: 'success' | 'error';
+  created_at: string;
+}
+
+/**
+ * Compute an agent's reliability from recent outcome events.
+ *
+ * - No history → `1.0` (trust by default — avoids cold-start penalty).
+ * - Otherwise → `successes / total` in `[0, 1]`.
+ *
+ * No floor: an agent with every recent event failing scores `0` and will
+ * not be picked by the weighted shuffle. Aging-out of events (queries
+ * filter by `RELIABILITY_WINDOW_MS`) restores the score to `1.0` once the
+ * last failure falls outside the window.
+ */
+export function computeReliability(events: readonly ReliabilityEvent[]): number {
+  if (events.length === 0) return 1.0;
+  let successes = 0;
+  for (const e of events) {
+    if (e.outcome === 'success') successes++;
+  }
+  return successes / events.length;
+}

--- a/packages/server/src/reputation.ts
+++ b/packages/server/src/reputation.ts
@@ -78,14 +78,16 @@ export function cooldownMultiplier(lastReviewAt: number | null): number {
 }
 
 /**
- * Combined effective grace period applying both reputation and cooldown multipliers.
+ * Effective grace period for preferred-vs-unpreferred time priority.
+ *
+ * Only the cooldown multiplier is applied here — reputation no longer extends
+ * the grace window. Reputation instead contributes to the weighted shuffle in
+ * batch-poll dispatch (see `POST /api/tasks/poll/batch`), so a good-reputation
+ * agent is more likely to be picked when multiple agents race for the same
+ * task rather than seeing it earlier in time.
  */
-export function effectiveGracePeriod(
-  baseMs: number,
-  score: number,
-  lastReviewAt: number | null,
-): number {
-  return baseMs * reputationMultiplier(score) * cooldownMultiplier(lastReviewAt);
+export function effectiveGracePeriod(baseMs: number, lastReviewAt: number | null): number {
+  return baseMs * cooldownMultiplier(lastReviewAt);
 }
 
 /**

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -32,8 +32,10 @@ import {
   AGENT_REJECTION_THRESHOLD,
   AGENT_REJECTION_WINDOW_MS,
   REPUTATION_SCORE_WINDOW_MS,
+  RELIABILITY_WINDOW_MS,
 } from '../store/constants.js';
 import { computeAgentReputation, effectiveGracePeriod } from '../reputation.js';
+import { computeReliability } from '../reliability.js';
 import { evaluateSummaryQuality, MAX_SUMMARY_RETRIES } from '../summary-evaluator.js';
 import { isAgentEligibleForRole } from '../eligibility.js';
 import { rateLimitByAgent, rateLimitByIdentity } from '../middleware/rate-limit.js';
@@ -867,33 +869,22 @@ async function filterTasksForAgent(
 ): Promise<PollTask[]> {
   const { tasks, tasksById, dedupBlockedRepos, oldestDedupPerRepo, groupClaimedModels } = ctx;
 
-  // Fetch agent reputation data for grace period multiplier computation
-  const reputationSinceMs = Date.now() - REPUTATION_SCORE_WINDOW_MS;
-  const [reputationEvents, lastCompletedAt] = await Promise.all([
-    store.getAgentReputationEvents(agent.agentId, reputationSinceMs),
-    store.getAgentLastCompletedClaimAt(agent.agentId),
-  ]);
-
-  // Only apply reputation multiplier when there are actual reputation events.
-  // Agents with no history get default grace periods (backward-compatible).
-  // Cooldown multiplier always applies for fair task distribution.
-  const hasReputation = reputationEvents.length > 0;
-  const wilsonScore = hasReputation ? computeAgentReputation(reputationEvents) : 0.5;
+  // Cooldown multiplier (per-agent back-to-back spacing) is still applied
+  // to grace periods; reputation now contributes to the weighted dispatch
+  // shuffle in batch poll instead of extending this time window.
+  const lastCompletedAt = await store.getAgentLastCompletedClaimAt(agent.agentId);
 
   // Pre-compute effective grace periods for each base duration
   const effectiveReviewGraceMs = effectiveGracePeriod(
     PREFERRED_REVIEW_GRACE_PERIOD_MS,
-    wilsonScore,
     lastCompletedAt,
   );
   const effectiveTargetModelGraceMs = effectiveGracePeriod(
     TARGET_MODEL_GRACE_PERIOD_MS,
-    wilsonScore,
     lastCompletedAt,
   );
   const effectiveSummaryGraceMs = effectiveGracePeriod(
     PREFERRED_SYNTH_GRACE_PERIOD_MS,
-    wilsonScore,
     lastCompletedAt,
   );
 
@@ -1218,12 +1209,39 @@ export function taskRoutes() {
         assignments[agent.agent_name] = [];
       }
 
-      // Shuffle agents for fair distribution across poll cycles
-      const shuffledAgents = [...body.agents];
-      for (let i = shuffledAgents.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [shuffledAgents[i], shuffledAgents[j]] = [shuffledAgents[j], shuffledAgents[i]];
+      // Weighted-random shuffle: agents with higher (reputation × reliability)
+      // are more likely to land first and claim available tasks. Fetch both
+      // signals for all polling agents in parallel.
+      const agentNames = body.agents.map((a) => a.agent_name);
+      const now = Date.now();
+      const reputationSinceMs = now - REPUTATION_SCORE_WINDOW_MS;
+      const reliabilitySinceMs = now - RELIABILITY_WINDOW_MS;
+      const [reputationByAgent, reliabilityByAgent] = await Promise.all([
+        Promise.all(
+          agentNames.map((name) => store.getAgentReputationEvents(name, reputationSinceMs)),
+        ).then((lists) => {
+          const m = new Map<string, number>();
+          for (let i = 0; i < agentNames.length; i++) {
+            const events = lists[i];
+            // Agents with no reputation history get a neutral 0.5 baseline
+            // (same default previously used for grace-period computation).
+            m.set(agentNames[i], events.length > 0 ? computeAgentReputation(events) : 0.5);
+          }
+          return m;
+        }),
+        store.getAgentReliabilityEventsBatch(agentNames, reliabilitySinceMs),
+      ]);
+
+      function agentWeight(agentName: string): number {
+        const rep = reputationByAgent.get(agentName) ?? 0.5;
+        const rel = computeReliability(reliabilityByAgent.get(agentName) ?? []);
+        return rep * rel;
       }
+
+      const shuffledAgents = body.agents
+        .map((agent) => ({ agent, score: agentWeight(agent.agent_name) * Math.random() }))
+        .sort((a, b) => b.score - a.score)
+        .map((e) => e.agent);
 
       // First pass: preferred-model round-robin — distribute tasks to agents whose
       // model/tool matches the task's preferred_models/preferred_tools config.
@@ -1337,22 +1355,12 @@ export function taskRoutes() {
       );
     }
 
-    // Grace period checks (adjusted by reputation)
+    // Grace period checks (cooldown-adjusted).
     {
-      const repSinceMs = Date.now() - REPUTATION_SCORE_WINDOW_MS;
-      const [repEvents, lastCompleted] = await Promise.all([
-        store.getAgentReputationEvents(agent_id, repSinceMs),
-        store.getAgentLastCompletedClaimAt(agent_id),
-      ]);
-      // Only apply reputation multiplier when there are actual events
-      const score = repEvents.length > 0 ? computeAgentReputation(repEvents) : 0.5;
+      const lastCompleted = await store.getAgentLastCompletedClaimAt(agent_id);
 
       if (isSummaryTask(task)) {
-        const effGrace = effectiveGracePeriod(
-          PREFERRED_SYNTH_GRACE_PERIOD_MS,
-          score,
-          lastCompleted,
-        );
+        const effGrace = effectiveGracePeriod(PREFERRED_SYNTH_GRACE_PERIOD_MS, lastCompleted);
         if (!isSummaryVisibleToAgent(task, agent_id, model, effGrace)) {
           return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
         }
@@ -1360,7 +1368,6 @@ export function taskRoutes() {
         // Worker task — check model/tool preference grace period
         const effReviewGrace = effectiveGracePeriod(
           PREFERRED_REVIEW_GRACE_PERIOD_MS,
-          score,
           lastCompleted,
         );
         if (!isWorkerVisibleToAgent(task, model, tool, effReviewGrace)) {
@@ -1369,11 +1376,7 @@ export function taskRoutes() {
       }
 
       // Target model grace period check
-      const effTargetGrace = effectiveGracePeriod(
-        TARGET_MODEL_GRACE_PERIOD_MS,
-        score,
-        lastCompleted,
-      );
+      const effTargetGrace = effectiveGracePeriod(TARGET_MODEL_GRACE_PERIOD_MS, lastCompleted);
       if (!isTargetModelVisible(task, model, effTargetGrace)) {
         return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
       }
@@ -1522,6 +1525,18 @@ export function taskRoutes() {
       verdict: verdict as ReviewVerdict | undefined,
       tokens_used,
     });
+
+    // Record a reliability success event. Best-effort — a store failure here
+    // should never block result submission.
+    try {
+      await store.recordAgentReliabilityEvent(agent_id, 'success', new Date().toISOString());
+    } catch (err) {
+      logger.warn('Failed to record reliability success event', {
+        agentId: agent_id,
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     // Check if the task exists
     const task = await store.getTask(taskId);
@@ -1777,6 +1792,17 @@ export function taskRoutes() {
 
     // Release the task so another agent can claim it
     await store.releaseTask(taskId);
+
+    // Record a reliability failure event. Best-effort.
+    try {
+      await store.recordAgentReliabilityEvent(agent_id, 'error', new Date().toISOString());
+    } catch (err) {
+      logger.warn('Failed to record reliability error event', {
+        agentId: agent_id,
+        taskId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     logger.error('Agent reported error', {
       agentId: agent_id,

--- a/packages/server/src/store/constants.ts
+++ b/packages/server/src/store/constants.ts
@@ -38,3 +38,13 @@ export const COOLDOWN_FULL_MS = 10 * 60_000;
 
 /** Cooldown: half-cooled threshold at 5 minutes. */
 export const COOLDOWN_HALF_MS = 5 * 60_000;
+
+// ── Reliability system constants ─────────────────────────────────
+
+/**
+ * Rolling window for per-agent success/error events used in dispatch weighting.
+ * 30 minutes: short enough that a recovering agent comes back into rotation
+ * naturally as its old failures age out; long enough to smooth over transient
+ * hiccups.
+ */
+export const RELIABILITY_WINDOW_MS = 30 * 60_000;

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -1060,6 +1060,47 @@ export class D1DataStore implements DataStore {
     return row?.latest ?? null;
   }
 
+  // ── Agent reliability (recent success/error outcomes) ────────
+
+  async recordAgentReliabilityEvent(
+    agentId: string,
+    outcome: 'success' | 'error',
+    createdAt: string,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        'INSERT INTO agent_reliability_events (agent_id, outcome, created_at) VALUES (?, ?, ?)',
+      )
+      .bind(agentId, outcome, createdAt)
+      .run();
+  }
+
+  async getAgentReliabilityEventsBatch(
+    agentIds: readonly string[],
+    sinceMs: number,
+  ): Promise<Map<string, Array<{ outcome: 'success' | 'error'; created_at: string }>>> {
+    const result = new Map<string, Array<{ outcome: 'success' | 'error'; created_at: string }>>();
+    if (agentIds.length === 0) return result;
+    const sinceIso = new Date(sinceMs).toISOString();
+    const placeholders = agentIds.map(() => '?').join(',');
+    const rows = await this.db
+      .prepare(
+        `SELECT agent_id, outcome, created_at FROM agent_reliability_events
+         WHERE agent_id IN (${placeholders}) AND created_at >= ?`,
+      )
+      .bind(...agentIds, sinceIso)
+      .all<{ agent_id: string; outcome: 'success' | 'error'; created_at: string }>();
+    for (const row of rows.results ?? []) {
+      let list = result.get(row.agent_id);
+      if (!list) {
+        list = [];
+        result.set(row.agent_id, list);
+      }
+      list.push({ outcome: row.outcome, created_at: row.created_at });
+    }
+    return result;
+  }
+
   // ── OAuth token cache ────────────────────────────────────────
 
   async getOAuthCache(tokenHash: string): Promise<VerifiedIdentity | null> {

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -182,6 +182,19 @@ export interface DataStore {
   /** Get the timestamp of an agent's most recent completed claim. Returns null if none. */
   getAgentLastCompletedClaimAt(agentId: string): Promise<number | null>;
 
+  // Agent reliability (recent success/error outcome events for dispatch weighting)
+  /** Append a reliability event when a task completes or errors. */
+  recordAgentReliabilityEvent(
+    agentId: string,
+    outcome: 'success' | 'error',
+    createdAt: string,
+  ): Promise<void>;
+  /** Batch-fetch recent reliability events for multiple agents in one query. */
+  getAgentReliabilityEventsBatch(
+    agentIds: readonly string[],
+    sinceMs: number,
+  ): Promise<Map<string, Array<{ outcome: 'success' | 'error'; created_at: string }>>>;
+
   // OAuth token cache
   /** Look up a cached verified identity by token hash. Returns null if not found or expired. */
   getOAuthCache(tokenHash: string): Promise<VerifiedIdentity | null>;

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -23,6 +23,11 @@ export class MemoryDataStore implements DataStore {
   private postedReviewNextId = 1;
   private reputationEvents: ReputationEvent[] = [];
   private reputationEventNextId = 1;
+  private reliabilityEvents: Array<{
+    agent_id: string;
+    outcome: 'success' | 'error';
+    created_at: string;
+  }> = [];
   private readonly ttlMs: number;
 
   constructor(ttlDays: number = DEFAULT_TTL_DAYS) {
@@ -619,6 +624,36 @@ export class MemoryDataStore implements DataStore {
     return latest;
   }
 
+  // Agent reliability (recent success/error outcomes)
+
+  async recordAgentReliabilityEvent(
+    agentId: string,
+    outcome: 'success' | 'error',
+    createdAt: string,
+  ): Promise<void> {
+    this.reliabilityEvents.push({ agent_id: agentId, outcome, created_at: createdAt });
+  }
+
+  async getAgentReliabilityEventsBatch(
+    agentIds: readonly string[],
+    sinceMs: number,
+  ): Promise<Map<string, Array<{ outcome: 'success' | 'error'; created_at: string }>>> {
+    const result = new Map<string, Array<{ outcome: 'success' | 'error'; created_at: string }>>();
+    if (agentIds.length === 0) return result;
+    const allowed = new Set(agentIds);
+    const sinceIso = new Date(sinceMs).toISOString();
+    for (const e of this.reliabilityEvents) {
+      if (!allowed.has(e.agent_id) || e.created_at < sinceIso) continue;
+      let list = result.get(e.agent_id);
+      if (!list) {
+        list = [];
+        result.set(e.agent_id, list);
+      }
+      list.push({ outcome: e.outcome, created_at: e.created_at });
+    }
+    return result;
+  }
+
   // OAuth token cache
 
   async getOAuthCache(tokenHash: string): Promise<VerifiedIdentity | null> {
@@ -676,6 +711,7 @@ export class MemoryDataStore implements DataStore {
     this.postedReviewNextId = 1;
     this.reputationEvents = [];
     this.reputationEventNextId = 1;
+    this.reliabilityEvents = [];
     this.timeoutLastCheck = 0;
   }
 }


### PR DESCRIPTION
## Summary
Fixes the stuck-Codex loop surfaced on ParadiseEngine/ParadiseEngine#29 and the underlying design gap: the server had no notion of per-agent reliability and distributed tasks with a plain Fisher-Yates shuffle, so an agent that consistently failed (e.g. Codex hanging on `npx @openai/codex@latest exec -`) kept being re-assigned the same task every poll cycle.

- **New event log** (`agent_reliability_events`, migration `0018`) — 30-minute rolling window of `success` / `error` outcomes per agent. Failures age out naturally so a broken agent recovers without an explicit backoff.
- **`computeReliability(events)`** — `1.0` on empty history (no cold-start penalty), otherwise `successes / total`. No floor, per design review: an all-failure window scores `0` and the agent is skipped by the shuffle until the window rolls.
- **Outcome recording** on `POST /api/tasks/:id/result` and `/error` — best-effort so a store failure can't block the endpoint.
- **Weighted-random dispatch** in `POST /api/tasks/poll/batch` — replaces Fisher-Yates with `score = reputation × reliability × Math.random()`. Uses the same weighted-shuffle pattern the CLI already ships in `packages/cli/src/commands/agent.ts:1830-1833`.
- **`effectiveGracePeriod` simplified** — drops the reputation multiplier (reputation now lives in the weighted shuffle); keeps the cooldown multiplier for agent back-to-back spacing. All six call sites in `routes/tasks.ts` updated.

## Why this fixes the loop
- Codex fails → reliability drops → shuffle score drops on every subsequent poll.
- Opus (unaffected) wins the next assignment on the very next poll cycle — no reputation-grace to wait out.
- When Codex eventually recovers (failures age out after 30 min), it comes back into rotation automatically.

## Schema
```sql
CREATE TABLE agent_reliability_events (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  agent_id TEXT NOT NULL,
  outcome TEXT NOT NULL CHECK(outcome IN ('success', 'error')),
  created_at TEXT NOT NULL
);
CREATE INDEX idx_reliability_agent_time
  ON agent_reliability_events(agent_id, created_at);
```

## Test plan
- [x] `pnpm build` (all three packages)
- [x] `pnpm test` — 2925 passing (new `reliability.test.ts`, `agent-reliability.test.ts`; `reputation.test.ts` + `reputation-eligibility.test.ts` updated for the new signature)
- [x] `pnpm lint`
- [x] `pnpm run format:check`
- [x] `pnpm run typecheck`
- [ ] After merge → auto-deploy to dev → re-run the ParadiseEngine summary path; Codex should be deprioritized after one timeout and Opus should claim on the next batch poll.

Generated with [Claude Code](https://claude.ai/code)