### PR TITLE
[cli-dev] Derive default branch locally when task.base_ref is missing

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -17,7 +17,7 @@ import type { ReviewExecutorDeps } from '../review.js';
 import { createSessionTracker } from '../consumption.js';
 import { FakeServer, FAKE_SERVER_URL } from './helpers/fake-server.js';
 import { executeTool } from '../tool-executor.js';
-import { checkoutWorktree } from '../repo-cache.js';
+import { checkoutWorktree, diffFromWorktree } from '../repo-cache.js';
 
 // ── Mock child_process so fetchDiffViaGh falls back to HTTP ──
 
@@ -65,6 +65,13 @@ vi.mock('../repo-cache.js', async () => {
         // ignore
       }
     }),
+    // With a worktree present, agent.ts requires a working git-diff path —
+    // no silent fallback to gh. Mock a canned diff so task execution proceeds.
+    diffFromWorktree: vi.fn(
+      () =>
+        'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,1 +1,1 @@\n-foo\n+bar\n',
+    ),
+    withRepoLock: vi.fn(async (_repoKey: string, fn: () => unknown) => fn()),
   };
 });
 
@@ -291,6 +298,10 @@ describe('Agent Coverage Tests', () => {
 
   describe('fetchDiff with token', () => {
     it('uses API URL and Bearer token when githubToken is provided', async () => {
+      // Force the gh/HTTP diff path by failing worktree checkout — with a
+      // worktree the agent always uses local git-diff and never hits gh.
+      vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
       let diffFetchUrl: string | undefined;
       let diffFetchHeaders: Record<string, string> | undefined;
 
@@ -387,6 +398,10 @@ describe('Agent Coverage Tests', () => {
 
   describe('safeReject and safeError failure paths', () => {
     it('logs locally when reject endpoint fails', async () => {
+      // Force the gh/HTTP diff path by failing worktree checkout — with a
+      // worktree the agent always uses local git-diff and never hits gh.
+      vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
       const originalFetch = globalThis.fetch;
       server.uninstallFetch();
 
@@ -665,6 +680,73 @@ describe('Agent Coverage Tests', () => {
       }
     });
 
+    it('rejects the task when worktree exists but git diff fails — never falls back to gh', async () => {
+      // With a worktree present, git-diff is the ONLY diff path. If it
+      // throws, the task should be rejected with the propagated error and
+      // the gh/HTTP diff endpoint MUST NOT be touched. This protects against
+      // the silent degradation #775 was filed for.
+      const mockedDiff = vi.mocked(diffFromWorktree);
+      mockedDiff.mockImplementationOnce(() => {
+        throw new Error('fatal: bad revision HEAD');
+      });
+
+      const taskId = await server.injectTask({ reviewCount: 2 });
+
+      // Spy every outbound fetch — we must never see a call to the diff URL
+      // or GitHub's REST diff endpoint while the worktree is available.
+      const ghFetchSpy = vi.fn();
+
+      let rejectBody: Record<string, unknown> | null = null;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        // Any diff-url or GitHub PR diff fetch is a contract violation here.
+        if (url.includes('.diff') || url.includes('/pulls/') || url.includes('api.github.com')) {
+          ghFetchSpy(url);
+        }
+        if (url.includes(`/api/tasks/${taskId}/reject`)) {
+          if (typeof init?.body === 'string') rejectBody = JSON.parse(init.body);
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const deps = makeDeps('git-diff-fail-agent');
+        const reviewDeps: ReviewExecutorDeps = {
+          ...deps.reviewDeps,
+          codebaseDir: '/tmp/test-codebases',
+        };
+
+        const promise = startAgent(
+          'git-diff-fail-agent',
+          FAKE_SERVER_URL,
+          { model: 'test', tool: 'test' },
+          reviewDeps,
+          deps.consumptionDeps,
+          { pollIntervalMs: 100 },
+        );
+
+        await advanceTime(2000);
+
+        // Loud error logged, task rejected, and no gh/HTTP diff fetch
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining('git diff failed for task'),
+        );
+        expect(ghFetchSpy).not.toHaveBeenCalled();
+        expect(rejectBody).not.toBeNull();
+        expect(rejectBody).toMatchObject({
+          reason: expect.stringMatching(/Cannot access diff.*bad revision/),
+        });
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(promise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it('continues with diff-only when worktree checkout fails', async () => {
       // Override checkoutWorktree to throw for this test
       const mockedCheckout = vi.mocked(checkoutWorktree);
@@ -777,6 +859,10 @@ describe('Agent Coverage Tests', () => {
 
   describe('Diff fetch repeated failures', () => {
     it('skips task after MAX_DIFF_FETCH_ATTEMPTS failures', async () => {
+      // Force the gh/HTTP diff path: with a worktree, the agent uses local
+      // git-diff and this retry counter never fires.
+      vi.mocked(checkoutWorktree).mockRejectedValue(new Error('no worktree in test'));
+
       await server.injectTask({ reviewCount: 2 });
       server.diffFetchError = true;
 
@@ -999,6 +1085,10 @@ describe('Agent Coverage Tests', () => {
 
   describe('fetchDiff with non-API URL and token', () => {
     it('adds Bearer token to non-API diff URL', async () => {
+      // Force the gh/HTTP diff path by failing worktree checkout — with a
+      // worktree the agent always uses local git-diff and never hits gh.
+      vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
       let diffFetchUrl: string | undefined;
       let diffFetchHeaders: Record<string, string> | undefined;
 
@@ -1280,6 +1370,10 @@ describe('Agent Coverage Tests', () => {
 
   describe('fetchDiff streaming size guard', () => {
     it('aborts early when Content-Length exceeds maxDiffSizeKb', async () => {
+      // Force the gh/HTTP diff path by failing worktree checkout — with a
+      // worktree the agent always uses local git-diff and never hits gh.
+      vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
       const originalFetch = globalThis.fetch;
       server.uninstallFetch();
 
@@ -1369,6 +1463,10 @@ describe('Agent Coverage Tests', () => {
     });
 
     it('aborts mid-stream when accumulated bytes exceed maxDiffSizeKb', async () => {
+      // Force the gh/HTTP diff path by failing worktree checkout — with a
+      // worktree the agent always uses local git-diff and never hits gh.
+      vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
       const originalFetch = globalThis.fetch;
       server.uninstallFetch();
 

--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -620,6 +620,51 @@ describe('Agent Coverage Tests', () => {
   // ═══════════════════════════════════════════════════════════
 
   describe('Codebase clone paths', () => {
+    it('warns and derives base locally when base_ref is empty', async () => {
+      // Task has no base_ref — the checkout succeeds (mocked) but the git-diff
+      // path still runs via the derive-base fallback. The gh-fetch mock below
+      // returns a canned diff so the agent can submit a review.
+      const taskId = await server.injectTask({ reviewCount: 2, baseRef: '' });
+
+      const deps = makeDeps('missing-base-ref-agent');
+      const reviewDeps: ReviewExecutorDeps = {
+        ...deps.reviewDeps,
+        codebaseDir: '/tmp/test-codebases',
+      };
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const promise = startAgent(
+          'missing-base-ref-agent',
+          FAKE_SERVER_URL,
+          { model: 'test', tool: 'test' },
+          reviewDeps,
+          deps.consumptionDeps,
+          { pollIntervalMs: 100 },
+        );
+
+        await advanceTime(2000);
+
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringMatching(/no base_ref.*deriving default branch/i),
+        );
+
+        await server.store.updateTask(taskId, { status: 'completed' });
+        await stopAgent(promise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     it('continues with diff-only when worktree checkout fails', async () => {
       // Override checkoutWorktree to throw for this test
       const mockedCheckout = vi.mocked(checkoutWorktree);

--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -635,10 +635,16 @@ describe('Agent Coverage Tests', () => {
   // ═══════════════════════════════════════════════════════════
 
   describe('Codebase clone paths', () => {
-    it('warns and derives base locally when base_ref is empty', async () => {
-      // Task has no base_ref — the checkout succeeds (mocked) but the git-diff
-      // path still runs via the derive-base fallback. The gh-fetch mock below
-      // returns a canned diff so the agent can submit a review.
+    it('warns and routes an empty base_ref through the local git-diff path', async () => {
+      // Task has no base_ref. The warn confirms agent.ts took the new
+      // derive-base branch rather than bailing to gh; diffFromWorktree is
+      // actually called (not just defined), confirming the worktree-implies-
+      // git-diff invariant holds even with an empty base_ref. The derive
+      // logic itself is unit-tested against `deriveDefaultBranch` —
+      // diffFromWorktree here is stubbed to return a canned diff.
+      const mockedDiff = vi.mocked(diffFromWorktree);
+      mockedDiff.mockClear();
+
       const taskId = await server.injectTask({ reviewCount: 2, baseRef: '' });
 
       const deps = makeDeps('missing-base-ref-agent');
@@ -647,10 +653,25 @@ describe('Agent Coverage Tests', () => {
         codebaseDir: '/tmp/test-codebases',
       };
 
+      // Spy only on diff-content endpoints — PR-context fetches (comments,
+      // reviews) are unrelated to the diff path and still run normally.
+      // A worktree is available, so the diff URL and the .diff Accept header
+      // MUST NOT be touched while the empty-base_ref path runs.
+      const ghFetchSpy = vi.fn();
       const originalFetch = globalThis.fetch;
       globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
         const url =
           typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        const headers = init?.headers as Record<string, string> | undefined;
+        const accept = headers?.['Accept'] ?? '';
+        const isDiffUrl = url.endsWith('.diff');
+        const isApiDiffFetch =
+          url.includes('api.github.com/repos') &&
+          url.includes('/pulls/') &&
+          accept.includes('diff');
+        if (isDiffUrl || isApiDiffFetch) {
+          ghFetchSpy(url);
+        }
         if (url.includes(`/api/tasks/${taskId}/result`)) {
           return new Response(JSON.stringify({ success: true }), { status: 200 });
         }
@@ -672,6 +693,12 @@ describe('Agent Coverage Tests', () => {
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringMatching(/no base_ref.*deriving default branch/i),
         );
+        // Agent actually called diffFromWorktree (not silently fell through
+        // to gh). baseRef argument is the 3rd positional arg.
+        expect(mockedDiff).toHaveBeenCalled();
+        const baseRefArg = mockedDiff.mock.calls[0][2];
+        expect(baseRefArg === '' || baseRefArg === undefined || baseRefArg === null).toBe(true);
+        expect(ghFetchSpy).not.toHaveBeenCalled();
 
         await server.store.updateTask(taskId, { status: 'completed' });
         await stopAgent(promise, server);

--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -636,16 +636,16 @@ describe('Agent Coverage Tests', () => {
 
   describe('Codebase clone paths', () => {
     it('warns and routes an empty base_ref through the local git-diff path', async () => {
-      // Task has no base_ref. The warn confirms agent.ts took the new
-      // derive-base branch rather than bailing to gh; diffFromWorktree is
-      // actually called (not just defined), confirming the worktree-implies-
-      // git-diff invariant holds even with an empty base_ref. The derive
-      // logic itself is unit-tested against `deriveDefaultBranch` —
-      // diffFromWorktree here is stubbed to return a canned diff.
+      // Server-write invariant (PR #781): MemoryDataStore throws
+      // MissingBaseRefError on a PR-scoped insert with empty base_ref, so we
+      // cannot inject that state directly. Instead we inject with a valid
+      // base_ref and rewrite the PollResponse here to simulate the read-path
+      // edge case (a legitimate production possibility if the server's
+      // log-and-allow path ever emits `''` via D1).
       const mockedDiff = vi.mocked(diffFromWorktree);
       mockedDiff.mockClear();
 
-      const taskId = await server.injectTask({ reviewCount: 2, baseRef: '' });
+      const taskId = await server.injectTask({ reviewCount: 2, baseRef: 'main' });
 
       const deps = makeDeps('missing-base-ref-agent');
       const reviewDeps: ReviewExecutorDeps = {
@@ -675,7 +675,26 @@ describe('Agent Coverage Tests', () => {
         if (url.includes(`/api/tasks/${taskId}/result`)) {
           return new Response(JSON.stringify({ success: true }), { status: 200 });
         }
-        return originalFetch(input, init);
+
+        const response = await originalFetch(input, init);
+
+        // Rewrite the poll response to strip base_ref on our target task,
+        // simulating the server emitting an empty base_ref on the read path.
+        if (url.includes('/api/tasks/poll') && response.ok) {
+          const body = (await response.clone().json()) as {
+            tasks?: Array<Record<string, unknown>>;
+          };
+          if (Array.isArray(body.tasks)) {
+            body.tasks = body.tasks.map((t) => (t.task_id === taskId ? { ...t, base_ref: '' } : t));
+          }
+          return new Response(JSON.stringify(body), {
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+          });
+        }
+
+        return response;
       }) as typeof fetch;
 
       try {

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -42,6 +42,13 @@ vi.mock('../repo-cache.js', async () => {
         // ignore
       }
     }),
+    // With a worktree present, agent.ts requires a working git-diff path —
+    // no silent fallback to gh. Mock a canned diff so task execution proceeds.
+    diffFromWorktree: vi.fn(
+      () =>
+        'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,1 +1,1 @@\n-foo\n+bar\n',
+    ),
+    withRepoLock: vi.fn(async (_repoKey: string, fn: () => unknown) => fn()),
   };
 });
 
@@ -62,6 +69,7 @@ vi.mock('../tool-executor.js', async (importOriginal) => {
 });
 
 import { testCommand } from '../tool-executor.js';
+import { checkoutWorktree } from '../repo-cache.js';
 
 const originalFetch = globalThis.fetch;
 
@@ -671,6 +679,10 @@ describe('agent poll loop', () => {
   });
 
   it('passes AbortSignal to fetch when fetching diff', async () => {
+    // Force the gh/HTTP diff path: with a worktree, the agent uses local
+    // git-diff and the AbortSignal never touches the diff URL fetch.
+    vi.mocked(checkoutWorktree).mockRejectedValueOnce(new Error('no worktree in test'));
+
     let diffFetchInit: RequestInit | undefined;
 
     globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {

--- a/packages/cli/src/__tests__/batch-poll.test.ts
+++ b/packages/cli/src/__tests__/batch-poll.test.ts
@@ -54,6 +54,13 @@ vi.mock('../repo-cache.js', async () => {
         // ignore
       }
     }),
+    // With a worktree present, agent.ts requires a working git-diff path —
+    // no silent fallback to gh. Mock a canned diff so task execution proceeds.
+    diffFromWorktree: vi.fn(
+      () =>
+        'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,1 +1,1 @@\n-foo\n+bar\n',
+    ),
+    withRepoLock: vi.fn(async (_repoKey: string, fn: () => unknown) => fn()),
   };
 });
 

--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -52,6 +52,13 @@ vi.mock('../repo-cache.js', async () => {
         // ignore
       }
     }),
+    // With a worktree present, agent.ts requires a working git-diff path —
+    // no silent fallback to gh. Mock a canned diff so task execution proceeds.
+    diffFromWorktree: vi.fn(
+      () =>
+        'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,1 +1,1 @@\n-foo\n+bar\n',
+    ),
+    withRepoLock: vi.fn(async (_repoKey: string, fn: () => unknown) => fn()),
   };
 });
 

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -18,6 +18,7 @@ import type { ReviewExecutorDeps } from '../review.js';
 import { createSessionTracker } from '../consumption.js';
 import { FakeServer, FAKE_SERVER_URL } from './helpers/fake-server.js';
 import { executeTool } from '../tool-executor.js';
+import { checkoutWorktree } from '../repo-cache.js';
 
 // ── Mock child_process so fetchDiffViaGh falls back to HTTP ──
 
@@ -87,6 +88,13 @@ vi.mock('../repo-cache.js', async () => {
         // ignore
       }
     }),
+    // With a worktree present, agent.ts requires a working git-diff path —
+    // no silent fallback to gh. Mock a canned diff so task execution proceeds.
+    diffFromWorktree: vi.fn(
+      () =>
+        'diff --git a/src/index.ts b/src/index.ts\n--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1,1 +1,1 @@\n-foo\n+bar\n',
+    ),
+    withRepoLock: vi.fn(async (_repoKey: string, fn: () => unknown) => fn()),
   };
 });
 
@@ -252,6 +260,11 @@ describe('E2E Agent Scenarios', () => {
 
   describe('C. Diff fetch failure → rejection', () => {
     it('diff URL returns 500 → agent rejects task on server', async () => {
+      // Force the gh/HTTP diff path: with a worktree, the agent uses local
+      // git-diff and never touches the diff URL. Use mockRejectedValue (not
+      // Once) so retries also hit the no-worktree branch.
+      vi.mocked(checkoutWorktree).mockRejectedValue(new Error('no worktree in test'));
+
       await server.injectTask();
       server.diffFetchError = true;
 
@@ -343,6 +356,12 @@ describe('E2E Agent Scenarios', () => {
 
   describe('G. Diff too large → rejection', () => {
     it('diff exceeds maxDiffSizeKb → agent rejects task', async () => {
+      // Force the gh/HTTP diff path: agent.ts enforces the size cap on
+      // whichever source produced the diff (git or gh), but streaming size
+      // detection lives in the gh fetcher. Use mockRejectedValue so retries
+      // also hit the no-worktree branch.
+      vi.mocked(checkoutWorktree).mockRejectedValue(new Error('no worktree in test'));
+
       const taskId = await server.injectTask({ reviewCount: 2 }); // review role
       server.diffContent = 'x'.repeat(2 * 1024); // 2KB
 

--- a/packages/cli/src/__tests__/helpers/fake-server.ts
+++ b/packages/cli/src/__tests__/helpers/fake-server.ts
@@ -230,6 +230,7 @@ export class FakeServer {
     reviewCount?: number;
     timeout?: string;
     private?: boolean;
+    baseRef?: string;
   }): Promise<string> {
     const config: ReviewConfig = {
       ...DEFAULT_REVIEW_CONFIG,
@@ -247,6 +248,7 @@ export class FakeServer {
           repo: opts?.repo ?? 'test-repo',
           pr_number: opts?.prNumber ?? 1,
           ...(opts?.private !== undefined ? { private: opts.private } : {}),
+          ...(opts?.baseRef !== undefined ? { base_ref: opts.baseRef } : {}),
           config,
         }),
       },

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -31,7 +31,10 @@ import {
   parseDiffPaths,
   buildSparsePatterns,
   configureSparseCheckout,
+  deriveDefaultBranch,
+  diffFromWorktree,
 } from '../repo-cache.js';
+import { DiffTooLargeError } from '../review.js';
 
 describe('repo-cache', () => {
   beforeEach(() => {
@@ -717,6 +720,266 @@ describe('repo-cache', () => {
       expect(args).toContain('src/index.ts');
       expect(args).toContain('package.json');
       expect(call[2]).toMatchObject({ cwd: '/tmp/worktrees/pr-42' });
+    });
+  });
+
+  describe('deriveDefaultBranch', () => {
+    it('returns the branch parsed from symbolic-ref origin/HEAD', () => {
+      vi.mocked(execFileSync).mockReturnValueOnce('refs/remotes/origin/main\n');
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+    });
+
+    it('handles branches with slashes in their names', () => {
+      vi.mocked(execFileSync).mockReturnValueOnce('refs/remotes/origin/release/2026.04\n');
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('release/2026.04');
+    });
+
+    it('falls back to main when symbolic-ref fails', () => {
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('symbolic-ref: no such ref');
+        })
+        .mockReturnValueOnce(''); // main fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(2);
+      const fetchArgs = calls[1][1] as string[];
+      expect(fetchArgs).toContain('fetch');
+      expect(fetchArgs).toContain('main:refs/remotes/origin/main');
+      // Credential helper is included when gh is available
+      expect(fetchArgs).toContain('credential.helper=!gh auth git-credential');
+    });
+
+    it('falls back to master when symbolic-ref and main both fail', () => {
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('symbolic-ref failed');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('main not found');
+        })
+        .mockReturnValueOnce(''); // master fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', false);
+
+      expect(branch).toBe('master');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(3);
+      const masterFetchArgs = calls[2][1] as string[];
+      expect(masterFetchArgs).toContain('master:refs/remotes/origin/master');
+      // No credential helper when gh is not available
+      expect(masterFetchArgs).not.toContain('-c');
+    });
+
+    it('throws when symbolic-ref, main, and master all fail', () => {
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error('failed');
+      });
+
+      expect(() => deriveDefaultBranch('/tmp/repos/acme/widgets.git', true)).toThrow(
+        /Cannot derive default branch/,
+      );
+    });
+
+    it('rejects a symbolic-ref output with an unexpected prefix and falls back', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/heads/main\n') // unexpected prefix — skipped
+        .mockReturnValueOnce(''); // main fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
+    });
+
+    it('rejects a branch name that fails the allowlist and falls back', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/-malicious\n') // rejected by allowlist
+        .mockReturnValueOnce(''); // main fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
+    });
+  });
+
+  describe('diffFromWorktree', () => {
+    it('fetches the supplied base_ref and runs git diff ...HEAD', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // fetch main
+        .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        'main',
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(2);
+
+      // Fetch call runs in the bare repo with credential helper
+      const fetchArgs = calls[0][1] as string[];
+      expect(fetchArgs).toContain('fetch');
+      expect(fetchArgs).toContain('main:refs/remotes/origin/main');
+      expect(calls[0][2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets.git' });
+
+      // Diff call runs in the worktree
+      expect(calls[1][1]).toEqual(['diff', 'origin/main...HEAD']);
+      expect(calls[1][2]).toMatchObject({ cwd: '/tmp/repos/acme/widgets-worktrees/pr-42' });
+    });
+
+    it('rejects an invalid base_ref without shelling out', () => {
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          '-malicious',
+          true,
+        ),
+      ).toThrow(/Invalid base ref/);
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+    });
+
+    it('derives the default branch when base_ref is undefined', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref
+        .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        undefined,
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(2);
+      expect(calls[0][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+      expect(calls[1][1]).toEqual(['diff', 'origin/main...HEAD']);
+    });
+
+    it('derives via main fallback when base_ref is empty string', () => {
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('symbolic-ref fails');
+        })
+        .mockReturnValueOnce('') // main fetch succeeds
+        .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff against main
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        '',
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
+      const diffCall = vi.mocked(execFileSync).mock.calls.at(-1);
+      expect(diffCall?.[1]).toEqual(['diff', 'origin/main...HEAD']);
+    });
+
+    it('derives via master fallback when symbolic-ref and main both fail', () => {
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('symbolic-ref fails');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('main not found');
+        })
+        .mockReturnValueOnce('') // master fetch succeeds
+        .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff against master
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        null,
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
+      const diffCall = vi.mocked(execFileSync).mock.calls.at(-1);
+      expect(diffCall?.[1]).toEqual(['diff', 'origin/master...HEAD']);
+    });
+
+    it('propagates derive-base failure to the caller', () => {
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error('all refs fail');
+      });
+
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          undefined,
+          true,
+        ),
+      ).toThrow(/Cannot derive default branch/);
+    });
+
+    it('translates maxBuffer errors into DiffTooLargeError', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // fetch main
+        .mockImplementationOnce(() => {
+          throw new Error('stdout maxBuffer length exceeded');
+        });
+
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          'main',
+          true,
+          1024,
+        ),
+      ).toThrow(DiffTooLargeError);
+    });
+
+    it('rethrows non-maxBuffer git-diff errors unchanged', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // fetch main
+        .mockImplementationOnce(() => {
+          throw new Error('fatal: ambiguous argument');
+        });
+
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          'main',
+          true,
+        ),
+      ).toThrow(/fatal: ambiguous argument/);
+    });
+
+    it('omits credential helper when gh is not available', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('') // fetch main
+        .mockReturnValueOnce(''); // git diff
+
+      diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        'main',
+        false,
+      );
+
+      const fetchArgs = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+      expect(fetchArgs).not.toContain('-c');
     });
   });
 });

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -810,43 +810,6 @@ describe('repo-cache', () => {
       expect(masterFetchArgs).not.toContain('-c');
     });
 
-    it('falls back to develop when main and master both fail', () => {
-      vi.mocked(execFileSync)
-        .mockImplementationOnce(() => {
-          throw new Error('symbolic-ref failed');
-        })
-        .mockImplementationOnce(() => {
-          throw new Error('main not found');
-        })
-        .mockImplementationOnce(() => {
-          throw new Error('master not found');
-        })
-        .mockReturnValueOnce(''); // develop fetch succeeds
-
-      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', false);
-
-      expect(branch).toBe('develop');
-      const developFetchArgs = vi.mocked(execFileSync).mock.calls.at(-1)?.[1] as string[];
-      expect(developFetchArgs).toContain('develop:refs/remotes/origin/develop');
-    });
-
-    it('falls back to trunk when main, master, and develop all fail', () => {
-      const failingBranches = 3; // main, master, develop
-      vi.mocked(execFileSync).mockImplementationOnce(() => {
-        throw new Error('symbolic-ref failed');
-      });
-      for (let i = 0; i < failingBranches; i++) {
-        vi.mocked(execFileSync).mockImplementationOnce(() => {
-          throw new Error('branch not found');
-        });
-      }
-      vi.mocked(execFileSync).mockReturnValueOnce(''); // trunk fetch succeeds
-
-      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', false);
-
-      expect(branch).toBe('trunk');
-    });
-
     it('throws when symbolic-ref and all fallbacks fail', () => {
       vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error('failed');

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -981,5 +981,53 @@ describe('repo-cache', () => {
       const fetchArgs = vi.mocked(execFileSync).mock.calls[0][1] as string[];
       expect(fetchArgs).not.toContain('-c');
     });
+
+    it('falls back to derive-base when the provided base_ref cannot be fetched', () => {
+      // Simulates a stale base_ref after a force-push or branch rename: the
+      // targeted fetch fails, so the function derives the default branch and
+      // diffs against that instead of propagating the fetch error.
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error("fatal: couldn't find remote ref stale-branch");
+        }) // fetch base_ref=stale-branch — fails
+        .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref succeeds
+        .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff against main
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        'stale-branch',
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
+      const calls = vi.mocked(execFileSync).mock.calls;
+      expect(calls).toHaveLength(3);
+      // Fetch attempted against the stale ref
+      const staleFetchArgs = calls[0][1] as string[];
+      expect(staleFetchArgs).toContain('stale-branch:refs/remotes/origin/stale-branch');
+      // Then derive-base via symbolic-ref
+      expect(calls[1][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+      // Diff runs against the derived branch, not the stale one
+      expect(calls[2][1]).toEqual(['diff', 'origin/main...HEAD']);
+    });
+
+    it('propagates derive-base failure when both the stale base_ref and derivation fail', () => {
+      // If the targeted fetch fails AND derive-base also fails, the caller
+      // sees the derive-base error so the gh-fetch fallback in agent.ts can
+      // take over as the last resort.
+      vi.mocked(execFileSync).mockImplementation(() => {
+        throw new Error('every git call fails');
+      });
+
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          'stale-branch',
+          true,
+        ),
+      ).toThrow(/Cannot derive default branch/);
+    });
   });
 });

--- a/packages/cli/src/__tests__/repo-cache.test.ts
+++ b/packages/cli/src/__tests__/repo-cache.test.ts
@@ -724,23 +724,52 @@ describe('repo-cache', () => {
   });
 
   describe('deriveDefaultBranch', () => {
-    it('returns the branch parsed from symbolic-ref origin/HEAD', () => {
-      vi.mocked(execFileSync).mockReturnValueOnce('refs/remotes/origin/main\n');
+    it('returns the branch parsed from symbolic-ref AND refreshes it via fetch', () => {
+      // symbolic-ref gives us the branch name, but the bare clone is cached
+      // across runs so we MUST fetch to refresh `refs/remotes/origin/<branch>`
+      // before the caller diffs against it.
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref
+        .mockReturnValueOnce(''); // fetch main
 
       const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
 
       expect(branch).toBe('main');
       const calls = vi.mocked(execFileSync).mock.calls;
-      expect(calls).toHaveLength(1);
+      expect(calls).toHaveLength(2);
       expect(calls[0][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+      const fetchArgs = calls[1][1] as string[];
+      expect(fetchArgs).toContain('fetch');
+      expect(fetchArgs).toContain('main:refs/remotes/origin/main');
+      expect(fetchArgs).toContain('credential.helper=!gh auth git-credential');
     });
 
-    it('handles branches with slashes in their names', () => {
-      vi.mocked(execFileSync).mockReturnValueOnce('refs/remotes/origin/release/2026.04\n');
+    it('handles branches with slashes in their names and fetches them', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/release/2026.04\n')
+        .mockReturnValueOnce(''); // fetch release/2026.04
 
       const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
 
       expect(branch).toBe('release/2026.04');
+      const fetchArgs = vi.mocked(execFileSync).mock.calls[1][1] as string[];
+      expect(fetchArgs).toContain('release/2026.04:refs/remotes/origin/release/2026.04');
+    });
+
+    it('falls through to candidate probes when the symbolic-ref fetch fails', () => {
+      // If the symbolic-ref refresh fetch fails (e.g., branch deleted since
+      // HEAD was set at clone time), we continue to the candidate list so a
+      // working base is still resolved.
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/gone\n') // symbolic-ref
+        .mockImplementationOnce(() => {
+          throw new Error("fatal: couldn't find remote ref gone");
+        }) // fetch gone — fails
+        .mockReturnValueOnce(''); // fetch main succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
     });
 
     it('falls back to main when symbolic-ref fails', () => {
@@ -758,7 +787,6 @@ describe('repo-cache', () => {
       const fetchArgs = calls[1][1] as string[];
       expect(fetchArgs).toContain('fetch');
       expect(fetchArgs).toContain('main:refs/remotes/origin/main');
-      // Credential helper is included when gh is available
       expect(fetchArgs).toContain('credential.helper=!gh auth git-credential');
     });
 
@@ -779,11 +807,47 @@ describe('repo-cache', () => {
       expect(calls).toHaveLength(3);
       const masterFetchArgs = calls[2][1] as string[];
       expect(masterFetchArgs).toContain('master:refs/remotes/origin/master');
-      // No credential helper when gh is not available
       expect(masterFetchArgs).not.toContain('-c');
     });
 
-    it('throws when symbolic-ref, main, and master all fail', () => {
+    it('falls back to develop when main and master both fail', () => {
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('symbolic-ref failed');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('main not found');
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('master not found');
+        })
+        .mockReturnValueOnce(''); // develop fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', false);
+
+      expect(branch).toBe('develop');
+      const developFetchArgs = vi.mocked(execFileSync).mock.calls.at(-1)?.[1] as string[];
+      expect(developFetchArgs).toContain('develop:refs/remotes/origin/develop');
+    });
+
+    it('falls back to trunk when main, master, and develop all fail', () => {
+      const failingBranches = 3; // main, master, develop
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
+        throw new Error('symbolic-ref failed');
+      });
+      for (let i = 0; i < failingBranches; i++) {
+        vi.mocked(execFileSync).mockImplementationOnce(() => {
+          throw new Error('branch not found');
+        });
+      }
+      vi.mocked(execFileSync).mockReturnValueOnce(''); // trunk fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', false);
+
+      expect(branch).toBe('trunk');
+    });
+
+    it('throws when symbolic-ref and all fallbacks fail', () => {
       vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error('failed');
       });
@@ -805,7 +869,17 @@ describe('repo-cache', () => {
 
     it('rejects a branch name that fails the allowlist and falls back', () => {
       vi.mocked(execFileSync)
-        .mockReturnValueOnce('refs/remotes/origin/-malicious\n') // rejected by allowlist
+        .mockReturnValueOnce('refs/remotes/origin/-malicious\n') // rejected: leading dash
+        .mockReturnValueOnce(''); // main fetch succeeds
+
+      const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
+
+      expect(branch).toBe('main');
+    });
+
+    it('rejects a branch name containing `..` and falls back', () => {
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('refs/remotes/origin/re..lease\n') // rejected: contains ..
         .mockReturnValueOnce(''); // main fetch succeeds
 
       const branch = deriveDefaultBranch('/tmp/repos/acme/widgets.git', true);
@@ -857,6 +931,7 @@ describe('repo-cache', () => {
     it('derives the default branch when base_ref is undefined', () => {
       vi.mocked(execFileSync)
         .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref
+        .mockReturnValueOnce('') // fetch main (refresh stale cache)
         .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff
 
       const diff = diffFromWorktree(
@@ -868,9 +943,11 @@ describe('repo-cache', () => {
 
       expect(diff).toContain('diff --git');
       const calls = vi.mocked(execFileSync).mock.calls;
-      expect(calls).toHaveLength(2);
+      expect(calls).toHaveLength(3);
       expect(calls[0][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
-      expect(calls[1][1]).toEqual(['diff', 'origin/main...HEAD']);
+      const fetchArgs = calls[1][1] as string[];
+      expect(fetchArgs).toContain('main:refs/remotes/origin/main');
+      expect(calls[2][1]).toEqual(['diff', 'origin/main...HEAD']);
     });
 
     it('derives via main fallback when base_ref is empty string', () => {
@@ -982,15 +1059,19 @@ describe('repo-cache', () => {
       expect(fetchArgs).not.toContain('-c');
     });
 
-    it('falls back to derive-base when the provided base_ref cannot be fetched', () => {
+    it('falls back to derive-base when the provided base_ref no longer exists on origin', () => {
       // Simulates a stale base_ref after a force-push or branch rename: the
-      // targeted fetch fails, so the function derives the default branch and
-      // diffs against that instead of propagating the fetch error.
+      // targeted fetch surfaces "couldn't find remote ref", which is the
+      // signal that the branch is genuinely gone. In that (and only that)
+      // case we derive the default branch and diff against it.
       vi.mocked(execFileSync)
         .mockImplementationOnce(() => {
-          throw new Error("fatal: couldn't find remote ref stale-branch");
-        }) // fetch base_ref=stale-branch — fails
-        .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref succeeds
+          throw new Error(
+            "fatal: couldn't find remote ref stale-branch\nerror: some refs could not be fetched",
+          );
+        }) // fetch base_ref=stale-branch — missing on origin
+        .mockReturnValueOnce('refs/remotes/origin/main\n') // symbolic-ref
+        .mockReturnValueOnce('') // refresh fetch of main
         .mockReturnValueOnce('diff --git a/a b/a\n'); // git diff against main
 
       const diff = diffFromWorktree(
@@ -1002,20 +1083,62 @@ describe('repo-cache', () => {
 
       expect(diff).toContain('diff --git');
       const calls = vi.mocked(execFileSync).mock.calls;
-      expect(calls).toHaveLength(3);
-      // Fetch attempted against the stale ref
-      const staleFetchArgs = calls[0][1] as string[];
-      expect(staleFetchArgs).toContain('stale-branch:refs/remotes/origin/stale-branch');
-      // Then derive-base via symbolic-ref
+      expect(calls).toHaveLength(4);
+      expect(calls[0][1] as string[]).toContain('stale-branch:refs/remotes/origin/stale-branch');
       expect(calls[1][1]).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
-      // Diff runs against the derived branch, not the stale one
-      expect(calls[2][1]).toEqual(['diff', 'origin/main...HEAD']);
+      expect(calls[2][1] as string[]).toContain('main:refs/remotes/origin/main');
+      expect(calls[3][1]).toEqual(['diff', 'origin/main...HEAD']);
+    });
+
+    it('rethrows transient fetch errors instead of silently diffing against the default branch', () => {
+      // Network/auth/timeout errors MUST NOT be treated as "branch missing".
+      // If we silently derived the default branch here, a PR against
+      // `develop` would get reviewed as if it were against `main` — the
+      // review would be about a completely different patch.
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
+        throw new Error('fatal: unable to access https://github.com/: Could not resolve host');
+      });
+
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          'develop',
+          true,
+        ),
+      ).toThrow(/Could not resolve host/);
+
+      // Only the initial fetch call ran — no derive-base probes.
+      expect(vi.mocked(execFileSync).mock.calls).toHaveLength(1);
+    });
+
+    it('also recognizes alternative remote-ref-missing error phrasings', () => {
+      // Git wording varies; `no such ref` is another common form.
+      vi.mocked(execFileSync)
+        .mockImplementationOnce(() => {
+          throw new Error('fatal: no such ref: refs/heads/gone');
+        })
+        .mockReturnValueOnce('refs/remotes/origin/main\n')
+        .mockReturnValueOnce('') // refresh fetch
+        .mockReturnValueOnce('diff --git a/a b/a\n');
+
+      const diff = diffFromWorktree(
+        '/tmp/repos/acme/widgets.git',
+        '/tmp/repos/acme/widgets-worktrees/pr-42',
+        'gone',
+        true,
+      );
+
+      expect(diff).toContain('diff --git');
     });
 
     it('propagates derive-base failure when both the stale base_ref and derivation fail', () => {
-      // If the targeted fetch fails AND derive-base also fails, the caller
-      // sees the derive-base error so the gh-fetch fallback in agent.ts can
-      // take over as the last resort.
+      // If the targeted fetch fails with "remote ref missing" AND derive-base
+      // also fails, the caller sees the derive-base error so agent.ts rejects
+      // the task loudly.
+      vi.mocked(execFileSync).mockImplementationOnce(() => {
+        throw new Error("fatal: couldn't find remote ref stale-branch");
+      });
       vi.mocked(execFileSync).mockImplementation(() => {
         throw new Error('every git call fails');
       });
@@ -1028,6 +1151,18 @@ describe('repo-cache', () => {
           true,
         ),
       ).toThrow(/Cannot derive default branch/);
+    });
+
+    it('rejects a base_ref containing `..` without shelling out', () => {
+      expect(() =>
+        diffFromWorktree(
+          '/tmp/repos/acme/widgets.git',
+          '/tmp/repos/acme/widgets-worktrees/pr-42',
+          're..lease',
+          true,
+        ),
+      ).toThrow(/Invalid base ref/);
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -768,8 +768,16 @@ async function handleTask(
     }
 
     // Prefer local git diff when a worktree is available — handles PRs of
-    // any size and works for private repos without a platform token.
-    if (taskCheckoutPath && taskBareRepoPath && base_ref) {
+    // any size and works for private repos without a platform token. When
+    // `base_ref` is missing we let `diffFromWorktree` derive the default
+    // branch locally (origin/HEAD → main → master) rather than silently
+    // bailing out to the size-capped gh-fetch path.
+    if (taskCheckoutPath && taskBareRepoPath) {
+      if (!base_ref) {
+        logWarn(
+          `  Warning: task ${task_id} has no base_ref — deriving default branch from worktree`,
+        );
+      }
       try {
         // Hoist `gh auth status` outside the repo lock — it's independent of
         // the repo and does a synchronous subprocess call (up to 10s timeout).

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -767,11 +767,15 @@ async function handleTask(
       taskReviewDeps = { ...reviewDeps, codebaseDir: null };
     }
 
-    // Prefer local git diff when a worktree is available — handles PRs of
-    // any size and works for private repos without a platform token. When
-    // `base_ref` is missing we let `diffFromWorktree` derive the default
-    // branch locally (origin/HEAD → main → master) rather than silently
-    // bailing out to the size-capped gh-fetch path.
+    // With a worktree available, `git diff` is the ONLY diff path — no
+    // silent fallback to gh/HTTP. The worktree already cost us a clone and
+    // a fetch; letting a git failure degrade to the 300-file gh diff just
+    // hides problems (and has: see #775 / ParadiseEngine#38). If git diff
+    // fails here, the task errors out loudly so the server can re-dispatch.
+    //
+    // The gh-fetch fallback below is reached only when worktree checkout
+    // itself failed earlier (the catch at line 742 leaves both task paths
+    // null), i.e. agents that couldn't set up a worktree at all.
     if (taskCheckoutPath && taskBareRepoPath) {
       if (!base_ref) {
         logWarn(
@@ -801,25 +805,20 @@ async function handleTask(
         diffContent = gitDiff;
         log(`  Diff generated via git (${Math.round(diffContent.length / 1024)}KB)`);
       } catch (err) {
+        const message = (err as Error).message;
         if (err instanceof DiffTooLargeError) {
-          logError(`  ${(err as Error).message}`);
-          await safeReject(
-            client,
-            task_id,
-            agentId,
-            `Cannot access diff: ${(err as Error).message}`,
-            logger,
-          );
-          return { diffFetchFailed: true };
+          logError(`  ${message}`);
+        } else {
+          logError(`  git diff failed for task ${task_id}: ${message}`);
         }
-        logWarn(
-          `  Warning: git diff failed (${(err as Error).message}) — falling back to API fetch`,
-        );
+        await safeReject(client, task_id, agentId, `Cannot access diff: ${message}`, logger);
+        return { diffFetchFailed: true };
       }
-    }
-
-    // Fallback: fetch via gh CLI / HTTP API.
-    if (!diffContent) {
+    } else {
+      // Worktree unavailable — fall back to gh CLI / HTTP API. This is the
+      // ONLY reachable gh-fetch path now; it is entered solely when the
+      // earlier `checkoutWorktree` attempt threw (taskCheckoutPath and
+      // taskBareRepoPath both null).
       try {
         const result = await fetchDiff(diff_url, owner, repo, pr_number, {
           githubToken: client.currentToken,

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -393,10 +393,66 @@ function gitExec(
   }
 }
 
+/** Fallback default-branch names, tried in order when symbolic-ref fails. */
+const DEFAULT_BRANCH_FALLBACKS = ['main', 'master'];
+
+/**
+ * Derive the repo's default branch name. Tries, in order:
+ *   1. `git symbolic-ref refs/remotes/origin/HEAD` → strip `refs/remotes/origin/` prefix.
+ *   2. Fetch `main` from origin (if it exists).
+ *   3. Fetch `master` from origin (if it exists).
+ *
+ * The returned branch is guaranteed to be fetched into `refs/remotes/origin/<branch>`
+ * so the caller can immediately `git diff origin/<branch>...HEAD`.
+ *
+ * Throws if none of the candidates can be resolved.
+ */
+export function deriveDefaultBranch(bareRepoPath: string, ghAvailable: boolean): string {
+  const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
+
+  try {
+    const out = gitExec('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], bareRepoPath).trim();
+    const prefix = 'refs/remotes/origin/';
+    if (out.startsWith(prefix)) {
+      const branch = out.slice(prefix.length);
+      if (branch && /^[A-Za-z0-9_./-]+$/.test(branch) && !branch.startsWith('-')) {
+        return branch;
+      }
+    }
+  } catch {
+    // Fall through to candidate-branch probing.
+  }
+
+  for (const candidate of DEFAULT_BRANCH_FALLBACKS) {
+    try {
+      gitExec(
+        'git',
+        [
+          ...credArgs,
+          'fetch',
+          '--force',
+          'origin',
+          `${candidate}:refs/remotes/origin/${candidate}`,
+        ],
+        bareRepoPath,
+      );
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  throw new Error('Cannot derive default branch: origin/HEAD, main, and master all failed');
+}
+
 /**
  * Generate a unified diff for a PR from a local worktree. Fetches the base
  * branch into the bare clone (idempotent) and runs
  * `git diff origin/<baseRef>...HEAD` inside the worktree.
+ *
+ * When `baseRef` is omitted or empty, the repo's default branch is derived
+ * via `deriveDefaultBranch` (origin/HEAD → main → master) so the caller does
+ * not need to know the target branch up-front.
  *
  * Unlike GitHub's REST diff endpoint (which caps at 300 files), the local
  * git diff has no such limit, so this is how we handle large PRs.
@@ -406,24 +462,34 @@ function gitExec(
 export function diffFromWorktree(
   bareRepoPath: string,
   worktreePath: string,
-  baseRef: string,
+  baseRef: string | null | undefined,
   ghAvailable: boolean,
   maxDiffBytes = 128 * 1024 * 1024, // 128 MB
 ): string {
-  // Defensive allowlist for ref names. We pass baseRef as a separate argv to
-  // execFileSync so there's no shell expansion, but a ref with whitespace,
-  // newlines, or leading `-` could still confuse `git` itself.
-  if (!/^[A-Za-z0-9_./-]+$/.test(baseRef) || baseRef.startsWith('-')) {
-    throw new Error(`Invalid base ref: ${baseRef}`);
-  }
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
-  gitExec(
-    'git',
-    [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
-    bareRepoPath,
-  );
+
+  let resolvedBaseRef: string;
+  if (baseRef) {
+    // Defensive allowlist for ref names. We pass baseRef as a separate argv to
+    // execFileSync so there's no shell expansion, but a ref with whitespace,
+    // newlines, or leading `-` could still confuse `git` itself.
+    if (!/^[A-Za-z0-9_./-]+$/.test(baseRef) || baseRef.startsWith('-')) {
+      throw new Error(`Invalid base ref: ${baseRef}`);
+    }
+    gitExec(
+      'git',
+      [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
+      bareRepoPath,
+    );
+    resolvedBaseRef = baseRef;
+  } else {
+    // No caller-provided base ref — derive locally. deriveDefaultBranch also
+    // ensures the resolved ref is fetched into refs/remotes/origin/<branch>.
+    resolvedBaseRef = deriveDefaultBranch(bareRepoPath, ghAvailable);
+  }
+
   try {
-    return gitExec('git', ['diff', `origin/${baseRef}...HEAD`], worktreePath, {
+    return gitExec('git', ['diff', `origin/${resolvedBaseRef}...HEAD`], worktreePath, {
       maxBuffer: maxDiffBytes,
     });
   } catch (err) {

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -394,7 +394,7 @@ function gitExec(
 }
 
 /** Fallback default-branch names, tried in order when symbolic-ref fails. */
-const DEFAULT_BRANCH_FALLBACKS = ['main', 'master', 'develop', 'trunk'];
+const DEFAULT_BRANCH_FALLBACKS = ['main', 'master'];
 
 /**
  * Validate a git branch name against a defensive allowlist.
@@ -445,8 +445,6 @@ function isRemoteRefMissingError(err: unknown): boolean {
  *      then fetch that branch to refresh `refs/remotes/origin/<branch>`.
  *   2. Fetch `main` from origin (if it exists).
  *   3. Fetch `master` from origin (if it exists).
- *   4. Fetch `develop` from origin (if it exists).
- *   5. Fetch `trunk` from origin (if it exists).
  *
  * The returned branch is guaranteed to be fetched into `refs/remotes/origin/<branch>`
  * during this call so the caller can immediately `git diff origin/<branch>...HEAD`
@@ -488,9 +486,7 @@ export function deriveDefaultBranch(bareRepoPath: string, ghAvailable: boolean):
     }
   }
 
-  throw new Error(
-    `Cannot derive default branch: origin/HEAD and fallbacks (${DEFAULT_BRANCH_FALLBACKS.join(', ')}) all failed`,
-  );
+  throw new Error('Cannot derive default branch: origin/HEAD, main, and master all failed');
 }
 
 /**

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -452,7 +452,10 @@ export function deriveDefaultBranch(bareRepoPath: string, ghAvailable: boolean):
  *
  * When `baseRef` is omitted or empty, the repo's default branch is derived
  * via `deriveDefaultBranch` (origin/HEAD → main → master) so the caller does
- * not need to know the target branch up-front.
+ * not need to know the target branch up-front. If a non-empty `baseRef` is
+ * provided but cannot be fetched (stale after a force-push, renamed branch,
+ * etc.), derivation is also used as a fallback so we don't throw over a
+ * server-side ref that happens to no longer exist on origin.
  *
  * Unlike GitHub's REST diff endpoint (which caps at 300 files), the local
  * git diff has no such limit, so this is how we handle large PRs.
@@ -468,7 +471,7 @@ export function diffFromWorktree(
 ): string {
   const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
 
-  let resolvedBaseRef: string;
+  let resolvedBaseRef: string | undefined;
   if (baseRef) {
     // Defensive allowlist for ref names. We pass baseRef as a separate argv to
     // execFileSync so there's no shell expansion, but a ref with whitespace,
@@ -476,15 +479,25 @@ export function diffFromWorktree(
     if (!/^[A-Za-z0-9_./-]+$/.test(baseRef) || baseRef.startsWith('-')) {
       throw new Error(`Invalid base ref: ${baseRef}`);
     }
-    gitExec(
-      'git',
-      [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
-      bareRepoPath,
-    );
-    resolvedBaseRef = baseRef;
-  } else {
-    // No caller-provided base ref — derive locally. deriveDefaultBranch also
-    // ensures the resolved ref is fetched into refs/remotes/origin/<branch>.
+    try {
+      gitExec(
+        'git',
+        [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
+        bareRepoPath,
+      );
+      resolvedBaseRef = baseRef;
+    } catch {
+      // Fetch failed (e.g., stale ref after a force-push or branch rename).
+      // Fall through to deriveDefaultBranch below so we still get a local
+      // diff instead of throwing to the gh-fetch fallback.
+      resolvedBaseRef = undefined;
+    }
+  }
+
+  if (!resolvedBaseRef) {
+    // No usable caller-provided base ref — derive locally.
+    // deriveDefaultBranch also ensures the resolved ref is fetched into
+    // refs/remotes/origin/<branch>.
     resolvedBaseRef = deriveDefaultBranch(bareRepoPath, ghAvailable);
   }
 

--- a/packages/cli/src/repo-cache.ts
+++ b/packages/cli/src/repo-cache.ts
@@ -394,55 +394,103 @@ function gitExec(
 }
 
 /** Fallback default-branch names, tried in order when symbolic-ref fails. */
-const DEFAULT_BRANCH_FALLBACKS = ['main', 'master'];
+const DEFAULT_BRANCH_FALLBACKS = ['main', 'master', 'develop', 'trunk'];
+
+/**
+ * Validate a git branch name against a defensive allowlist.
+ * Git itself rejects refs containing `..`, whitespace, control chars, and
+ * leading `-`, but our argv-based invocation doesn't re-check; a narrow
+ * allowlist keeps unusual inputs from reaching `git diff`.
+ */
+function isValidBranchName(name: string): boolean {
+  if (!name) return false;
+  if (name.startsWith('-')) return false;
+  if (name.includes('..')) return false;
+  return /^[A-Za-z0-9_./-]+$/.test(name);
+}
+
+/**
+ * Fetch a branch into `refs/remotes/origin/<branch>`. Silently succeeds if the
+ * branch already exists locally and the network is down — any fetch error is
+ * swallowed by the caller if that's the right policy for its path.
+ */
+function fetchBranch(bareRepoPath: string, branch: string, ghAvailable: boolean): void {
+  const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
+  gitExec(
+    'git',
+    [...credArgs, 'fetch', '--force', 'origin', `${branch}:refs/remotes/origin/${branch}`],
+    bareRepoPath,
+  );
+}
+
+/**
+ * Recognize error messages that indicate the remote ref doesn't exist on
+ * origin (as opposed to transient network/auth/timeout failures). Git's
+ * wording differs slightly by version, so we match the stable substrings.
+ */
+function isRemoteRefMissingError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /couldn't find remote ref/i.test(msg) ||
+    /couldnt find remote ref/i.test(msg) ||
+    /no such ref/i.test(msg) ||
+    /remote ref.*not found/i.test(msg) ||
+    /unknown revision or path not in the working tree/i.test(msg)
+  );
+}
 
 /**
  * Derive the repo's default branch name. Tries, in order:
- *   1. `git symbolic-ref refs/remotes/origin/HEAD` → strip `refs/remotes/origin/` prefix.
+ *   1. `git symbolic-ref refs/remotes/origin/HEAD` → strip `refs/remotes/origin/` prefix,
+ *      then fetch that branch to refresh `refs/remotes/origin/<branch>`.
  *   2. Fetch `main` from origin (if it exists).
  *   3. Fetch `master` from origin (if it exists).
+ *   4. Fetch `develop` from origin (if it exists).
+ *   5. Fetch `trunk` from origin (if it exists).
  *
  * The returned branch is guaranteed to be fetched into `refs/remotes/origin/<branch>`
- * so the caller can immediately `git diff origin/<branch>...HEAD`.
+ * during this call so the caller can immediately `git diff origin/<branch>...HEAD`
+ * against fresh tip contents. The bare clone is persistent across runs, so
+ * skipping the fetch (as an earlier version did) produced diffs against stale
+ * base branches.
  *
  * Throws if none of the candidates can be resolved.
  */
 export function deriveDefaultBranch(bareRepoPath: string, ghAvailable: boolean): string {
-  const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
-
   try {
     const out = gitExec('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], bareRepoPath).trim();
     const prefix = 'refs/remotes/origin/';
     if (out.startsWith(prefix)) {
       const branch = out.slice(prefix.length);
-      if (branch && /^[A-Za-z0-9_./-]+$/.test(branch) && !branch.startsWith('-')) {
-        return branch;
+      if (isValidBranchName(branch)) {
+        // Refresh the cached ref so the diff runs against the current tip,
+        // not whatever was there at clone time. If the fetch fails (network
+        // blip, repo went private), fall through to the candidate probes —
+        // they will surface the underlying problem.
+        try {
+          fetchBranch(bareRepoPath, branch, ghAvailable);
+          return branch;
+        } catch {
+          // Fall through.
+        }
       }
     }
   } catch {
-    // Fall through to candidate-branch probing.
+    // symbolic-ref not set, or other git error — fall through to probes.
   }
 
   for (const candidate of DEFAULT_BRANCH_FALLBACKS) {
     try {
-      gitExec(
-        'git',
-        [
-          ...credArgs,
-          'fetch',
-          '--force',
-          'origin',
-          `${candidate}:refs/remotes/origin/${candidate}`,
-        ],
-        bareRepoPath,
-      );
+      fetchBranch(bareRepoPath, candidate, ghAvailable);
       return candidate;
     } catch {
       // Try the next candidate.
     }
   }
 
-  throw new Error('Cannot derive default branch: origin/HEAD, main, and master all failed');
+  throw new Error(
+    `Cannot derive default branch: origin/HEAD and fallbacks (${DEFAULT_BRANCH_FALLBACKS.join(', ')}) all failed`,
+  );
 }
 
 /**
@@ -469,27 +517,27 @@ export function diffFromWorktree(
   ghAvailable: boolean,
   maxDiffBytes = 128 * 1024 * 1024, // 128 MB
 ): string {
-  const credArgs = ghAvailable ? ['-c', `credential.helper=${GH_CREDENTIAL_HELPER}`] : [];
-
   let resolvedBaseRef: string | undefined;
   if (baseRef) {
     // Defensive allowlist for ref names. We pass baseRef as a separate argv to
     // execFileSync so there's no shell expansion, but a ref with whitespace,
-    // newlines, or leading `-` could still confuse `git` itself.
-    if (!/^[A-Za-z0-9_./-]+$/.test(baseRef) || baseRef.startsWith('-')) {
+    // newlines, leading `-`, or `..` could still confuse `git` itself.
+    if (!isValidBranchName(baseRef)) {
       throw new Error(`Invalid base ref: ${baseRef}`);
     }
     try {
-      gitExec(
-        'git',
-        [...credArgs, 'fetch', '--force', 'origin', `${baseRef}:refs/remotes/origin/${baseRef}`],
-        bareRepoPath,
-      );
+      fetchBranch(bareRepoPath, baseRef, ghAvailable);
       resolvedBaseRef = baseRef;
-    } catch {
-      // Fetch failed (e.g., stale ref after a force-push or branch rename).
-      // Fall through to deriveDefaultBranch below so we still get a local
-      // diff instead of throwing to the gh-fetch fallback.
+    } catch (err) {
+      // Only fall through when the error proves the remote ref no longer
+      // exists (force-push, branch rename). Transient failures — network
+      // blip, auth, timeout, rate limit — MUST surface as errors, because
+      // silently diffing against the default branch would produce a review
+      // of the wrong patch (e.g., a PR targeting `develop` reviewed against
+      // `main`). See PR #780 review.
+      if (!isRemoteRefMissingError(err)) {
+        throw err;
+      }
       resolvedBaseRef = undefined;
     }
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -87,6 +87,11 @@ export interface ReviewTask {
   pr_number: number;
   pr_url: string;
   diff_url: string;
+  /**
+   * PR base branch. The server may emit an empty string when it could not
+   * determine a base ref; the CLI interprets `''` as "derive the default
+   * branch locally" rather than treating it as a hard failure. See PR #780.
+   */
   base_ref: string;
   head_ref: string;
   prompt: string;


### PR DESCRIPTION
Part of #775

## Summary

**Worktree implies git-diff — no silent gh fallback.** When a local worktree is available (which it always is after a successful checkout), `git diff` is now the _only_ diff path. Any failure rejects the task loudly so the server can re-dispatch, rather than silently degrading to `gh pr diff` (capped at 300 files). This fixes the ParadiseEngine#38 symptom that motivated #775.

- **agent.ts:751** — falsy-guard relaxed to `taskCheckoutPath && taskBareRepoPath`; missing `base_ref` now emits a `logWarn` matching the other skip paths in the block.
- **agent.ts:793** — the old `git failed → gh fallback` branch is gone. Git-diff failure now calls `safeReject` with the propagated error, same as `DiffTooLargeError`. The gh-fetch path below is reachable only when `checkoutWorktree` itself threw earlier (task paths both null).
- **repo-cache.ts — `deriveDefaultBranch`** — new exported helper: `git symbolic-ref refs/remotes/origin/HEAD` → `main` → `master`. Rejects outputs that fail the ref allowlist.
- **repo-cache.ts — `diffFromWorktree`** — accepts `baseRef: string | null | undefined`. Empty → derive. A provided-but-stale `baseRef` (force-push, branch rename) catches the fetch failure and falls through to derivation; if derivation also fails, the error propagates.

## Files changed

- `packages/cli/src/commands/agent.ts` — worktree-implies-git-diff invariant + base_ref logWarn
- `packages/cli/src/repo-cache.ts` — new `deriveDefaultBranch`, `diffFromWorktree` accepts optional/stale base_ref with derive fallback
- `packages/cli/src/__tests__/repo-cache.test.ts` — 19 new test cases covering derive-base (symbolic-ref, main/master fallbacks, allowlist rejection, total failure) and diffFromWorktree (explicit/empty/undefined/null/stale base_ref, maxBuffer→DiffTooLargeError, gh-unavailable, stale→derive fallback, stale+derive fail propagation)
- `packages/cli/src/__tests__/agent-coverage.test.ts` — empty-base_ref warn + new "no gh fallback when git diff fails with a worktree" test
- `packages/cli/src/__tests__/{agent,batch-poll,e2e-agent,cli-server-integration,agent-coverage}.test.ts` — repo-cache mocks now include `diffFromWorktree` and `withRepoLock`; gh-path-dependent tests force `checkoutWorktree` to reject so the fallback branch is exercised
- `packages/cli/src/__tests__/helpers/fake-server.ts` — `injectTask` accepts an optional `baseRef` so tests hit the same `/test/events/pr` path production uses

## Test plan

- `pnpm build && pnpm lint && pnpm run format:check && pnpm run typecheck` all green.
- `pnpm test` 2947/2947 passing locally. (Note: the previously-flaky `cli-server-integration > E. tool crash` test now passes reliably as a side-effect of the repo-cache mock now exporting a working `diffFromWorktree`.)
- `repo-cache.ts` coverage: 100% statements / 100% functions / 100% lines / 97.18% branches. The uncovered branches are unrelated `err instanceof Error ? ... : String(err)` ternary fallbacks.

## Acceptance criteria (from #775)

- [x] Review task without `base_ref` uses the local git-diff path via derived base.
- [x] Each skip branch (falsy guard, worktree checkout fail) emits a `logWarn` with context.
- [x] gh-fetch path only reached when worktree checkout itself failed (stronger than the original spec, per team-lead direction).
- [x] Existing base_ref-present behaviour unchanged when the ref is fresh on origin.
- [x] Stale base_ref is tolerated — falls back to derive-base instead of failing the task.
- [x] Build / test / lint / format:check / typecheck all pass.
- [x] Coverage near 100% on the modified paths.