### PR TITLE
feat(cli): prefer local git diff when a PR worktree is available

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -34,6 +34,14 @@ vi.mock('node:child_process', async (importOriginal) => {
       }
       return { pid: 0, kill: () => false };
     }),
+    // Stub sync variant so isGhAvailable() returns false fast (no real
+    // `gh auth status` subprocess blocking the test event loop).
+    execFileSync: vi.fn(() => {
+      const err: NodeJS.ErrnoException = Object.assign(new Error('gh not available in test'), {
+        code: 'ENOENT',
+      });
+      throw err;
+    }),
   };
 });
 

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -35,6 +35,15 @@ vi.mock('node:child_process', async (importOriginal) => {
       }
       return { pid: 0, kill: () => false };
     }),
+    // Also stub the sync variant so isGhAvailable() (called per task in
+    // handleTask's git-diff path) returns false fast instead of shelling
+    // out to a real `gh auth status`.
+    execFileSync: vi.fn(() => {
+      const err: NodeJS.ErrnoException = Object.assign(new Error('gh not available in test'), {
+        code: 'ENOENT',
+      });
+      throw err;
+    }),
   };
 });
 

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -423,7 +423,8 @@ describe('repo-cache', () => {
       // 2: gh repo clone --bare (ensureBareClone)
       // 3: git fetch (fetchPRRef)
       // 4: git worktree add (addWorktree)
-      expect(calls.length).toBe(4);
+      // 5: git checkout --detach --force FETCH_HEAD (reset reused worktrees to fresh PR tip)
+      expect(calls.length).toBe(5);
 
       // Verify bare clone
       expect(calls[1][1]).toContain('--bare');
@@ -435,6 +436,9 @@ describe('repo-cache', () => {
       expect(calls[3][1]).toContain('worktree');
       expect(calls[3][1]).toContain('FETCH_HEAD');
       expect(calls[3][1]).toContain('/tmp/repos/acme/widgets-worktrees/pr-42');
+
+      // Verify post-add reset to FETCH_HEAD
+      expect(calls[4][1]).toEqual(['checkout', '--detach', '--force', 'FETCH_HEAD']);
     });
 
     it('increments ref count on checkout', async () => {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -263,18 +263,14 @@ export async function fetchDiffViaGh(
     });
     return stdout;
   } catch {
-    // `gh` not installed / not on PATH → return null so the caller can
-    // fall back to HTTP. Any other non-zero exit (e.g. GitHub returned
-    // 406 for a >300-file PR, 404 for a missing PR, auth failure) is
-    // surfaced with its real message so the operator sees the actual
-    // reason rather than the "private repo" red herring the HTTP path
-    // produces for private resources.
-    if (state.err?.code === 'ENOENT') {
-      return null;
-    }
+    // Return null so `fetchDiff` can cascade to the HTTP tier — the API
+    // fallback is the whole point of returning here. We do log whatever
+    // `gh` reported on stderr (sanitized) so that when the HTTP path also
+    // fails, the operator can see both failure modes rather than just the
+    // generic 404 "private repo" red herring.
     const trimmed = state.stderr.trim();
-    if (trimmed.length > 0) {
-      throw new NonRetryableError(`gh api failed: ${trimmed}`);
+    if (trimmed.length > 0 && state.err?.code !== 'ENOENT') {
+      console.warn(`[fetchDiffViaGh] gh api failed: ${sanitizeTokens(trimmed)}`);
     }
     return null;
   }
@@ -754,12 +750,21 @@ async function handleTask(
     // any size and works for private repos without a platform token.
     if (taskCheckoutPath && taskBareRepoPath && base_ref) {
       try {
+        // Hoist `gh auth status` outside the repo lock — it's independent of
+        // the repo and does a synchronous subprocess call (up to 10s timeout).
+        const ghAvailable = isGhAvailable();
+        const maxDiffBytes = reviewDeps.maxDiffSizeKb ? reviewDeps.maxDiffSizeKb * 1024 : undefined;
         const repoKey = `${owner}/${repo}`;
         const gitDiff = await withRepoLock(repoKey, () =>
-          diffFromWorktree(taskBareRepoPath!, taskCheckoutPath!, base_ref, isGhAvailable()),
+          diffFromWorktree(
+            taskBareRepoPath!,
+            taskCheckoutPath!,
+            base_ref,
+            ghAvailable,
+            maxDiffBytes,
+          ),
         );
-        const maxBytes = reviewDeps.maxDiffSizeKb ? reviewDeps.maxDiffSizeKb * 1024 : Infinity;
-        if (gitDiff.length > maxBytes) {
+        if (maxDiffBytes !== undefined && gitDiff.length > maxDiffBytes) {
           throw new DiffTooLargeError(
             `Diff too large (${Math.round(gitDiff.length / 1024)}KB > ${reviewDeps.maxDiffSizeKb}KB)`,
           );

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -33,10 +33,10 @@ import {
 import {
   checkoutWorktree,
   cleanupWorktree,
-  getRepoSize,
-  parseDiffPaths,
-  type SparseCheckoutOptions,
+  diffFromWorktree,
+  withRepoLock,
 } from '../repo-cache.js';
+import { isGhAvailable } from '../codebase.js';
 import {
   parseTtl,
   CodebaseCleanupTracker,
@@ -224,6 +224,10 @@ export async function fetchDiffViaGh(
   prNumber: number,
   signal?: AbortSignal,
 ): Promise<string | null> {
+  const state: { stderr: string; err: (Error & { code?: string | number | null }) | null } = {
+    stderr: '',
+    err: null,
+  };
   try {
     const stdout = await new Promise<string>((resolve, reject) => {
       const child = execFile(
@@ -235,9 +239,14 @@ export async function fetchDiffViaGh(
           'Accept: application/vnd.github.v3.diff',
         ],
         { maxBuffer: 50 * 1024 * 1024 }, // 50 MB
-        (err, stdout) => {
-          if (err) reject(err);
-          else resolve(stdout);
+        (err, stdoutStr, stderrStr) => {
+          if (err) {
+            state.err = err;
+            state.stderr = stderrStr ?? '';
+            reject(err);
+          } else {
+            resolve(stdoutStr);
+          }
         },
       );
       if (signal) {
@@ -254,6 +263,19 @@ export async function fetchDiffViaGh(
     });
     return stdout;
   } catch {
+    // `gh` not installed / not on PATH → return null so the caller can
+    // fall back to HTTP. Any other non-zero exit (e.g. GitHub returned
+    // 406 for a >300-file PR, 404 for a missing PR, auth failure) is
+    // surfaced with its real message so the operator sees the actual
+    // reason rather than the "private repo" red herring the HTTP path
+    // produces for private resources.
+    if (state.err?.code === 'ENOENT') {
+      return null;
+    }
+    const trimmed = state.stderr.trim();
+    if (trimmed.length > 0) {
+      throw new NonRetryableError(`gh api failed: ${trimmed}`);
+    }
     return null;
   }
 }
@@ -656,7 +678,8 @@ async function handleTask(
   cleanupTracker?: CodebaseCleanupTracker,
   verbose?: boolean,
 ): Promise<HandleTaskResult> {
-  const { task_id, owner, repo, pr_number, diff_url, timeout_seconds, prompt, role } = task;
+  const { task_id, owner, repo, pr_number, diff_url, timeout_seconds, prompt, role, base_ref } =
+    task;
   const { log, logError, logWarn } = logger;
 
   const isIssueTask = pr_number === 0;
@@ -706,77 +729,81 @@ async function handleTask(
   if (isIssueTask) {
     log('  Issue-based task — skipping diff fetch');
   } else {
-    // Fetch diff — gh CLI first, fall back to HTTP
+    // Checkout codebase first — a local worktree lets us compute the diff
+    // via `git diff` instead of GitHub's REST diff endpoint, which caps at
+    // 300 files. Sparse checkout is only applied when both a diff is
+    // available up-front (via the API) AND the repo exceeds the configured
+    // size cap; in the git-diff path we always do a full checkout since we
+    // don't know the diff paths ahead of time.
+    const codebaseDir = reviewDeps.codebaseDir || path.join(CONFIG_DIR, 'repos');
     try {
-      const result = await fetchDiff(diff_url, owner, repo, pr_number, {
-        githubToken: client.currentToken,
-        signal,
-        maxDiffSizeKb: reviewDeps.maxDiffSizeKb,
-      });
-      diffContent = result.diff;
-      log(`  Diff fetched via ${result.method} (${Math.round(diffContent.length / 1024)}KB)`);
+      const result = await checkoutWorktree(owner, repo, pr_number, codebaseDir, task_id);
+      const mode = result.cloned ? 'cloned' : 'cached';
+      log(`  Codebase ${mode} → worktree: ${result.worktreePath}`);
+      taskCheckoutPath = result.worktreePath;
+      taskBareRepoPath = result.bareRepoPath;
+      taskReviewDeps = { ...reviewDeps, codebaseDir: result.worktreePath };
     } catch (err) {
-      logError(`  Failed to fetch diff for task ${task_id}: ${(err as Error).message}`);
-      await safeReject(
-        client,
-        task_id,
-        agentId,
-        `Cannot access diff: ${(err as Error).message}`,
-        logger,
+      logWarn(
+        `  Warning: worktree checkout failed: ${(err as Error).message}. Will try API diff only.`,
       );
-      return { diffFetchFailed: true };
+      taskReviewDeps = { ...reviewDeps, codebaseDir: null };
     }
 
-    // Checkout codebase using persistent bare clone + git worktree
-    // For large repos, use sparse checkout with only diff-affected files
-    {
-      const codebaseDir = reviewDeps.codebaseDir || path.join(CONFIG_DIR, 'repos');
-      let sparseOptions: SparseCheckoutOptions | undefined;
-
-      // Check repo size and decide on sparse checkout
-      const maxRepoSizeMb = reviewDeps.maxRepoSizeMb ?? 0;
-      if (maxRepoSizeMb > 0) {
-        const repoSizeKb = getRepoSize(owner, repo);
-        if (repoSizeKb === null) {
-          // gh unavailable or API failed — default to sparse checkout (safer fallback)
-          const diffPaths = parseDiffPaths(diffContent);
-          if (diffPaths.length > 0) {
-            log('  Repo size unknown (gh unavailable) — using sparse checkout as safe default');
-            sparseOptions = { diffPaths };
-          }
-        } else {
-          const repoSizeMb = repoSizeKb / 1024;
-          if (repoSizeMb > maxRepoSizeMb) {
-            const diffPaths = parseDiffPaths(diffContent);
-            if (diffPaths.length > 0) {
-              log(
-                `  Large repo detected (${Math.round(repoSizeMb)}MB > ${maxRepoSizeMb}MB) — using sparse checkout (${diffPaths.length} files)`,
-              );
-              sparseOptions = { diffPaths };
-            }
-          }
-        }
-      }
-
+    // Prefer local git diff when a worktree is available — handles PRs of
+    // any size and works for private repos without a platform token.
+    if (taskCheckoutPath && taskBareRepoPath && base_ref) {
       try {
-        const result = await checkoutWorktree(
-          owner,
-          repo,
-          pr_number,
-          codebaseDir,
-          task_id,
-          sparseOptions,
+        const repoKey = `${owner}/${repo}`;
+        const gitDiff = await withRepoLock(repoKey, () =>
+          diffFromWorktree(taskBareRepoPath!, taskCheckoutPath!, base_ref, isGhAvailable()),
         );
-        const mode = result.sparse ? 'sparse' : result.cloned ? 'cloned' : 'cached';
-        log(`  Codebase ${mode} → worktree: ${result.worktreePath}`);
-        taskCheckoutPath = result.worktreePath;
-        taskBareRepoPath = result.bareRepoPath;
-        taskReviewDeps = { ...reviewDeps, codebaseDir: result.worktreePath };
+        const maxBytes = reviewDeps.maxDiffSizeKb ? reviewDeps.maxDiffSizeKb * 1024 : Infinity;
+        if (gitDiff.length > maxBytes) {
+          throw new DiffTooLargeError(
+            `Diff too large (${Math.round(gitDiff.length / 1024)}KB > ${reviewDeps.maxDiffSizeKb}KB)`,
+          );
+        }
+        diffContent = gitDiff;
+        log(`  Diff generated via git (${Math.round(diffContent.length / 1024)}KB)`);
       } catch (err) {
+        if (err instanceof DiffTooLargeError) {
+          logError(`  ${(err as Error).message}`);
+          await safeReject(
+            client,
+            task_id,
+            agentId,
+            `Cannot access diff: ${(err as Error).message}`,
+            logger,
+          );
+          return { diffFetchFailed: true };
+        }
         logWarn(
-          `  Warning: worktree checkout failed: ${(err as Error).message}. Continuing with diff-only review.`,
+          `  Warning: git diff failed (${(err as Error).message}) — falling back to API fetch`,
         );
-        taskReviewDeps = { ...reviewDeps, codebaseDir: null };
+      }
+    }
+
+    // Fallback: fetch via gh CLI / HTTP API.
+    if (!diffContent) {
+      try {
+        const result = await fetchDiff(diff_url, owner, repo, pr_number, {
+          githubToken: client.currentToken,
+          signal,
+          maxDiffSizeKb: reviewDeps.maxDiffSizeKb,
+        });
+        diffContent = result.diff;
+        log(`  Diff fetched via ${result.method} (${Math.round(diffContent.length / 1024)}KB)`);
+      } catch (err) {
+        logError(`  Failed to fetch diff for task ${task_id}: ${(err as Error).message}`);
+        await safeReject(
+          client,
+          task_id,
+          agentId,
+          `Cannot access diff: ${(err as Error).message}`,
+          logger,
+        );
+        return { diffFetchFailed: true };
       }
     }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -324,6 +324,16 @@ function validateConfigData(
       `\u26a0 Config warning: max_repo_size_mb must be >= 0, got ${data.max_repo_size_mb}, using default (${DEFAULT_MAX_REPO_SIZE_MB})`,
     );
     overrides.maxRepoSizeMb = DEFAULT_MAX_REPO_SIZE_MB;
+  } else if (typeof data.max_repo_size_mb === 'number' && data.max_repo_size_mb > 0) {
+    // Sparse checkout was removed along with the API-first diff fetch
+    // (diffs are now computed locally from the worktree, which doesn't know
+    // file paths ahead of time). `max_repo_size_mb` is preserved on the
+    // schema for backward compatibility but no longer influences checkout.
+    console.warn(
+      `\u26a0 Config notice: max_repo_size_mb is currently a no-op — sparse checkout was removed ` +
+        `when git-diff became the primary diff source. Full clones use --filter=blob:none so disk ` +
+        `usage stays low for most repos.`,
+    );
   }
 
   // Validate usage limit fields

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -356,16 +356,55 @@ export function configureSparseCheckout(worktreePath: string, filePaths: string[
 /**
  * Run a command synchronously with sanitized error messages.
  */
-function gitExec(command: string, args: string[], cwd?: string): string {
+function gitExec(
+  command: string,
+  args: string[],
+  cwd?: string,
+  opts?: { maxBuffer?: number },
+): string {
   try {
     return execFileSync(command, args, {
       cwd,
       encoding: 'utf-8',
       timeout: GIT_TIMEOUT_MS,
       stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: opts?.maxBuffer,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(sanitizeTokens(message));
   }
+}
+
+/**
+ * Generate a unified diff for a PR from a local worktree. Fetches the base
+ * branch into the bare clone (idempotent) and runs
+ * `git diff origin/<baseRef>...HEAD` inside the worktree.
+ *
+ * Unlike GitHub's REST diff endpoint (which caps at 300 files), the local
+ * git diff has no such limit, so this is how we handle large PRs.
+ *
+ * The caller is responsible for holding the per-repo lock around this call.
+ */
+export function diffFromWorktree(
+  bareRepoPath: string,
+  worktreePath: string,
+  baseRef: string,
+  ghAvailable: boolean,
+  maxDiffBytes = 128 * 1024 * 1024, // 128 MB
+): string {
+  // Defensive: reject ref names that look like option flags to avoid argv
+  // injection if `baseRef` somehow leaks from untrusted input.
+  if (baseRef.startsWith('-')) {
+    throw new Error(`Invalid base ref: ${baseRef}`);
+  }
+  const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
+  gitExec(
+    'git',
+    [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
+    bareRepoPath,
+  );
+  return gitExec('git', ['diff', `origin/${baseRef}...HEAD`], worktreePath, {
+    maxBuffer: maxDiffBytes,
+  });
 }

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -243,6 +243,11 @@ export async function checkoutWorktree(
     const { bareRepoPath, cloned } = ensureBareClone(owner, repo, baseDir, ghAvailable);
     fetchPRRef(bareRepoPath, prNumber, ghAvailable);
     const worktreePath = addWorktree(bareRepoPath, wtKey);
+    // addWorktree reuses an existing directory by path without touching its
+    // HEAD, so after a force-push or re-poll the worktree can be stale.
+    // Force-detach to the freshly fetched PR tip so `git diff` sees current
+    // contents.
+    gitExec('git', ['checkout', '--detach', '--force', 'FETCH_HEAD'], worktreePath);
 
     if (useSparse) {
       configureSparseCheckout(worktreePath, sparseOptions.diffPaths);

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { sanitizeTokens } from './sanitize.js';
 import { validatePathSegment, isGhAvailable, buildCloneUrl } from './codebase.js';
+import { DiffTooLargeError } from './review.js';
 
 /** Git credential helper arg that delegates to gh CLI */
 const GH_CREDENTIAL_HELPER = '!gh auth git-credential';
@@ -398,9 +399,10 @@ export function diffFromWorktree(
   ghAvailable: boolean,
   maxDiffBytes = 128 * 1024 * 1024, // 128 MB
 ): string {
-  // Defensive: reject ref names that look like option flags to avoid argv
-  // injection if `baseRef` somehow leaks from untrusted input.
-  if (baseRef.startsWith('-')) {
+  // Defensive allowlist for ref names. We pass baseRef as a separate argv to
+  // execFileSync so there's no shell expansion, but a ref with whitespace,
+  // newlines, or leading `-` could still confuse `git` itself.
+  if (!/^[A-Za-z0-9_./-]+$/.test(baseRef) || baseRef.startsWith('-')) {
     throw new Error(`Invalid base ref: ${baseRef}`);
   }
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
@@ -409,7 +411,18 @@ export function diffFromWorktree(
     [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
     bareRepoPath,
   );
-  return gitExec('git', ['diff', `origin/${baseRef}...HEAD`], worktreePath, {
-    maxBuffer: maxDiffBytes,
-  });
+  try {
+    return gitExec('git', ['diff', `origin/${baseRef}...HEAD`], worktreePath, {
+      maxBuffer: maxDiffBytes,
+    });
+  } catch (err) {
+    // Translate execFileSync's maxBuffer-exceeded error into DiffTooLargeError
+    // so the caller can reject the task cleanly instead of falling through to
+    // the API path (which has its own — different — size and file-count caps).
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/maxBuffer/i.test(msg) || /ERR_CHILD_PROCESS_STDIO_MAXBUFFER/.test(msg)) {
+      throw new DiffTooLargeError(`Diff exceeds limit (${Math.round(maxDiffBytes / 1024)}KB)`);
+    }
+    throw err;
+  }
 }

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -994,6 +994,7 @@ async function filterTasksForAgent(
       pr_review_comments: task.pr_review_comments,
       head_sha: task.head_sha,
       head_ref: task.head_ref || undefined,
+      base_ref: task.base_ref || undefined,
     };
 
     // For summary tasks, include worker results from the group

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -51,6 +51,8 @@ export interface PollTask {
   head_sha?: string;
   /** PR branch name (for fix tasks to checkout and push) */
   head_ref?: string;
+  /** PR base branch (target of the merge) — used by the CLI to compute diffs locally from the worktree. */
+  base_ref?: string;
 
   /** Completed worker reviews — provided to summary tasks so the synthesizer has context. */
   reviews?: ClaimReview[];


### PR DESCRIPTION
## Summary
Fixes the "Failed to fetch diff: 404" cascade on large PRs.

GitHub's REST diff endpoint caps at **300 files**. A large PR (like `talespark-git/bank-heist#103` — NuGet-for-Unity migration) returns HTTP 406 `too_large`, the fallback HTTP fetch returns 404 (GitHub serves 404 for unauthorized private resources), and the user gets the red-herring "private repo, ensure gh CLI is installed" message.

Since the CLI already clones every non-issue task into a local git worktree (the "Codebase cached → worktree" log line), the fix is to use `git diff origin/<base>...HEAD` from the worktree as the *primary* diff source. Local git has no file-count limit, works for any PR size, and doesn't need a platform OAuth token for private repos.

## Changes
- **`packages/cli/src/repo-cache.ts`** — new `diffFromWorktree(bareRepoPath, worktreePath, baseRef, ghAvailable, maxBytes)` helper. Fetches the base ref (idempotent), runs `git diff origin/<baseRef>...HEAD`, returns the diff.
- **`packages/shared/src/api.ts` + server**: expose `base_ref` on `PollTask` (already persisted on `ReviewTask`) so the CLI knows what to diff against.
- **`packages/cli/src/commands/agent.ts`** — reorder `handleTask`:
  1. Checkout worktree (full, no sparse).
  2. Try `diffFromWorktree` → use its output when it succeeds.
  3. Fall back to the existing `fetchDiff` (gh-then-HTTP) only when no worktree is available or git diff fails.
  4. Apply `maxDiffSizeKb` cap in both paths.
- **`fetchDiffViaGh`**: surface the actual `gh api` stderr (e.g. "exceeded the maximum number of files (300)") on non-ENOENT failures instead of swallowing it, so the API-fallback path is also diagnosable.

## Trade-off
Sparse checkout is dropped from the primary path — without the API diff we don't have the paths up front. With `--filter=blob:none` on the bare clone, full checkouts stay cheap for most repos. Re-introducing sparse (via paginated `/pulls/:n/files`) is a follow-up if disk usage turns out to matter.

## Test plan
- [x] `pnpm build && pnpm test` — 2927 passing
- [x] `pnpm lint && pnpm run format:check && pnpm run typecheck`
- [ ] After deploy + CLI upgrade, confirm `bank-heist#103` (and any 300+-file PR) reviews end-to-end instead of erroring at diff fetch.

Generated with [Claude Code](https://claude.ai/code)