### PR TITLE
feat(cli): make summary input cap configurable via max_summary_input_kb

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -858,8 +858,8 @@ describe('Agent Coverage Tests', () => {
       const groupTasks = await server.store.getTasksByGroup(groupId);
       const workerTasks = groupTasks.filter((t) => t.task_type !== 'summary');
 
-      // Create review claims with huge text to exceed MAX_INPUT_SIZE_BYTES (200KB)
-      const hugeReview = 'x'.repeat(150 * 1024);
+      // Create review claims with huge text to exceed MAX_INPUT_SIZE_BYTES default (500KB)
+      const hugeReview = 'x'.repeat(300 * 1024);
       for (let i = 0; i < workerTasks.length; i++) {
         const wt = workerTasks[i];
         await server.store.updateTask(wt.id, { status: 'completed' });

--- a/packages/cli/src/__tests__/summary.test.ts
+++ b/packages/cli/src/__tests__/summary.test.ts
@@ -434,6 +434,37 @@ describe('executeSummary', () => {
     await expect(executeSummary(request, defaultDeps, vi.fn())).rejects.toThrow(InputTooLargeError);
   });
 
+  it('honors deps.maxSummaryInputKb override below the default', async () => {
+    // Payload ~100KB — fits under the 500KB default but exceeds the 50KB override.
+    const review = 'x'.repeat(100 * 1024);
+    const request: SummaryRequest = {
+      ...defaultRequest,
+      reviews: [{ agentId: 'a1', model: 'm', tool: 't', review, verdict: 'approve' }],
+    };
+    const tightDeps: ReviewExecutorDeps = { ...defaultDeps, maxSummaryInputKb: 50 };
+
+    await expect(executeSummary(request, tightDeps, vi.fn())).rejects.toThrow(InputTooLargeError);
+    // Same payload with the default deps should not hit the size gate — proves
+    // the override is what trips it, not the default.
+    const mockRunTool = createMockRunTool('Summary', 200, true);
+    await expect(executeSummary(request, defaultDeps, mockRunTool)).resolves.toBeDefined();
+  });
+
+  it('honors deps.maxSummaryInputKb override above the default', async () => {
+    // Payload ~600KB — exceeds the 500KB default but fits under the 1024KB override.
+    const review = 'x'.repeat(600 * 1024);
+    const request: SummaryRequest = {
+      ...defaultRequest,
+      reviews: [{ agentId: 'a1', model: 'm', tool: 't', review, verdict: 'approve' }],
+    };
+    const roomyDeps: ReviewExecutorDeps = { ...defaultDeps, maxSummaryInputKb: 1024 };
+    const mockRunTool = createMockRunTool('Summary', 200, true);
+
+    await expect(executeSummary(request, roomyDeps, mockRunTool)).resolves.toBeDefined();
+    // Same payload with the default deps should still hit the size gate.
+    await expect(executeSummary(request, defaultDeps, vi.fn())).rejects.toThrow(InputTooLargeError);
+  });
+
   it('rejects when not enough time remaining', async () => {
     const request: SummaryRequest = { ...defaultRequest, timeout: 0 };
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -2362,6 +2362,7 @@ export async function startAgentRouter(): Promise<void> {
   const reviewDeps: ReviewExecutorDeps = {
     commandTemplate: commandTemplate ?? '',
     maxDiffSizeKb: config.maxDiffSizeKb,
+    maxSummaryInputKb: config.maxSummaryInputKb,
     maxRepoSizeMb: config.maxRepoSizeMb,
     codebaseDir,
     livenessTimeoutMs:
@@ -2463,6 +2464,7 @@ function startAgentByIndex(
   const reviewDeps: ReviewExecutorDeps = {
     commandTemplate,
     maxDiffSizeKb: config.maxDiffSizeKb,
+    maxSummaryInputKb: config.maxSummaryInputKb,
     maxRepoSizeMb: config.maxRepoSizeMb,
     codebaseDir,
     livenessTimeoutMs:

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -33,6 +33,7 @@ export interface CliConfig {
   platformUrl: string;
   authFile: string | null;
   maxDiffSizeKb: number;
+  maxSummaryInputKb: number;
   maxConsecutiveErrors: number;
   maxRepoSizeMb: number;
   codebaseDir: string | null;
@@ -56,6 +57,7 @@ export function ensureConfigDir(): void {
 }
 
 export const DEFAULT_MAX_DIFF_SIZE_KB = 100;
+export const DEFAULT_MAX_SUMMARY_INPUT_KB = 500;
 export const DEFAULT_MAX_CONSECUTIVE_ERRORS = 10;
 export const DEFAULT_MAX_REPO_SIZE_MB = 100;
 export const DEFAULT_COMMAND_TEST_TIMEOUT_MS = 10_000;
@@ -279,6 +281,7 @@ function isValidHttpUrl(value: string): boolean {
 
 interface ValidatedOverrides {
   maxDiffSizeKb?: number;
+  maxSummaryInputKb?: number;
   maxConsecutiveErrors?: number;
   maxRepoSizeMb?: number;
 }
@@ -310,6 +313,13 @@ function validateConfigData(
       `\u26a0 Config warning: max_diff_size_kb must be > 0, got ${data.max_diff_size_kb}, using default (${DEFAULT_MAX_DIFF_SIZE_KB})`,
     );
     overrides.maxDiffSizeKb = DEFAULT_MAX_DIFF_SIZE_KB;
+  }
+
+  if (typeof data.max_summary_input_kb === 'number' && data.max_summary_input_kb <= 0) {
+    console.warn(
+      `⚠ Config warning: max_summary_input_kb must be > 0, got ${data.max_summary_input_kb}, using default (${DEFAULT_MAX_SUMMARY_INPUT_KB})`,
+    );
+    overrides.maxSummaryInputKb = DEFAULT_MAX_SUMMARY_INPUT_KB;
   }
 
   if (typeof data.max_consecutive_errors === 'number' && data.max_consecutive_errors <= 0) {
@@ -365,6 +375,7 @@ export function loadConfig(): CliConfig {
     platformUrl: envPlatformUrl || DEFAULT_PLATFORM_URL,
     authFile: null,
     maxDiffSizeKb: DEFAULT_MAX_DIFF_SIZE_KB,
+    maxSummaryInputKb: DEFAULT_MAX_SUMMARY_INPUT_KB,
     maxConsecutiveErrors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
     maxRepoSizeMb: DEFAULT_MAX_REPO_SIZE_MB,
     codebaseDir: null,
@@ -450,6 +461,11 @@ export function loadConfig(): CliConfig {
       (typeof data.max_diff_size_kb === 'number'
         ? data.max_diff_size_kb
         : DEFAULT_MAX_DIFF_SIZE_KB),
+    maxSummaryInputKb:
+      overrides.maxSummaryInputKb ??
+      (typeof data.max_summary_input_kb === 'number'
+        ? data.max_summary_input_kb
+        : DEFAULT_MAX_SUMMARY_INPUT_KB),
     maxConsecutiveErrors:
       overrides.maxConsecutiveErrors ??
       (typeof data.max_consecutive_errors === 'number'
@@ -509,6 +525,9 @@ export function saveConfig(config: CliConfig): void {
   }
   if (config.maxDiffSizeKb !== DEFAULT_MAX_DIFF_SIZE_KB) {
     data.max_diff_size_kb = config.maxDiffSizeKb;
+  }
+  if (config.maxSummaryInputKb !== DEFAULT_MAX_SUMMARY_INPUT_KB) {
+    data.max_summary_input_kb = config.maxSummaryInputKb;
   }
   if (config.maxConsecutiveErrors !== DEFAULT_MAX_CONSECUTIVE_ERRORS) {
     data.max_consecutive_errors = config.maxConsecutiveErrors;

--- a/packages/cli/src/review.ts
+++ b/packages/cli/src/review.ts
@@ -123,6 +123,8 @@ export function extractVerdict(text: string): { verdict: ReviewVerdict; review: 
 export interface ReviewExecutorDeps {
   commandTemplate: string;
   maxDiffSizeKb: number;
+  /** Summary input cap in KB — applied by executeSummary. Falls back to DEFAULT_MAX_INPUT_SIZE_BYTES when undefined. */
+  maxSummaryInputKb?: number;
   maxRepoSizeMb?: number;
   codebaseDir?: string | null;
   livenessTimeoutMs?: number;

--- a/packages/cli/src/summary.ts
+++ b/packages/cli/src/summary.ts
@@ -51,7 +51,11 @@ export interface SummaryResponse {
 }
 
 export const TIMEOUT_SAFETY_MARGIN_MS = 30_000;
-export const MAX_INPUT_SIZE_BYTES = 200 * 1024;
+/**
+ * Default max combined summary input (prompt + diff + reviews + context) in bytes.
+ * Overridable per agent via `deps.maxSummaryInputKb` (from `max_summary_input_kb` in config.toml).
+ */
+export const MAX_INPUT_SIZE_BYTES = 500 * 1024;
 
 export class InputTooLargeError extends Error {
   constructor(message: string) {
@@ -134,9 +138,11 @@ export async function executeSummary(
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<SummaryResponse> {
   const inputSize = calculateInputSize(req.prompt, req.reviews, req.diffContent, req.contextBlock);
-  if (inputSize > MAX_INPUT_SIZE_BYTES) {
+  const maxInputBytes =
+    deps.maxSummaryInputKb !== undefined ? deps.maxSummaryInputKb * 1024 : MAX_INPUT_SIZE_BYTES;
+  if (inputSize > maxInputBytes) {
     throw new InputTooLargeError(
-      `Summary input too large (${Math.round(inputSize / 1024)}KB > ${Math.round(MAX_INPUT_SIZE_BYTES / 1024)}KB limit)`,
+      `Summary input too large (${Math.round(inputSize / 1024)}KB > ${Math.round(maxInputBytes / 1024)}KB limit)`,
     );
   }
 


### PR DESCRIPTION
## Summary

The synthesizer was rejecting summary tasks whose combined input (prompt + diff + reviews + context) exceeded a hard-coded **200 KB** cap (`MAX_INPUT_SIZE_BYTES = 200 * 1024` at \`packages/cli/src/summary.ts:54\`). Live failure observed: \`Summary input too large (208KB > 200KB limit)\` on a 145 KB diff with three ~50k-token reviews.

Two changes:

1. **New config field** \`max_summary_input_kb\` in \`config.toml\`, mirroring the existing \`max_diff_size_kb\` pattern (top-level, integer KB, positive). Threaded through \`ReviewExecutorDeps.maxSummaryInputKb\` → \`executeSummary\`.

2. **Default raised** from 200 KB → 500 KB. Still well under any modern tool's context window (~200k tokens ≈ 800 KB chars), but enough headroom for typical multi-agent review packages. Empty/absent config field uses the default.

## Test plan

- [x] \`pnpm build\` — clean
- [x] \`pnpm test\` — **2998 / 2998 pass**
- [x] \`pnpm lint\`, \`pnpm run format:check\`, \`pnpm run typecheck\` — clean

New unit tests:
- \`packages/cli/src/__tests__/summary.test.ts\`:
  - \`honors deps.maxSummaryInputKb override below the default\` — 100 KB payload: tight \`maxSummaryInputKb: 50\` trips the gate; default deps let it through.
  - \`honors deps.maxSummaryInputKb override above the default\` — 600 KB payload: roomy \`maxSummaryInputKb: 1024\` passes; default deps trip.
- \`packages/cli/src/__tests__/agent-coverage.test.ts\`: bumped the huge-review payload from 150 KB to 300 KB so the "Summary input too large" path still fires against the new 500 KB default.

## Notes

- Back-compat: omitting \`max_summary_input_kb\` uses the new 500 KB default. Existing configs keep working.
- No server or shared-types changes. Pure CLI.