### PR TITLE
[cli-dev] Raise flaky integration test timeout to 30s

### DIFF
--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -330,7 +330,7 @@ describe('CLI ↔ Server Integration', () => {
       // Mark completed to stop loop
       await server.store.updateTask(taskId, { status: 'completed' });
       await stopAgent(agentPromise, server);
-    }, 15000);
+    }, 30000);
   });
 
   // ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
Part of #774

## Summary
- Raises the per-test timeout on `cli-server-integration.test.ts > E > 'tool crash reports error to server, slot is freed'` from 15000ms to 30000ms.
- The test had ~1s headroom (13.6s typical vs 15s deadline) and intermittently timed out under full-suite CPU contention. No functional change; just doubles the cushion.
- Picked option (1) from the issue (lowest-risk two-digit change) over slimming the test body — the test still exercises the real path (child crash → CLI → server → freed slot).

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 2927/2927 pass; the flaky test runs in ~14.4s under full-suite load (well under 30s)
- [x] `pnpm lint` clean
- [x] `pnpm run format:check` clean
- [x] `pnpm run typecheck` clean