### PR TITLE
fix(cli): resolve FETCH_HEAD in bare repo for worktree reuse

### DIFF
--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -157,7 +157,7 @@ describe('repo-cache', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       vi.mocked(execFileSync).mockReturnValue('');
 
-      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42');
+      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42', 'abc123');
 
       expect(result).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
       expect(fs.mkdirSync).toHaveBeenCalledWith('/tmp/repos/acme/widgets-worktrees', {
@@ -171,7 +171,7 @@ describe('repo-cache', () => {
         'add',
         '--detach',
         '/tmp/repos/acme/widgets-worktrees/pr-42',
-        'FETCH_HEAD',
+        'abc123',
       ]);
       expect(call[2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets.git' });
     });
@@ -180,7 +180,7 @@ describe('repo-cache', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(execFileSync).mockReturnValue('');
 
-      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42');
+      const result = addWorktree('/tmp/repos/acme/widgets.git', 'pr-42', 'abc123');
 
       expect(result).toBe('/tmp/repos/acme/widgets-worktrees/pr-42');
       // Should NOT call git worktree add
@@ -190,13 +190,13 @@ describe('repo-cache', () => {
     });
 
     it('rejects invalid worktreeKey', () => {
-      expect(() => addWorktree('/tmp/repos/acme/widgets.git', '../../etc')).toThrow(
+      expect(() => addWorktree('/tmp/repos/acme/widgets.git', '../../etc', 'abc123')).toThrow(
         'disallowed characters',
       );
     });
 
     it('rejects worktreeKey with slashes', () => {
-      expect(() => addWorktree('/tmp/repos/acme/widgets.git', 'a/b')).toThrow(
+      expect(() => addWorktree('/tmp/repos/acme/widgets.git', 'a/b', 'abc123')).toThrow(
         'disallowed characters',
       );
     });
@@ -409,7 +409,13 @@ describe('repo-cache', () => {
   describe('checkoutWorktree', () => {
     it('uses pr-keyed worktree path instead of taskId', async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
-      vi.mocked(execFileSync).mockReturnValue('');
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // gh auth status
+        .mockReturnValueOnce('') // gh repo clone
+        .mockReturnValueOnce('') // git fetch
+        .mockReturnValueOnce('abc123\n') // rev-parse FETCH_HEAD
+        .mockReturnValueOnce('') // git worktree add
+        .mockReturnValueOnce(''); // git checkout
 
       const result = await checkoutWorktree('acme', 'widgets', 42, '/tmp/repos', 'task-abc');
 
@@ -422,9 +428,10 @@ describe('repo-cache', () => {
       // 1: gh auth status (isGhAvailable — hoisted)
       // 2: gh repo clone --bare (ensureBareClone)
       // 3: git fetch (fetchPRRef)
-      // 4: git worktree add (addWorktree)
-      // 5: git checkout --detach --force FETCH_HEAD (reset reused worktrees to fresh PR tip)
-      expect(calls.length).toBe(5);
+      // 4: git rev-parse --verify FETCH_HEAD (resolve stable commit ID)
+      // 5: git worktree add (addWorktree)
+      // 6: git checkout --detach --force <sha> (reset reused worktrees to fresh PR tip)
+      expect(calls.length).toBe(6);
 
       // Verify bare clone
       expect(calls[1][1]).toContain('--bare');
@@ -432,13 +439,21 @@ describe('repo-cache', () => {
       // Verify fetch
       expect(calls[2][1]).toContain('pull/42/head');
 
-      // Verify worktree add uses pr-42
-      expect(calls[3][1]).toContain('worktree');
-      expect(calls[3][1]).toContain('FETCH_HEAD');
-      expect(calls[3][1]).toContain('/tmp/repos/acme/widgets-worktrees/pr-42');
+      // Verify FETCH_HEAD is resolved in the bare repo, not the linked worktree
+      expect(calls[3][1]).toEqual(['rev-parse', '--verify', 'FETCH_HEAD']);
+      expect(calls[3][2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets.git' });
 
-      // Verify post-add reset to FETCH_HEAD
-      expect(calls[4][1]).toEqual(['checkout', '--detach', '--force', 'FETCH_HEAD']);
+      // Verify worktree add uses pr-42 and the resolved commit SHA
+      expect(calls[4][1]).toEqual([
+        'worktree',
+        'add',
+        '--detach',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        'abc123',
+      ]);
+
+      // Verify post-add reset uses the resolved commit SHA, not FETCH_HEAD
+      expect(calls[5][1]).toEqual(['checkout', '--detach', '--force', 'abc123']);
     });
 
     it('increments ref count on checkout', async () => {

--- a/packages/cli/src/implement.ts
+++ b/packages/cli/src/implement.ts
@@ -205,8 +205,8 @@ export interface ImplementCheckoutResult {
 
 /**
  * Checkout a repo for implement task: bare clone + worktree on a new branch.
- * Unlike review worktrees (which checkout FETCH_HEAD), this creates a branch
- * from the default branch for pushing changes.
+ * Unlike review worktrees (which detach at the fetched PR tip), this creates a
+ * branch from the default branch for pushing changes.
  */
 export function checkoutForImplement(
   owner: string,

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -148,14 +148,14 @@ export function fetchPRRef(bareRepoPath: string, prNumber: number, ghAvailable: 
 
 /**
  * Create a git worktree from the bare repo.
- * The worktree is checked out at FETCH_HEAD (the PR ref just fetched).
+ * The worktree is checked out at the fetched PR tip commit.
  *
  * Path: `<bareRepoPath>/../<repo>-worktrees/<worktreeKey>/`
  *
  * If the worktree already exists (shared PR worktree), returns the existing path
  * without creating a new one.
  */
-export function addWorktree(bareRepoPath: string, worktreeKey: string): string {
+export function addWorktree(bareRepoPath: string, worktreeKey: string, targetRef: string): string {
   validatePathSegment(worktreeKey, 'worktreeKey');
 
   // Place worktrees alongside the bare repo for clean organization
@@ -171,7 +171,7 @@ export function addWorktree(bareRepoPath: string, worktreeKey: string): string {
 
   fs.mkdirSync(worktreeBase, { recursive: true });
 
-  gitExec('git', ['worktree', 'add', '--detach', worktreePath, 'FETCH_HEAD'], bareRepoPath);
+  gitExec('git', ['worktree', 'add', '--detach', worktreePath, targetRef], bareRepoPath);
 
   return worktreePath;
 }
@@ -205,6 +205,14 @@ function repoKeyFromBarePath(bareRepoPath: string): string {
   const repoName = path.basename(bareRepoPath, '.git');
   const owner = path.basename(path.dirname(bareRepoPath));
   return `${owner}/${repoName}`;
+}
+
+/**
+ * Resolve the just-fetched PR tip to a stable commit ID.
+ * Linked worktrees cannot reliably reuse the bare repo's FETCH_HEAD pseudoref.
+ */
+function resolveFetchedPrCommit(bareRepoPath: string): string {
+  return gitExec('git', ['rev-parse', '--verify', 'FETCH_HEAD'], bareRepoPath).trim();
 }
 
 /**
@@ -243,12 +251,15 @@ export async function checkoutWorktree(
     // Sparse checkout is a worktree concept — configured after worktree creation.
     const { bareRepoPath, cloned } = ensureBareClone(owner, repo, baseDir, ghAvailable);
     fetchPRRef(bareRepoPath, prNumber, ghAvailable);
-    const worktreePath = addWorktree(bareRepoPath, wtKey);
+    const prHeadCommit = resolveFetchedPrCommit(bareRepoPath);
+    const worktreePath = addWorktree(bareRepoPath, wtKey, prHeadCommit);
     // addWorktree reuses an existing directory by path without touching its
     // HEAD, so after a force-push or re-poll the worktree can be stale.
-    // Force-detach to the freshly fetched PR tip so `git diff` sees current
-    // contents.
-    gitExec('git', ['checkout', '--detach', '--force', 'FETCH_HEAD'], worktreePath);
+    // Reset to the freshly fetched commit so `git diff` sees current contents.
+    // Use the resolved OID, not FETCH_HEAD, because FETCH_HEAD is a pseudoref
+    // in the bare repo and is not available as a normal ref inside the linked
+    // worktree.
+    gitExec('git', ['checkout', '--detach', '--force', prHeadCommit], worktreePath);
 
     if (useSparse) {
       configureSparseCheckout(worktreePath, sparseOptions.diffPaths);


### PR DESCRIPTION
## Summary

- Resolve `FETCH_HEAD` to a stable commit SHA inside the bare repo via `git rev-parse --verify FETCH_HEAD`, then use the SHA for both `git worktree add --detach <wt> <sha>` and the post-add `git checkout --detach --force <sha>` reset.
- Root cause of #766: `FETCH_HEAD` is a pseudoref written by `git fetch` into the bare repo's gitdir. It is **not** visible as a normal ref from a linked worktree, so on the second invocation of `ensurePRWorktree` (when the worktree dir already exists) `git checkout --detach --force FETCH_HEAD` executed from the worktree's cwd failed to resolve the ref, leaving the worktree stale. Same problem would bite a fresh `worktree add … FETCH_HEAD` if git ever checked the worktree gitdir first.
- Linked worktrees now always receive an explicit commit ID, matching what `git worktree add --detach <path> <rev>` actually wants.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — 2927 tests pass
- [x] `pnpm lint`
- [x] `pnpm run typecheck`
- [x] New assertions in `packages/cli/src/__tests__/repo-cache.test.ts`:
  - `addWorktree` now requires an explicit `targetRef` and forwards it to `git worktree add`.
  - `checkoutWorktree` issues `git rev-parse --verify FETCH_HEAD` in the bare repo cwd and the resolved SHA flows into both `worktree add` and the checkout reset.

Part of #766