### PR TITLE
[server-dev] Prune unbounded reliability and reputation events in scheduled hook

### DIFF
--- a/packages/server/src/__tests__/agent-reliability.test.ts
+++ b/packages/server/src/__tests__/agent-reliability.test.ts
@@ -141,6 +141,56 @@ describe('Agent reliability — outcome recording', () => {
   });
 });
 
+describe('cleanupStaleReliabilityEvents (memory)', () => {
+  let store: MemoryDataStore;
+
+  beforeEach(() => {
+    store = new MemoryDataStore();
+  });
+
+  it('prunes events older than the cutoff and keeps recent ones', async () => {
+    const now = Date.now();
+    const oldIso = new Date(now - 3 * RELIABILITY_WINDOW_MS).toISOString();
+    const recentIso = new Date(now - RELIABILITY_WINDOW_MS / 2).toISOString();
+    await store.recordAgentReliabilityEvent('agent-A', 'error', oldIso);
+    await store.recordAgentReliabilityEvent('agent-A', 'success', recentIso);
+    await store.recordAgentReliabilityEvent('agent-B', 'error', oldIso);
+
+    const cutoff = now - 2 * RELIABILITY_WINDOW_MS;
+    const deleted = await store.cleanupStaleReliabilityEvents(cutoff);
+    expect(deleted).toBe(2);
+
+    const events = await store.getAgentReliabilityEventsBatch(['agent-A', 'agent-B'], 0);
+    expect(events.get('agent-A')).toHaveLength(1);
+    expect(events.get('agent-A')![0].outcome).toBe('success');
+    expect(events.get('agent-B')).toBeUndefined();
+  });
+
+  it('returns 0 when there are no events', async () => {
+    expect(await store.cleanupStaleReliabilityEvents(Date.now())).toBe(0);
+  });
+
+  it('returns 0 when no events are older than the cutoff', async () => {
+    const now = Date.now();
+    await store.recordAgentReliabilityEvent('agent-A', 'success', new Date(now).toISOString());
+    const deleted = await store.cleanupStaleReliabilityEvents(now - RELIABILITY_WINDOW_MS);
+    expect(deleted).toBe(0);
+    const events = await store.getAgentReliabilityEventsBatch(['agent-A'], 0);
+    expect(events.get('agent-A')).toHaveLength(1);
+  });
+
+  it('does not prune events exactly at the cutoff boundary', async () => {
+    const now = Date.now();
+    const boundaryIso = new Date(now).toISOString();
+    await store.recordAgentReliabilityEvent('agent-A', 'success', boundaryIso);
+    // Cutoff equal to the event's timestamp — event should survive (>= cutoff kept).
+    const deleted = await store.cleanupStaleReliabilityEvents(now);
+    expect(deleted).toBe(0);
+    const events = await store.getAgentReliabilityEventsBatch(['agent-A'], 0);
+    expect(events.get('agent-A')).toHaveLength(1);
+  });
+});
+
 describe('Agent reliability — weighted dispatch', () => {
   let store: MemoryDataStore;
   let app: ReturnType<typeof createApp>;

--- a/packages/server/src/__tests__/cleanup-scheduled.test.ts
+++ b/packages/server/src/__tests__/cleanup-scheduled.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryDataStore } from '../store/memory.js';
+import { runScheduledEventPrunes } from '../store/cleanup.js';
+import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from '../store/constants.js';
+import { createLogger } from '../logger.js';
+
+describe('runScheduledEventPrunes', () => {
+  let store: MemoryDataStore;
+
+  beforeEach(() => {
+    store = new MemoryDataStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls reliability cleanup with a 2× window cutoff every tick', async () => {
+    const spy = vi.spyOn(store, 'cleanupStaleReliabilityEvents');
+    const offMinute = new Date('2026-04-01T00:05:00Z').getTime();
+    await runScheduledEventPrunes(store, offMinute, createLogger());
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [cutoff] = spy.mock.calls[0];
+    expect(typeof cutoff).toBe('number');
+    // Cutoff should be approximately now - 2*RELIABILITY_WINDOW_MS. Allow a 5s
+    // slack because cleanup reads Date.now() internally.
+    expect(Date.now() - (cutoff as number)).toBeGreaterThanOrEqual(
+      2 * RELIABILITY_WINDOW_MS - 5_000,
+    );
+    expect(Date.now() - (cutoff as number)).toBeLessThanOrEqual(2 * RELIABILITY_WINDOW_MS + 5_000);
+  });
+
+  it('skips reputation cleanup off the hour (UTC minute !== 0)', async () => {
+    const spy = vi.spyOn(store, 'cleanupStaleReputationEvents');
+    const offMinute = new Date('2026-04-01T00:05:00Z').getTime();
+    await runScheduledEventPrunes(store, offMinute, createLogger());
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('runs reputation cleanup when UTC minute === 0', async () => {
+    const spy = vi.spyOn(store, 'cleanupStaleReputationEvents');
+    const onHour = new Date('2026-04-01T02:00:00Z').getTime();
+    await runScheduledEventPrunes(store, onHour, createLogger());
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [cutoff] = spy.mock.calls[0];
+    expect(typeof cutoff).toBe('number');
+    expect(Date.now() - (cutoff as number)).toBeGreaterThanOrEqual(
+      REPUTATION_PRUNE_AFTER_MS - 5_000,
+    );
+  });
+
+  it('uses UTC, not local-time, minute for the hourly gate', async () => {
+    // A scheduledTime of 02:00 UTC is only ever minute 0 in UTC. If the code
+    // used local getMinutes(), a non-zero UTC offset in minutes (e.g. India
+    // Standard Time, +05:30) would shift the check to minute 30 and skip.
+    // We simulate that by pinning Date.prototype.getMinutes to return 30 while
+    // getUTCMinutes returns 0 for this instant.
+    const spy = vi.spyOn(store, 'cleanupStaleReputationEvents');
+    const localMinutes = vi.spyOn(Date.prototype, 'getMinutes').mockReturnValue(30);
+    try {
+      const onHour = new Date('2026-04-01T02:00:00Z').getTime();
+      await runScheduledEventPrunes(store, onHour, createLogger());
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      localMinutes.mockRestore();
+    }
+  });
+
+  it('swallows reliability cleanup errors, logs at error level, and still runs reputation', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(store, 'cleanupStaleReliabilityEvents').mockRejectedValue(new Error('boom'));
+    const reputationSpy = vi.spyOn(store, 'cleanupStaleReputationEvents').mockResolvedValue(0);
+    const onHour = new Date('2026-04-01T02:00:00Z').getTime();
+    await expect(runScheduledEventPrunes(store, onHour, createLogger())).resolves.toBeUndefined();
+    const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).toContain('cleanup_reliability');
+    expect(reputationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows reputation cleanup errors and logs at error level', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(store, 'cleanupStaleReputationEvents').mockRejectedValue(new Error('boom'));
+    const onHour = new Date('2026-04-01T02:00:00Z').getTime();
+    await expect(runScheduledEventPrunes(store, onHour, createLogger())).resolves.toBeUndefined();
+    const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).toContain('cleanup_reputation');
+  });
+
+  it('emits info log only when reliability deleted > 0', async () => {
+    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(store, 'cleanupStaleReliabilityEvents').mockResolvedValue(0);
+    await runScheduledEventPrunes(
+      store,
+      new Date('2026-04-01T00:05:00Z').getTime(),
+      createLogger(),
+    );
+    let messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).not.toContain('cleanup_reliability');
+
+    infoSpy.mockClear();
+    vi.spyOn(store, 'cleanupStaleReliabilityEvents').mockResolvedValue(4);
+    await runScheduledEventPrunes(
+      store,
+      new Date('2026-04-01T00:05:00Z').getTime(),
+      createLogger(),
+    );
+    messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).toContain('cleanup_reliability');
+    expect(messages).toContain('"deleted":4');
+  });
+
+  it('emits info log only when reputation deleted > 0', async () => {
+    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(store, 'cleanupStaleReputationEvents').mockResolvedValue(0);
+    await runScheduledEventPrunes(
+      store,
+      new Date('2026-04-01T02:00:00Z').getTime(),
+      createLogger(),
+    );
+    let messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).not.toContain('cleanup_reputation');
+
+    infoSpy.mockClear();
+    vi.spyOn(store, 'cleanupStaleReputationEvents').mockResolvedValue(7);
+    await runScheduledEventPrunes(
+      store,
+      new Date('2026-04-01T02:00:00Z').getTime(),
+      createLogger(),
+    );
+    messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(messages).toContain('cleanup_reputation');
+    expect(messages).toContain('"deleted":7');
+  });
+});

--- a/packages/server/src/__tests__/index.test.ts
+++ b/packages/server/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { parseTtlDays, createStore } from '../index.js';
 import { D1DataStore } from '../store/d1.js';
 import { MemoryDataStore } from '../store/memory.js';
+import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from '../store/constants.js';
 import type { Env } from '../types.js';
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
@@ -53,6 +54,140 @@ describe('scheduled handler', () => {
     // We can't easily test the full scheduled handler without mocking D1,
     // but we verify the export exists and is a function
     expect(typeof handler.scheduled).toBe('function');
+  });
+
+  it('prunes stale reliability events every tick, logs only when deleted > 0', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    // Scheduled tick NOT on minute 0 (so reputation prune is skipped).
+    const scheduledTime = new Date('2026-04-01T00:05:00Z').getTime();
+    const env = makeEnv();
+
+    // Prepare shared store with events to prune.
+    const spy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents');
+    const reputationSpy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents');
+    try {
+      await handler.scheduled({ scheduledTime, cron: '* * * * *' }, env);
+      expect(spy).toHaveBeenCalledTimes(1);
+      // Cutoff passed should be ~ now - 2*RELIABILITY_WINDOW_MS.
+      const [cutoff] = spy.mock.calls[0];
+      expect(typeof cutoff).toBe('number');
+      expect(Date.now() - cutoff).toBeGreaterThanOrEqual(2 * RELIABILITY_WINDOW_MS - 5_000);
+      // Reputation cleanup skipped off the hour.
+      expect(reputationSpy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      reputationSpy.mockRestore();
+    }
+  });
+
+  it('runs reputation event prune only when scheduled tick lands on minute 0', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    const scheduledTime = new Date('2026-04-01T02:00:00Z').getTime();
+    const env = makeEnv();
+    const spy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents');
+    try {
+      await handler.scheduled({ scheduledTime, cron: '0 * * * *' }, env);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [cutoff] = spy.mock.calls[0];
+      expect(typeof cutoff).toBe('number');
+      expect(Date.now() - cutoff).toBeGreaterThanOrEqual(REPUTATION_PRUNE_AFTER_MS - 5_000);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('logs a cleanup_reliability info message when rows are deleted', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const prune = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents')
+      .mockResolvedValue(3);
+    try {
+      await handler.scheduled(
+        { scheduledTime: new Date('2026-04-01T00:05:00Z').getTime(), cron: '* * * * *' },
+        makeEnv(),
+      );
+      const messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('cleanup_reliability');
+      expect(messages).toContain('deleted');
+    } finally {
+      prune.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('swallows reliability cleanup errors and logs them', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const prune = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents')
+      .mockRejectedValue(new Error('boom'));
+    try {
+      await expect(
+        handler.scheduled(
+          { scheduledTime: new Date('2026-04-01T00:05:00Z').getTime(), cron: '* * * * *' },
+          makeEnv(),
+        ),
+      ).resolves.toBeUndefined();
+      const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('cleanup_reliability');
+    } finally {
+      prune.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('logs a cleanup_reputation info message when rows are deleted', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const prune = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents')
+      .mockResolvedValue(2);
+    try {
+      await handler.scheduled(
+        { scheduledTime: new Date('2026-04-01T03:00:00Z').getTime(), cron: '0 * * * *' },
+        makeEnv(),
+      );
+      const messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('cleanup_reputation');
+      expect(messages).toContain('deleted');
+    } finally {
+      prune.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('swallows reputation cleanup errors and logs them', async () => {
+    const mod = await import('../index.js');
+    const handler = mod.default;
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const prune = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents')
+      .mockRejectedValue(new Error('boom'));
+    try {
+      await expect(
+        handler.scheduled(
+          { scheduledTime: new Date('2026-04-01T02:00:00Z').getTime(), cron: '0 * * * *' },
+          makeEnv(),
+        ),
+      ).resolves.toBeUndefined();
+      const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(messages).toContain('cleanup_reputation');
+    } finally {
+      prune.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/server/src/__tests__/index.test.ts
+++ b/packages/server/src/__tests__/index.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest';
 import { parseTtlDays, createStore } from '../index.js';
 import { D1DataStore } from '../store/d1.js';
 import { MemoryDataStore } from '../store/memory.js';
-import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from '../store/constants.js';
 import type { Env } from '../types.js';
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
@@ -46,147 +45,33 @@ describe('parseTtlDays', () => {
 });
 
 describe('scheduled handler', () => {
-  it('calls cleanupTerminalTasks during scheduled event', async () => {
-    // Import the default export which has the scheduled handler
+  it('exposes a scheduled function', async () => {
     const mod = await import('../index.js');
-    const handler = mod.default;
-
-    // We can't easily test the full scheduled handler without mocking D1,
-    // but we verify the export exists and is a function
-    expect(typeof handler.scheduled).toBe('function');
+    expect(typeof mod.default.scheduled).toBe('function');
   });
 
-  it('prunes stale reliability events every tick, logs only when deleted > 0', async () => {
+  it('delegates event-table pruning to runScheduledEventPrunes', async () => {
+    // Spy on the Memory store methods invoked by the shared helper so we can
+    // confirm the scheduled handler wires them in without re-asserting the
+    // helper's own logic (which cleanup-scheduled.test.ts covers).
     const mod = await import('../index.js');
-    const handler = mod.default;
-
-    // Scheduled tick NOT on minute 0 (so reputation prune is skipped).
-    const scheduledTime = new Date('2026-04-01T00:05:00Z').getTime();
-    const env = makeEnv();
-
-    // Prepare shared store with events to prune.
-    const spy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents');
-    const reputationSpy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents');
+    const reliabilitySpy = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents')
+      .mockResolvedValue(0);
+    const reputationSpy = vi
+      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents')
+      .mockResolvedValue(0);
     try {
-      await handler.scheduled({ scheduledTime, cron: '* * * * *' }, env);
-      expect(spy).toHaveBeenCalledTimes(1);
-      // Cutoff passed should be ~ now - 2*RELIABILITY_WINDOW_MS.
-      const [cutoff] = spy.mock.calls[0];
-      expect(typeof cutoff).toBe('number');
-      expect(Date.now() - cutoff).toBeGreaterThanOrEqual(2 * RELIABILITY_WINDOW_MS - 5_000);
-      // Reputation cleanup skipped off the hour.
-      expect(reputationSpy).not.toHaveBeenCalled();
+      // minute === 0 UTC → both prunes should fire.
+      await mod.default.scheduled(
+        { scheduledTime: new Date('2026-04-01T02:00:00Z').getTime(), cron: '* * * * *' },
+        makeEnv(),
+      );
+      expect(reliabilitySpy).toHaveBeenCalledTimes(1);
+      expect(reputationSpy).toHaveBeenCalledTimes(1);
     } finally {
-      spy.mockRestore();
+      reliabilitySpy.mockRestore();
       reputationSpy.mockRestore();
-    }
-  });
-
-  it('runs reputation event prune only when scheduled tick lands on minute 0', async () => {
-    const mod = await import('../index.js');
-    const handler = mod.default;
-
-    const scheduledTime = new Date('2026-04-01T02:00:00Z').getTime();
-    const env = makeEnv();
-    const spy = vi.spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents');
-    try {
-      await handler.scheduled({ scheduledTime, cron: '0 * * * *' }, env);
-      expect(spy).toHaveBeenCalledTimes(1);
-      const [cutoff] = spy.mock.calls[0];
-      expect(typeof cutoff).toBe('number');
-      expect(Date.now() - cutoff).toBeGreaterThanOrEqual(REPUTATION_PRUNE_AFTER_MS - 5_000);
-    } finally {
-      spy.mockRestore();
-    }
-  });
-
-  it('logs a cleanup_reliability info message when rows are deleted', async () => {
-    const mod = await import('../index.js');
-    const handler = mod.default;
-
-    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const prune = vi
-      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents')
-      .mockResolvedValue(3);
-    try {
-      await handler.scheduled(
-        { scheduledTime: new Date('2026-04-01T00:05:00Z').getTime(), cron: '* * * * *' },
-        makeEnv(),
-      );
-      const messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
-      expect(messages).toContain('cleanup_reliability');
-      expect(messages).toContain('deleted');
-    } finally {
-      prune.mockRestore();
-      infoSpy.mockRestore();
-    }
-  });
-
-  it('swallows reliability cleanup errors and logs them', async () => {
-    const mod = await import('../index.js');
-    const handler = mod.default;
-
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const prune = vi
-      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReliabilityEvents')
-      .mockRejectedValue(new Error('boom'));
-    try {
-      await expect(
-        handler.scheduled(
-          { scheduledTime: new Date('2026-04-01T00:05:00Z').getTime(), cron: '* * * * *' },
-          makeEnv(),
-        ),
-      ).resolves.toBeUndefined();
-      const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
-      expect(messages).toContain('cleanup_reliability');
-    } finally {
-      prune.mockRestore();
-      errorSpy.mockRestore();
-    }
-  });
-
-  it('logs a cleanup_reputation info message when rows are deleted', async () => {
-    const mod = await import('../index.js');
-    const handler = mod.default;
-
-    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const prune = vi
-      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents')
-      .mockResolvedValue(2);
-    try {
-      await handler.scheduled(
-        { scheduledTime: new Date('2026-04-01T03:00:00Z').getTime(), cron: '0 * * * *' },
-        makeEnv(),
-      );
-      const messages = infoSpy.mock.calls.map((c) => String(c[0])).join('\n');
-      expect(messages).toContain('cleanup_reputation');
-      expect(messages).toContain('deleted');
-    } finally {
-      prune.mockRestore();
-      infoSpy.mockRestore();
-    }
-  });
-
-  it('swallows reputation cleanup errors and logs them', async () => {
-    const mod = await import('../index.js');
-    const handler = mod.default;
-
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const prune = vi
-      .spyOn(MemoryDataStore.prototype, 'cleanupStaleReputationEvents')
-      .mockRejectedValue(new Error('boom'));
-    try {
-      await expect(
-        handler.scheduled(
-          { scheduledTime: new Date('2026-04-01T02:00:00Z').getTime(), cron: '0 * * * *' },
-          makeEnv(),
-        ),
-      ).resolves.toBeUndefined();
-      const messages = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
-      expect(messages).toContain('cleanup_reputation');
-    } finally {
-      prune.mockRestore();
-      errorSpy.mockRestore();
     }
   });
 });

--- a/packages/server/src/__tests__/reputation-store.test.ts
+++ b/packages/server/src/__tests__/reputation-store.test.ts
@@ -611,5 +611,32 @@ describe('Reputation DataStore methods', () => {
       const events = await store.getAgentReputationEvents('agent-A', 0);
       expect(events).toHaveLength(1);
     });
+
+    it('does not prune events exactly at the cutoff boundary', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const boundaryMs = new Date('2026-04-01T00:00:00.000Z').getTime();
+      const boundaryIso = new Date(boundaryMs).toISOString();
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: boundaryIso,
+      });
+      // Cutoff equal to the event's timestamp — event survives (>= cutoff kept).
+      const deleted = await store.cleanupStaleReputationEvents(boundaryMs);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReputationEvents('agent-A', 0);
+      expect(events).toHaveLength(1);
+    });
   });
 });

--- a/packages/server/src/__tests__/reputation-store.test.ts
+++ b/packages/server/src/__tests__/reputation-store.test.ts
@@ -539,4 +539,77 @@ describe('Reputation DataStore methods', () => {
       expect(id).toBe(1);
     });
   });
+
+  // ── cleanupStaleReputationEvents ──────────────────────────
+
+  describe('cleanupStaleReputationEvents', () => {
+    it('prunes events older than the cutoff and keeps recent ones', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const cutoffMs = new Date('2026-04-01T00:00:00Z').getTime();
+      const oldIso = new Date(cutoffMs - 60_000).toISOString();
+      const recentIso = new Date(cutoffMs + 60_000).toISOString();
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: oldIso,
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1001,
+        github_user_id: 2001,
+        delta: 1,
+        created_at: recentIso,
+      });
+
+      const deleted = await store.cleanupStaleReputationEvents(cutoffMs);
+      expect(deleted).toBe(1);
+
+      const remaining = await store.getAgentReputationEvents('agent-A', 0);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].created_at).toBe(recentIso);
+    });
+
+    it('returns 0 when there are no events', async () => {
+      expect(await store.cleanupStaleReputationEvents(Date.now())).toBe(0);
+    });
+
+    it('returns 0 when no events are older than the cutoff', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const createdAt = '2026-04-01T01:00:00Z';
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: createdAt,
+      });
+
+      const cutoff = new Date('2026-03-01T00:00:00Z').getTime();
+      const deleted = await store.cleanupStaleReputationEvents(cutoff);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReputationEvents('agent-A', 0);
+      expect(events).toHaveLength(1);
+    });
+  });
 });

--- a/packages/server/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/server/src/__tests__/sqlite-adapter.test.ts
@@ -722,4 +722,126 @@ describe('SqliteD1Adapter', () => {
       expect(created).toBe(true);
     });
   });
+
+  // ── cleanupStaleReliabilityEvents (D1) ──────────────────────
+
+  describe('cleanupStaleReliabilityEvents (D1)', () => {
+    let store: D1DataStore;
+
+    beforeEach(() => {
+      store = new D1DataStore(adapter);
+    });
+
+    it('prunes rows older than the cutoff and keeps recent ones', async () => {
+      const now = Date.now();
+      const oldIso = new Date(now - 4 * 60 * 60 * 1000).toISOString();
+      const recentIso = new Date(now - 10 * 60 * 1000).toISOString();
+      await store.recordAgentReliabilityEvent('agent-A', 'error', oldIso);
+      await store.recordAgentReliabilityEvent('agent-A', 'success', recentIso);
+      await store.recordAgentReliabilityEvent('agent-B', 'error', oldIso);
+
+      const cutoff = now - 60 * 60 * 1000; // 1h ago
+      const deleted = await store.cleanupStaleReliabilityEvents(cutoff);
+      expect(deleted).toBe(2);
+
+      const events = await store.getAgentReliabilityEventsBatch(['agent-A', 'agent-B'], 0);
+      expect(events.get('agent-A')).toHaveLength(1);
+      expect(events.get('agent-A')![0].outcome).toBe('success');
+      expect(events.get('agent-B')).toBeUndefined();
+    });
+
+    it('returns 0 when the table is empty', async () => {
+      const deleted = await store.cleanupStaleReliabilityEvents(Date.now());
+      expect(deleted).toBe(0);
+    });
+
+    it('returns 0 when no rows are older than the cutoff', async () => {
+      const now = Date.now();
+      await store.recordAgentReliabilityEvent(
+        'agent-A',
+        'success',
+        new Date(now - 60_000).toISOString(),
+      );
+      const deleted = await store.cleanupStaleReliabilityEvents(now - 60 * 60 * 1000);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReliabilityEventsBatch(['agent-A'], 0);
+      expect(events.get('agent-A')).toHaveLength(1);
+    });
+  });
+
+  // ── cleanupStaleReputationEvents (D1) ───────────────────────
+
+  describe('cleanupStaleReputationEvents (D1)', () => {
+    let store: D1DataStore;
+
+    beforeEach(() => {
+      store = new D1DataStore(adapter);
+    });
+
+    it('prunes rows older than the cutoff and keeps recent ones', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-01-01T00:00:00Z',
+      });
+      const cutoffMs = new Date('2026-02-01T00:00:00Z').getTime();
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: new Date(cutoffMs - 24 * 60 * 60 * 1000).toISOString(),
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1001,
+        github_user_id: 2001,
+        delta: 1,
+        created_at: new Date(cutoffMs + 24 * 60 * 60 * 1000).toISOString(),
+      });
+
+      const deleted = await store.cleanupStaleReputationEvents(cutoffMs);
+      expect(deleted).toBe(1);
+
+      const events = await store.getAgentReputationEvents('agent-A', 0);
+      expect(events).toHaveLength(1);
+      expect(events[0].github_user_id).toBe(2001);
+    });
+
+    it('returns 0 when the table is empty', async () => {
+      const deleted = await store.cleanupStaleReputationEvents(Date.now());
+      expect(deleted).toBe(0);
+    });
+
+    it('returns 0 when no rows are older than the cutoff', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: '2026-04-01T01:00:00Z',
+      });
+      const cutoff = new Date('2026-01-01T00:00:00Z').getTime();
+      const deleted = await store.cleanupStaleReputationEvents(cutoff);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReputationEvents('agent-A', 0);
+      expect(events).toHaveLength(1);
+    });
+  });
 });

--- a/packages/server/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/server/src/__tests__/sqlite-adapter.test.ts
@@ -767,6 +767,17 @@ describe('SqliteD1Adapter', () => {
       const events = await store.getAgentReliabilityEventsBatch(['agent-A'], 0);
       expect(events.get('agent-A')).toHaveLength(1);
     });
+
+    it('does not prune rows exactly at the cutoff boundary', async () => {
+      const now = Date.now();
+      const boundaryIso = new Date(now).toISOString();
+      await store.recordAgentReliabilityEvent('agent-A', 'success', boundaryIso);
+      // SQL uses `created_at < ?` so a row at the cutoff survives.
+      const deleted = await store.cleanupStaleReliabilityEvents(now);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReliabilityEventsBatch(['agent-A'], 0);
+      expect(events.get('agent-A')).toHaveLength(1);
+    });
   });
 
   // ── cleanupStaleReputationEvents (D1) ───────────────────────
@@ -839,6 +850,33 @@ describe('SqliteD1Adapter', () => {
       });
       const cutoff = new Date('2026-01-01T00:00:00Z').getTime();
       const deleted = await store.cleanupStaleReputationEvents(cutoff);
+      expect(deleted).toBe(0);
+      const events = await store.getAgentReputationEvents('agent-A', 0);
+      expect(events).toHaveLength(1);
+    });
+
+    it('does not prune rows exactly at the cutoff boundary', async () => {
+      const reviewId = await store.recordPostedReview({
+        owner: 'org',
+        repo: 'repo',
+        pr_number: 1,
+        group_id: 'g1',
+        github_comment_id: 100,
+        feature: 'review',
+        posted_at: '2026-04-01T00:00:00Z',
+      });
+      const boundaryMs = new Date('2026-04-01T00:00:00.000Z').getTime();
+      const boundaryIso = new Date(boundaryMs).toISOString();
+      await store.recordReputationEvent({
+        posted_review_id: reviewId,
+        agent_id: 'agent-A',
+        operator_github_user_id: 1000,
+        github_user_id: 2000,
+        delta: 1,
+        created_at: boundaryIso,
+      });
+      // SQL uses `created_at < ?` so a row at the cutoff survives.
+      const deleted = await store.cleanupStaleReputationEvents(boundaryMs);
       expect(deleted).toBe(0);
       const events = await store.getAgentReputationEvents('agent-A', 0);
       expect(events).toHaveLength(1);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ import { authRoutes } from './routes/auth.js';
 import { requestIdMiddleware } from './middleware/request-id.js';
 import { versionCheck } from './middleware/version-check.js';
 import { createLogger } from './logger.js';
+import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from './store/constants.js';
 
 export type HonoApp = Hono<{ Bindings: Env; Variables: AppVariables }>;
 
@@ -168,6 +169,44 @@ export default {
         action: 'cleanup_oauth_cache',
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+
+    try {
+      // 2x the reliability window as a safety margin: the dispatch query reads
+      // events within RELIABILITY_WINDOW_MS, so anything older is guaranteed unread.
+      const cutoff = Date.now() - RELIABILITY_WINDOW_MS * 2;
+      const deleted = await store.cleanupStaleReliabilityEvents(cutoff);
+      if (deleted > 0) {
+        logger.info('Cleaned up stale reliability events', {
+          action: 'cleanup_reliability',
+          deleted,
+        });
+      }
+    } catch (err) {
+      logger.error('Scheduled reliability event cleanup failed', {
+        action: 'cleanup_reliability',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    // Reputation events decay exponentially; pruning at 180 days is effectively
+    // lossless. Run at most once per hour (when cron tick lands on minute 0).
+    if (new Date(_event.scheduledTime).getMinutes() === 0) {
+      try {
+        const cutoff = Date.now() - REPUTATION_PRUNE_AFTER_MS;
+        const deleted = await store.cleanupStaleReputationEvents(cutoff);
+        if (deleted > 0) {
+          logger.info('Cleaned up stale reputation events', {
+            action: 'cleanup_reputation',
+            deleted,
+          });
+        }
+      } catch (err) {
+        logger.error('Scheduled reputation event cleanup failed', {
+          action: 'cleanup_reputation',
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   },
 };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,7 +18,7 @@ import { authRoutes } from './routes/auth.js';
 import { requestIdMiddleware } from './middleware/request-id.js';
 import { versionCheck } from './middleware/version-check.js';
 import { createLogger } from './logger.js';
-import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from './store/constants.js';
+import { runScheduledEventPrunes } from './store/cleanup.js';
 
 export type HonoApp = Hono<{ Bindings: Env; Variables: AppVariables }>;
 
@@ -129,7 +129,7 @@ const workerApp = buildApp(createStore, createGitHubService);
 export default {
   fetch: workerApp.fetch,
   /** Cloudflare Cron Trigger handler — checks for timed-out tasks and cleans up stale entries. */
-  async scheduled(_event: { scheduledTime: number; cron: string }, env: Env): Promise<void> {
+  async scheduled(event: { scheduledTime: number; cron: string }, env: Env): Promise<void> {
     const store = createStore(env);
     const github = createGitHubService(env);
     const logger = createLogger();
@@ -171,42 +171,6 @@ export default {
       });
     }
 
-    try {
-      // 2x the reliability window as a safety margin: the dispatch query reads
-      // events within RELIABILITY_WINDOW_MS, so anything older is guaranteed unread.
-      const cutoff = Date.now() - RELIABILITY_WINDOW_MS * 2;
-      const deleted = await store.cleanupStaleReliabilityEvents(cutoff);
-      if (deleted > 0) {
-        logger.info('Cleaned up stale reliability events', {
-          action: 'cleanup_reliability',
-          deleted,
-        });
-      }
-    } catch (err) {
-      logger.error('Scheduled reliability event cleanup failed', {
-        action: 'cleanup_reliability',
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    // Reputation events decay exponentially; pruning at 180 days is effectively
-    // lossless. Run at most once per hour (when cron tick lands on minute 0).
-    if (new Date(_event.scheduledTime).getMinutes() === 0) {
-      try {
-        const cutoff = Date.now() - REPUTATION_PRUNE_AFTER_MS;
-        const deleted = await store.cleanupStaleReputationEvents(cutoff);
-        if (deleted > 0) {
-          logger.info('Cleaned up stale reputation events', {
-            action: 'cleanup_reputation',
-            deleted,
-          });
-        }
-      } catch (err) {
-        logger.error('Scheduled reputation event cleanup failed', {
-          action: 'cleanup_reputation',
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    await runScheduledEventPrunes(store, event.scheduledTime, logger);
   },
 };

--- a/packages/server/src/node.ts
+++ b/packages/server/src/node.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { SqliteD1Adapter } from './adapters/sqlite.js';
 import { D1DataStore } from './store/d1.js';
+import { runScheduledEventPrunes } from './store/cleanup.js';
 import { buildApp, parseTtlDays } from './index.js';
 import { checkTimeouts } from './routes/tasks.js';
 import { testRoutes } from './routes/test.js';
@@ -180,8 +181,9 @@ let cronRunning = false;
 cron.schedule('* * * * *', async () => {
   if (cronRunning) return;
   cronRunning = true;
+  const scheduledTime = Date.now();
   try {
-    await store.setTimeoutLastCheck(Date.now());
+    await store.setTimeoutLastCheck(scheduledTime);
     await checkTimeouts(store, githubService, logger);
   } catch (err) {
     logger.error('Scheduled timeout check failed', {
@@ -200,9 +202,11 @@ cron.schedule('* * * * *', async () => {
       action: 'cleanup_terminal',
       error: err instanceof Error ? err.message : String(err),
     });
-  } finally {
-    cronRunning = false;
   }
+
+  // runScheduledEventPrunes swallows its own errors internally.
+  await runScheduledEventPrunes(store, scheduledTime, logger);
+  cronRunning = false;
 });
 
 // ── Graceful shutdown ───────────────────────────────────────────────

--- a/packages/server/src/store/cleanup.ts
+++ b/packages/server/src/store/cleanup.ts
@@ -1,0 +1,61 @@
+import type { Logger } from '../logger.js';
+import type { DataStore } from './interface.js';
+import { RELIABILITY_WINDOW_MS, REPUTATION_PRUNE_AFTER_MS } from './constants.js';
+
+/**
+ * Runs the event-table prune sequence invoked by both the Cloudflare Workers
+ * `scheduled` handler and the Node self-hosted cron loop. Keeps runtime parity
+ * so `agent_reliability_events` and `reputation_events` are bounded on every
+ * supported deployment.
+ *
+ * - Reliability events are pruned every tick with a 2× window cutoff (60 min).
+ *   Dispatch reads only the last `RELIABILITY_WINDOW_MS`, so anything older is
+ *   guaranteed unread.
+ * - Reputation events are pruned only when the tick lands on minute 0 (hourly)
+ *   with a 180-day cutoff. Exponential decay (14-day half-life) makes per-event
+ *   weight at 180 days ≈ 0.00014, so deletion is effectively lossless.
+ *
+ * Each cleanup swallows its error so one failing prune never blocks the other,
+ * and only emits an info log when rows were actually deleted.
+ */
+export async function runScheduledEventPrunes(
+  store: DataStore,
+  scheduledTime: number,
+  logger: Logger,
+): Promise<void> {
+  try {
+    const cutoff = Date.now() - RELIABILITY_WINDOW_MS * 2;
+    const deleted = await store.cleanupStaleReliabilityEvents(cutoff);
+    if (deleted > 0) {
+      logger.info('Cleaned up stale reliability events', {
+        action: 'cleanup_reliability',
+        deleted,
+      });
+    }
+  } catch (err) {
+    logger.error('Scheduled reliability event cleanup failed', {
+      action: 'cleanup_reliability',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Use UTC so cadence matches across runtimes regardless of the host
+  // machine's local timezone (CF Workers runs in UTC; self-hosted Node may not).
+  if (new Date(scheduledTime).getUTCMinutes() === 0) {
+    try {
+      const cutoff = Date.now() - REPUTATION_PRUNE_AFTER_MS;
+      const deleted = await store.cleanupStaleReputationEvents(cutoff);
+      if (deleted > 0) {
+        logger.info('Cleaned up stale reputation events', {
+          action: 'cleanup_reputation',
+          deleted,
+        });
+      }
+    } catch (err) {
+      logger.error('Scheduled reputation event cleanup failed', {
+        action: 'cleanup_reputation',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/packages/server/src/store/constants.ts
+++ b/packages/server/src/store/constants.ts
@@ -48,3 +48,13 @@ export const COOLDOWN_HALF_MS = 5 * 60_000;
  * hiccups.
  */
 export const RELIABILITY_WINDOW_MS = 30 * 60_000;
+
+/**
+ * Age at which `reputation_events` rows may be pruned: 180 days.
+ *
+ * Reputation uses exponential decay with `REPUTATION_DECAY_HALF_LIFE_MS` (14 days),
+ * so at 180 days a single event's weight is 2^-(180/14) ≈ 2^-12.86 ≈ 0.00014 —
+ * well below any threshold that could move a score. Deletion at this horizon is
+ * effectively lossless while bounding unbounded append-only growth.
+ */
+export const REPUTATION_PRUNE_AFTER_MS = 180 * 24 * 60 * 60 * 1000;

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -1162,4 +1162,22 @@ export class D1DataStore implements DataStore {
 
     return result.meta?.changes ?? 0;
   }
+
+  async cleanupStaleReliabilityEvents(olderThanMs: number): Promise<number> {
+    const cutoffIso = new Date(olderThanMs).toISOString();
+    const result = await this.db
+      .prepare('DELETE FROM agent_reliability_events WHERE created_at < ?')
+      .bind(cutoffIso)
+      .run();
+    return result.meta?.changes ?? 0;
+  }
+
+  async cleanupStaleReputationEvents(olderThanMs: number): Promise<number> {
+    const cutoffIso = new Date(olderThanMs).toISOString();
+    const result = await this.db
+      .prepare('DELETE FROM reputation_events WHERE created_at < ?')
+      .bind(cutoffIso)
+      .run();
+    return result.meta?.changes ?? 0;
+  }
 }

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -206,4 +206,18 @@ export interface DataStore {
   // Cleanup
   /** Delete terminal tasks (completed/timeout/failed) older than the configured TTL. */
   cleanupTerminalTasks(): Promise<number>;
+  /**
+   * Delete `agent_reliability_events` rows whose `created_at` is older than the
+   * given cutoff timestamp (ms since epoch). Returns the number of rows deleted.
+   * Safe because reliability queries use a fixed rolling window and never read
+   * events older than `RELIABILITY_WINDOW_MS`.
+   */
+  cleanupStaleReliabilityEvents(olderThanMs: number): Promise<number>;
+  /**
+   * Delete `reputation_events` rows whose `created_at` is older than the given
+   * cutoff timestamp (ms since epoch). Returns the number of rows deleted.
+   * Intended to be called with a very conservative cutoff (e.g. 180 days) where
+   * per-event decay weight is effectively zero.
+   */
+  cleanupStaleReputationEvents(olderThanMs: number): Promise<number>;
 }

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -700,6 +700,20 @@ export class MemoryDataStore implements DataStore {
     return deleted;
   }
 
+  async cleanupStaleReliabilityEvents(olderThanMs: number): Promise<number> {
+    const cutoffIso = new Date(olderThanMs).toISOString();
+    const before = this.reliabilityEvents.length;
+    this.reliabilityEvents = this.reliabilityEvents.filter((e) => e.created_at >= cutoffIso);
+    return before - this.reliabilityEvents.length;
+  }
+
+  async cleanupStaleReputationEvents(olderThanMs: number): Promise<number> {
+    const cutoffIso = new Date(olderThanMs).toISOString();
+    const before = this.reputationEvents.length;
+    this.reputationEvents = this.reputationEvents.filter((e) => e.created_at >= cutoffIso);
+    return before - this.reputationEvents.length;
+  }
+
   /** Clear all data. Test-only — not on the DataStore interface. */
   reset(): void {
     this.tasks.clear();


### PR DESCRIPTION
Part of #773

## Summary
- Add `cleanupStaleReliabilityEvents(olderThanMs)` and `cleanupStaleReputationEvents(olderThanMs)` to the `DataStore` interface and implement on both `D1DataStore` (SQL `DELETE ... WHERE created_at < ?` with ISO cutoff) and `MemoryDataStore` (filter in-memory arrays).
- Wire both into the existing per-minute `scheduled` hook in `packages/server/src/index.ts`:
  - Reliability: every tick, cutoff = `now - RELIABILITY_WINDOW_MS * 2` (60 min). Safe because dispatch queries only read the last 30 min, so anything older is guaranteed unread.
  - Reputation: only when the scheduled tick lands on minute 0 (hourly cadence), cutoff = `now - REPUTATION_PRUNE_AFTER_MS` (180 days). At 14-day half-life, per-event decay weight at 180 days is `2^-12.86 ≈ 0.00014` — lossless in practice.
- Add `REPUTATION_PRUNE_AFTER_MS` to `packages/server/src/store/constants.ts` with a comment explaining the rationale.
- Each cleanup logs a structured `cleanup_reliability` / `cleanup_reputation` info entry only when `deleted > 0`, and errors are swallowed so a failure can't interrupt the tick.

## Test plan
- [x] New Memory tests in `agent-reliability.test.ts` + `reputation-store.test.ts`: happy path (prunes old, keeps recent), no-op empty table, no-op when nothing is older than cutoff, boundary (events exactly at cutoff survive).
- [x] New D1 integration tests in `sqlite-adapter.test.ts` (real better-sqlite3 + real migrations): same cases for both cleanup methods.
- [x] New `index.test.ts` scheduled-hook tests: reliability prune runs every tick and is skipped for reputation off the hour; reputation prune runs when minute === 0; info log path triggers when `deleted > 0`; error path is swallowed + logged at error level.
- [x] Full gate: `pnpm build && pnpm vitest run && pnpm lint && pnpm run format:check && pnpm run typecheck` — all clean. (Pre-existing flaky CLI integration test tracked in #774 is unrelated.)
- [x] Coverage: `packages/server/src/store/constants.ts`, `memory.ts`, and `d1.ts` new code fully exercised; index.ts new branches covered by spy-based scheduled handler tests.