### PR TITLE
fix(server): key batch-poll weight by agent_id, skip zero-weight agents

### DIFF
--- a/packages/cli/src/__tests__/batch-poll.test.ts
+++ b/packages/cli/src/__tests__/batch-poll.test.ts
@@ -234,12 +234,14 @@ describe('buildBatchPollRequest', () => {
     expect(request.agents).toHaveLength(2);
     expect(request.agents[0]).toEqual({
       agent_name: 'agent-1',
+      agent_id: 'uuid-1',
       roles: ['review', 'summary'],
       model: 'gpt-4',
       tool: 'claude',
     });
     expect(request.agents[1]).toEqual({
       agent_name: 'agent-2',
+      agent_id: 'uuid-2',
       roles: ['review'],
       model: 'gemini',
       tool: 'gemini',

--- a/packages/cli/src/batch-poll.ts
+++ b/packages/cli/src/batch-poll.ts
@@ -108,6 +108,7 @@ export function buildBatchPollRequest(agents: AgentDescriptor[]): BatchPollReque
   const batchAgents: BatchPollAgent[] = agents.map((a) => {
     const entry: BatchPollAgent = {
       agent_name: a.name,
+      agent_id: a.agentId,
       roles: a.roles,
       model: a.model,
       tool: a.tool,

--- a/packages/server/src/__tests__/agent-reliability.test.ts
+++ b/packages/server/src/__tests__/agent-reliability.test.ts
@@ -170,13 +170,13 @@ describe('Agent reliability — weighted dispatch', () => {
   }
 
   it('prefers a high-reliability agent over a zero-reliability agent', async () => {
-    // agent-bad has only errors in the window → reliability = 0 → shuffle score = 0.
+    // id-bad has only errors in the window → reliability = 0 → shuffle score = 0.
     const now = new Date().toISOString();
     for (let i = 0; i < 5; i++) {
-      await store.recordAgentReliabilityEvent('agent-bad', 'error', now);
+      await store.recordAgentReliabilityEvent('id-bad', 'error', now);
     }
-    // agent-good has only successes → reliability = 1.
-    await store.recordAgentReliabilityEvent('agent-good', 'success', now);
+    // id-good has only successes → reliability = 1.
+    await store.recordAgentReliabilityEvent('id-good', 'success', now);
 
     // One pending task, both agents accept role 'review' on a public repo.
     await store.createTask(
@@ -193,8 +193,20 @@ describe('Agent reliability — weighted dispatch', () => {
     try {
       const res = await batchPoll({
         agents: [
-          { agent_name: 'agent-bad', roles: ['review'], model: 'm1', tool: 't1' },
-          { agent_name: 'agent-good', roles: ['review'], model: 'm2', tool: 't2' },
+          {
+            agent_name: 'agent-bad',
+            agent_id: 'id-bad',
+            roles: ['review'],
+            model: 'm1',
+            tool: 't1',
+          },
+          {
+            agent_name: 'agent-good',
+            agent_id: 'id-good',
+            roles: ['review'],
+            model: 'm2',
+            tool: 't2',
+          },
         ],
       });
       expect(res.status).toBe(200);
@@ -206,6 +218,41 @@ describe('Agent reliability — weighted dispatch', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it('a zero-weight agent is skipped even when it is the only polling candidate', async () => {
+    // Only Codex is polling for this task; every recent event was an error.
+    const now = new Date().toISOString();
+    for (let i = 0; i < 5; i++) {
+      await store.recordAgentReliabilityEvent('id-broken', 'error', now);
+    }
+
+    await store.createTask(
+      makeTask({
+        id: 'only-task',
+        status: 'pending',
+        queue: 'review',
+        task_type: 'review',
+      }),
+    );
+
+    const res = await batchPoll({
+      agents: [
+        {
+          agent_name: 'agent-broken',
+          agent_id: 'id-broken',
+          roles: ['review'],
+          model: 'm',
+          tool: 't',
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      assignments: Record<string, { tasks: Array<{ task_id: string }> }>;
+    };
+    // Broken agent gets no assignment — task stays pending for someone else.
+    expect(body.assignments['agent-broken'].tasks).toHaveLength(0);
   });
 
   it('an agent with no history still gets a neutral weight (not zero)', async () => {
@@ -222,7 +269,15 @@ describe('Agent reliability — weighted dispatch', () => {
     const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
     try {
       const res = await batchPoll({
-        agents: [{ agent_name: 'agent-fresh', roles: ['review'], model: 'm', tool: 't' }],
+        agents: [
+          {
+            agent_name: 'agent-fresh',
+            agent_id: 'id-fresh',
+            roles: ['review'],
+            model: 'm',
+            tool: 't',
+          },
+        ],
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as {

--- a/packages/server/src/__tests__/agent-reliability.test.ts
+++ b/packages/server/src/__tests__/agent-reliability.test.ts
@@ -255,6 +255,37 @@ describe('Agent reliability — weighted dispatch', () => {
     expect(body.assignments['agent-broken'].tasks).toHaveLength(0);
   });
 
+  it('legacy CLI without agent_id still receives assignments at neutral weight', async () => {
+    // Even if another agent_id has a recorded error, a request that omits
+    // agent_id (older CLI) can't be penalised — treat it as neutral so it
+    // keeps getting work until it upgrades.
+    const now = new Date().toISOString();
+    for (let i = 0; i < 3; i++) {
+      await store.recordAgentReliabilityEvent('id-bad', 'error', now);
+    }
+
+    await store.createTask(
+      makeTask({
+        id: 'only-task',
+        status: 'pending',
+        queue: 'review',
+        task_type: 'review',
+      }),
+    );
+
+    const res = await batchPoll({
+      agents: [
+        // No agent_id — legacy shape
+        { agent_name: 'legacy', roles: ['review'], model: 'm', tool: 't' },
+      ],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      assignments: Record<string, { tasks: Array<{ task_id: string }> }>;
+    };
+    expect(body.assignments['legacy'].tasks).toHaveLength(1);
+  });
+
   it('an agent with no history still gets a neutral weight (not zero)', async () => {
     // agent-fresh has no events → reliability defaults to 1.0.
     await store.createTask(

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -1159,9 +1159,14 @@ export function taskRoutes() {
       // Collect per-agent task lists
       const agentTasks = new Map<string, PollTask[]>();
       for (const agent of body.agents) {
+        // Per-agent-id identity for persistence-keyed lookups (rejection
+        // counters, cooldown, reputation, reliability). Falls back to the
+        // request-local agent_name when agent_id is missing (older CLIs).
+        const identityKey = agent.agent_id ?? agent.agent_name;
+
         // Block check per agent — skip blocked agents
-        if (await isAgentBlocked(store, agent.agent_name, verifiedIdentity?.github_user_id)) {
-          logger.warn('Blocked agent in batch poll', { agentId: agent.agent_name });
+        if (await isAgentBlocked(store, identityKey, verifiedIdentity?.github_user_id)) {
+          logger.warn('Blocked agent in batch poll', { agentId: identityKey });
           agentTasks.set(agent.agent_name, []);
           continue;
         }
@@ -1182,7 +1187,7 @@ export function taskRoutes() {
         const available = await filterTasksForAgent(
           pollCtx,
           {
-            agentId: agent.agent_name,
+            agentId: identityKey,
             acceptedRoles: new Set(agent.roles),
             agentRepos: declaredRepos.size > 0 ? declaredRepos : null,
             model: agent.model,
@@ -1253,9 +1258,10 @@ export function taskRoutes() {
       // into rotation automatically. This prevents the retry loop where a
       // broken agent is the only polling candidate for a task and keeps
       // re-claiming it after each failure.
-      const shuffleCandidates = body.agents.filter((a) => agentWeight(a.agent_id) > 0);
-      const shuffledAgents = shuffleCandidates
-        .map((agent) => ({ agent, score: agentWeight(agent.agent_id) * Math.random() }))
+      const shuffledAgents = body.agents
+        .map((agent) => ({ agent, weight: agentWeight(agent.agent_id) }))
+        .filter(({ weight }) => weight > 0)
+        .map(({ agent, weight }) => ({ agent, score: weight * Math.random() }))
         .sort((a, b) => b.score - a.score)
         .map((e) => e.agent);
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -1210,36 +1210,52 @@ export function taskRoutes() {
       }
 
       // Weighted-random shuffle: agents with higher (reputation × reliability)
-      // are more likely to land first and claim available tasks. Fetch both
-      // signals for all polling agents in parallel.
-      const agentNames = body.agents.map((a) => a.agent_name);
+      // are more likely to land first and claim available tasks. Reputation
+      // and reliability events are keyed by the persistent `agent_id` (UUID),
+      // not the request-local `agent_name`. Agents that don't supply an
+      // `agent_id` (older CLIs) fall back to neutral weight so they still
+      // receive work.
+      const agentIds: string[] = [];
+      for (const a of body.agents) {
+        if (a.agent_id) agentIds.push(a.agent_id);
+      }
       const now = Date.now();
       const reputationSinceMs = now - REPUTATION_SCORE_WINDOW_MS;
       const reliabilitySinceMs = now - RELIABILITY_WINDOW_MS;
-      const [reputationByAgent, reliabilityByAgent] = await Promise.all([
+      const [reputationByAgentId, reliabilityByAgentId] = await Promise.all([
         Promise.all(
-          agentNames.map((name) => store.getAgentReputationEvents(name, reputationSinceMs)),
+          agentIds.map((id) => store.getAgentReputationEvents(id, reputationSinceMs)),
         ).then((lists) => {
           const m = new Map<string, number>();
-          for (let i = 0; i < agentNames.length; i++) {
+          for (let i = 0; i < agentIds.length; i++) {
             const events = lists[i];
             // Agents with no reputation history get a neutral 0.5 baseline
             // (same default previously used for grace-period computation).
-            m.set(agentNames[i], events.length > 0 ? computeAgentReputation(events) : 0.5);
+            m.set(agentIds[i], events.length > 0 ? computeAgentReputation(events) : 0.5);
           }
           return m;
         }),
-        store.getAgentReliabilityEventsBatch(agentNames, reliabilitySinceMs),
+        store.getAgentReliabilityEventsBatch(agentIds, reliabilitySinceMs),
       ]);
 
-      function agentWeight(agentName: string): number {
-        const rep = reputationByAgent.get(agentName) ?? 0.5;
-        const rel = computeReliability(reliabilityByAgent.get(agentName) ?? []);
+      function agentWeight(agentId: string | undefined): number {
+        // Without an agent_id we can't look up reliability — treat as neutral
+        // so the agent is not arbitrarily penalised.
+        if (!agentId) return 0.5;
+        const rep = reputationByAgentId.get(agentId) ?? 0.5;
+        const rel = computeReliability(reliabilityByAgentId.get(agentId) ?? []);
         return rep * rel;
       }
 
-      const shuffledAgents = body.agents
-        .map((agent) => ({ agent, score: agentWeight(agent.agent_name) * Math.random() }))
+      // Agents whose weight has collapsed (reliability 0 — every event in the
+      // window was an error) are skipped from dispatch entirely. Their events
+      // will age out of the RELIABILITY_WINDOW_MS window and they'll come back
+      // into rotation automatically. This prevents the retry loop where a
+      // broken agent is the only polling candidate for a task and keeps
+      // re-claiming it after each failure.
+      const shuffleCandidates = body.agents.filter((a) => agentWeight(a.agent_id) > 0);
+      const shuffledAgents = shuffleCandidates
+        .map((agent) => ({ agent, score: agentWeight(agent.agent_id) * Math.random() }))
         .sort((a, b) => b.score - a.score)
         .map((e) => e.agent);
 

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -51,6 +51,7 @@ export const PollRequestSchema = z.object({
 
 const batchPollAgentSchema = z.object({
   agent_name: z.string().min(1, 'agent_name must be a non-empty string'),
+  agent_id: agentIdSchema.optional(),
   roles: z.array(taskRoleSchema).min(1, 'roles must contain at least one role'),
   model: z.string().optional(),
   tool: z.string().optional(),

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -65,11 +65,17 @@ export interface PollResponse {
 
 /**
  * A single agent descriptor inside a batch poll request.
- * `agent_name` is a request-local key used to match assignments in the response —
- * it is NOT the persistent `agent_id` used in PollRequest/ClaimRequest.
+ * `agent_name` is a request-local key used to match assignments in the response.
+ * `agent_id` is the persistent UUID used by PollRequest/ClaimRequest/ResultRequest —
+ * the server uses it to look up per-agent reputation and reliability for
+ * weighted dispatch. Optional for backward compatibility with older CLIs;
+ * when absent, reputation/reliability are not consulted and the agent is
+ * treated as a neutral-weight participant.
  */
 export interface BatchPollAgent {
   agent_name: string;
+  /** Persistent UUID for reputation/reliability lookup. */
+  agent_id?: string;
   /** Required — each agent must declare which roles it accepts (unlike PollRequest where roles is optional). */
   roles: TaskRole[];
   model?: string;


### PR DESCRIPTION
## Summary
Two fixes that together make the new reliability system actually affect dispatch:

### 1. Keying bug
Reliability and reputation events are stored under `agent_id` (persistent UUID from `PollRequest`/`ClaimRequest`), but the batch-poll weight lookup was keyed by `agent_name` — the request-local label that's explicitly *not* the persistent `agent_id` (`packages/shared/src/api.ts:68`). So the lookup silently found no events, every agent's weight stayed at `1.0`, and the weighted shuffle collapsed back to a plain random shuffle.

- Add optional `agent_id` to `BatchPollAgent`.
- CLI populates it from `AgentDescriptor.agentId` in `buildBatchPollRequest`.
- Server uses it for both reputation and reliability lookups. Missing `agent_id` (older CLIs) falls back to a neutral `0.5` weight so they still get work.

### 2. Zero-weight agent still winning dispatch
When a broken agent (reliability 0) was the only polling candidate for a task, it still claimed because the shuffle only *orders* agents, it doesn't filter them. This reproduced the stuck-Codex loop: every 10s poll cycle, Codex was the only `bank-demo`-eligible agent free to poll, so it re-claimed the task it had just failed.

Skip agents with `agentWeight === 0` from dispatch entirely. Task stays pending until either another eligible agent becomes free or the 30-minute reliability window rolls and the broken agent's score recovers.

## Tests
- New: `agent-reliability.test.ts` — "a zero-weight agent is skipped even when it is the only polling candidate" (covers fix #2).
- Updated: existing tests now pass `agent_id` alongside `agent_name`.
- CLI test: `buildBatchPollRequest` expected shape updated.

## Verification
- [x] `pnpm build && pnpm test` — 2926 passing
- [x] `pnpm lint && pnpm run format:check && pnpm run typecheck`
- [ ] After deploy, confirm Codex stops re-claiming the same bank-demo task on failure — task sits pending until another agent picks it up, or Codex's events age out.

Generated with [Claude Code](https://claude.ai/code)