### PR TITLE
[server-dev] Strictly forbid duplicate-model reviews within a task group

### DIFF
--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -3239,7 +3239,7 @@ describe('Task Routes', () => {
       expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(1);
     });
 
-    it('still hides task after grace period expires (strict — grace no longer opens gate)', async () => {
+    it('grace period config is now no-op for workers — same model stays hidden past the old window', async () => {
       const config = makeDiversityConfig(30_000);
       // Task 1: claimed with gpt-5.4 well past the grace window
       await store.createTask(
@@ -3285,7 +3285,7 @@ describe('Task Routes', () => {
       expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(0);
     });
 
-    it('strict diversity applies even when modelDiversityGraceMs is 0 (field no longer disables)', async () => {
+    it('modelDiversityGraceMs=0 is now a no-op — strict diversity still hides duplicate model', async () => {
       const config = makeDiversityConfig(0);
       // Task 1: claimed with gpt-5.4
       await store.createTask(
@@ -3732,7 +3732,7 @@ describe('Task Routes', () => {
       expect(body.claimed).toBe(true);
     });
 
-    it('claim: same-model rejected even past legacy modelDiversityGraceMs window', async () => {
+    it('claim: grace period config is a no-op — same-model rejected past legacy window', async () => {
       const config = makeDiversityConfig(50); // tiny grace — must not open the gate
       await store.createTask(
         makeTask({

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -3777,6 +3777,91 @@ describe('Task Routes', () => {
       const body = await res.json();
       expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
+
+    it('claim: concurrent same-model claims on sibling tasks — exactly one survives (TOCTOU)', async () => {
+      const config = makeDiversityConfig();
+      // Two pending review tasks in the same group.
+      await store.createTask(
+        makeTask({
+          id: 'task-A',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-race',
+          status: 'pending',
+          config,
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'task-B',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-race',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      // Fire both claims concurrently with the same model on different sibling
+      // tasks — this is the race that the pre-check alone cannot close.
+      const [resA, resB] = await Promise.all([
+        request('POST', '/api/tasks/task-A/claim', {
+          agent_id: 'agent-A',
+          role: 'review',
+          model: 'claude-opus-4-7',
+          tool: 'claude',
+        }),
+        request('POST', '/api/tasks/task-B/claim', {
+          agent_id: 'agent-B',
+          role: 'review',
+          model: 'claude-opus-4-7',
+          tool: 'claude',
+        }),
+      ]);
+
+      // Exactly one winner, one loser. The tiebreaker is deterministic
+      // (smallest claim id wins), so the outcome is stable regardless of
+      // scheduling.
+      const statuses = [resA.status, resB.status].sort();
+      expect(statuses).toEqual([200, 409]);
+
+      const loser = resA.status === 409 ? resA : resB;
+      const loserBody = await loser.json();
+      expect(loserBody.error.code).toBe('CLAIM_CONFLICT');
+      expect(loserBody.error.message).toMatch(/claude-opus-4-7/);
+
+      // Exactly one non-terminal worker claim for this model in the group.
+      const allClaims = [
+        ...(await store.getClaims('task-A')),
+        ...(await store.getClaims('task-B')),
+      ];
+      const nonTerminalOpusClaims = allClaims.filter(
+        (c) =>
+          c.model === 'claude-opus-4-7' &&
+          c.role === 'review' &&
+          c.status !== 'rejected' &&
+          c.status !== 'error',
+      );
+      expect(nonTerminalOpusClaims).toHaveLength(1);
+
+      // The winning claim is the one with the smaller id (deterministic).
+      const winningId = nonTerminalOpusClaims[0].id;
+      const expectedWinner = ['task-A:agent-A:review', 'task-B:agent-B:review'].sort()[0];
+      expect(winningId).toBe(expectedWinner);
+
+      // The losing claim exists as a terminal 'error' (rolled back), not
+      // deleted — so the operator can see why the request failed.
+      const loserClaims = allClaims.filter(
+        (c) => c.model === 'claude-opus-4-7' && c.status === 'error',
+      );
+      expect(loserClaims).toHaveLength(1);
+
+      // And the loser's task is back to pending so another (different-model)
+      // agent can still claim it.
+      const losingTaskId = loser === resA ? 'task-A' : 'task-B';
+      const losingTask = await store.getTask(losingTaskId);
+      expect(losingTask?.status).toBe('pending');
+    });
   });
 
   // ── Summary claim timeout recovery (#462) ──────────────────

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -3136,9 +3136,10 @@ describe('Task Routes', () => {
     });
   });
 
-  // ── Model diversity grace period (#554) ─────────────────────
+  // ── Strict model diversity (#785) ────────────────────────────
+  // Also retains coverage for the related #554 visibility behavior.
 
-  describe('model diversity grace period (#554)', () => {
+  describe('strict model diversity (#785)', () => {
     function makeDiversityConfig(graceMs: number = 30_000) {
       return {
         ...DEFAULT_REVIEW_CONFIG,
@@ -3238,9 +3239,9 @@ describe('Task Routes', () => {
       expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(1);
     });
 
-    it('shows task after grace period expires even if same model', async () => {
+    it('still hides task after grace period expires (strict — grace no longer opens gate)', async () => {
       const config = makeDiversityConfig(30_000);
-      // Task 1: claimed with gpt-5.4
+      // Task 1: claimed with gpt-5.4 well past the grace window
       await store.createTask(
         makeTask({
           id: 'task-1',
@@ -3262,7 +3263,7 @@ describe('Task Routes', () => {
         created_at: Date.now() - 60_000,
       });
 
-      // Task 2: pending, same group, created 60s ago (> 30s grace)
+      // Task 2: pending, same group, created 60s ago (past legacy 30s grace)
       await store.createTask(
         makeTask({
           id: 'task-2',
@@ -3275,16 +3276,16 @@ describe('Task Routes', () => {
         }),
       );
 
-      // Agent with gpt-5.4 should see task-2 after grace period
+      // #785: grace no longer opens the gate — same model still hidden.
       const res = await request('POST', '/api/tasks/poll', {
         agent_id: 'agent-B',
         model: 'gpt-5.4',
       });
       const body = await res.json();
-      expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(1);
+      expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(0);
     });
 
-    it('diversity grace disabled (0) allows same model immediately', async () => {
+    it('strict diversity applies even when modelDiversityGraceMs is 0 (field no longer disables)', async () => {
       const config = makeDiversityConfig(0);
       // Task 1: claimed with gpt-5.4
       await store.createTask(
@@ -3321,13 +3322,14 @@ describe('Task Routes', () => {
         }),
       );
 
-      // Same model but diversity disabled — should see task
+      // #785: back-compat field is parsed but no longer consulted — strict
+      // diversity still hides the task from duplicate-model agents.
       const res = await request('POST', '/api/tasks/poll', {
         agent_id: 'agent-B',
         model: 'gpt-5.4',
       });
       const body = await res.json();
-      expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(1);
+      expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(0);
     });
 
     it('agent without model is visible even if models are claimed in group', async () => {
@@ -3375,7 +3377,7 @@ describe('Task Routes', () => {
       expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(1);
     });
 
-    it('applies diversity check to summary tasks too', async () => {
+    it('summary tasks are exempt from diversity — synthesizer may reuse any worker model', async () => {
       const config = makeDiversityConfig();
       // Review tasks: completed with various models
       await store.createTask(
@@ -3434,7 +3436,8 @@ describe('Task Routes', () => {
         }),
       );
 
-      // Agent with gpt-5.4 — model already used in group — should be hidden during grace
+      // #785: summary is worker-diversity-exempt — agent with gpt-5.4 (already
+      // used by a worker) can still see and claim the summary.
       const res1 = await request('POST', '/api/tasks/poll', {
         agent_id: 'agent-C',
         model: 'gpt-5.4',
@@ -3443,9 +3446,9 @@ describe('Task Routes', () => {
       const summaryTasks1 = body1.tasks.filter(
         (t: { task_id: string }) => t.task_id === 'task-summary',
       );
-      expect(summaryTasks1).toHaveLength(0);
+      expect(summaryTasks1).toHaveLength(1);
 
-      // Agent with claude-sonnet-4-6 — different model — should see it
+      // Agent with a different model still sees it too
       const res2 = await request('POST', '/api/tasks/poll', {
         agent_id: 'agent-D',
         model: 'claude-sonnet-4-6',
@@ -3502,6 +3505,277 @@ describe('Task Routes', () => {
       });
       const body = await res.json();
       expect(body.tasks.filter((t: { task_id: string }) => t.task_id === 'task-2')).toHaveLength(0);
+    });
+
+    // ── Claim-time strict enforcement (#785) ────────────────
+
+    it('claim: same-model second claim in group is rejected with 409 CLAIM_CONFLICT', async () => {
+      const config = makeDiversityConfig();
+      // Two review tasks in one group
+      await store.createTask(
+        makeTask({
+          id: 'task-1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-dup',
+          status: 'reviewing',
+          config,
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-A:review',
+        task_id: 'task-1',
+        agent_id: 'agent-A',
+        role: 'review',
+        status: 'pending',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+        created_at: Date.now(),
+      });
+      await store.createTask(
+        makeTask({
+          id: 'task-2',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-dup',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-2/claim', {
+        agent_id: 'agent-B',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
+      expect(body.error.message).toMatch(/claude-opus-4-7/);
+      expect(body.error.message).toMatch(/already in use/i);
+    });
+
+    it('claim: same-model third agent allowed after first claim errors', async () => {
+      const config = makeDiversityConfig();
+      await store.createTask(
+        makeTask({
+          id: 'task-1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-retry',
+          status: 'reviewing',
+          config,
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-A:review',
+        task_id: 'task-1',
+        agent_id: 'agent-A',
+        role: 'review',
+        status: 'error',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+        created_at: Date.now(),
+      });
+      // Release so task-1 itself can be re-claimed. Also create a sibling pending task.
+      await store.releaseTask('task-1');
+      await store.createTask(
+        makeTask({
+          id: 'task-2',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-retry',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-2/claim', {
+        agent_id: 'agent-C',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.claimed).toBe(true);
+    });
+
+    it('claim: same-model allowed after prior claim is rejected', async () => {
+      const config = makeDiversityConfig();
+      await store.createTask(
+        makeTask({
+          id: 'task-1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-rej',
+          status: 'reviewing',
+          config,
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-A:review',
+        task_id: 'task-1',
+        agent_id: 'agent-A',
+        role: 'review',
+        status: 'rejected',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+        created_at: Date.now(),
+      });
+      await store.releaseTask('task-1');
+      await store.createTask(
+        makeTask({
+          id: 'task-2',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-rej',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-2/claim', {
+        agent_id: 'agent-C',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('claim: different models in same group are both allowed', async () => {
+      const config = makeDiversityConfig();
+      await store.createTask(
+        makeTask({
+          id: 'task-1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-mix',
+          status: 'pending',
+          config,
+        }),
+      );
+      await store.createTask(
+        makeTask({
+          id: 'task-2',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-mix',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      const res1 = await request('POST', '/api/tasks/task-1/claim', {
+        agent_id: 'agent-A',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res1.status).toBe(200);
+
+      const res2 = await request('POST', '/api/tasks/task-2/claim', {
+        agent_id: 'agent-B',
+        role: 'review',
+        model: 'gemini-2.5-pro',
+        tool: 'gemini',
+      });
+      expect(res2.status).toBe(200);
+    });
+
+    it('claim: summary may reuse a worker model (diversity is worker-only)', async () => {
+      const config = makeDiversityConfig();
+      // Completed worker with claude-opus-4-7
+      await store.createTask(
+        makeTask({
+          id: 'task-w1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-sum',
+          status: 'completed',
+          config,
+        }),
+      );
+      await store.createClaim({
+        id: 'task-w1:agent-A:review',
+        task_id: 'task-w1',
+        agent_id: 'agent-A',
+        role: 'review',
+        status: 'completed',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+        review_text: 'LGTM',
+        created_at: Date.now(),
+      });
+      // Summary ready to claim
+      await store.createTask(
+        makeTask({
+          id: 'task-sum',
+          task_type: 'summary',
+          queue: 'summary',
+          group_id: 'group-sum',
+          status: 'pending',
+          config,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-sum/claim', {
+        agent_id: 'agent-B',
+        role: 'summary',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.claimed).toBe(true);
+    });
+
+    it('claim: same-model rejected even past legacy modelDiversityGraceMs window', async () => {
+      const config = makeDiversityConfig(50); // tiny grace — must not open the gate
+      await store.createTask(
+        makeTask({
+          id: 'task-1',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-grace',
+          status: 'reviewing',
+          config,
+          created_at: Date.now() - 10_000,
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-A:review',
+        task_id: 'task-1',
+        agent_id: 'agent-A',
+        role: 'review',
+        status: 'pending',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+        created_at: Date.now() - 10_000,
+      });
+      await store.createTask(
+        makeTask({
+          id: 'task-2',
+          task_type: 'review',
+          queue: 'review',
+          group_id: 'group-grace',
+          status: 'pending',
+          config,
+          created_at: Date.now() - 10_000,
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-2/claim', {
+        agent_id: 'agent-B',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
   });
 

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -3778,9 +3778,16 @@ describe('Task Routes', () => {
       expect(body.error.code).toBe('CLAIM_CONFLICT');
     });
 
-    it('claim: concurrent same-model claims on sibling tasks — exactly one survives (TOCTOU)', async () => {
+    // The store-level atomic INSERT (`createWorkerClaimIfNoModelConflict`) is
+    // the sole authority for duplicate-model rejection. These tests exercise
+    // the three scenarios a check-then-insert pattern can get wrong:
+    //   - fully concurrent with firing order A→B (first fired wins)
+    //   - fully concurrent with firing order B→A (first fired still wins)
+    //   - fully sequential where B completes before A starts (A still loses)
+    // All three must produce exactly one 200 and one 409, with exactly one
+    // non-terminal worker claim for that model in the group.
+    async function setupRaceGroup() {
       const config = makeDiversityConfig();
-      // Two pending review tasks in the same group.
       await store.createTask(
         makeTask({
           id: 'task-A',
@@ -3801,9 +3808,29 @@ describe('Task Routes', () => {
           config,
         }),
       );
+    }
 
-      // Fire both claims concurrently with the same model on different sibling
-      // tasks — this is the race that the pre-check alone cannot close.
+    function assertExactlyOneWinner(statuses: number[]) {
+      expect([...statuses].sort()).toEqual([200, 409]);
+    }
+
+    async function assertGroupHasOneOpusClaim() {
+      const allClaims = [
+        ...(await store.getClaims('task-A')),
+        ...(await store.getClaims('task-B')),
+      ];
+      const nonTerminal = allClaims.filter(
+        (c) =>
+          c.model === 'claude-opus-4-7' &&
+          c.role === 'review' &&
+          c.status !== 'rejected' &&
+          c.status !== 'error',
+      );
+      expect(nonTerminal).toHaveLength(1);
+    }
+
+    it('claim: concurrent same-model sibling-task race — A fired first', async () => {
+      await setupRaceGroup();
       const [resA, resB] = await Promise.all([
         request('POST', '/api/tasks/task-A/claim', {
           agent_id: 'agent-A',
@@ -3818,49 +3845,63 @@ describe('Task Routes', () => {
           tool: 'claude',
         }),
       ]);
+      assertExactlyOneWinner([resA.status, resB.status]);
+      await assertGroupHasOneOpusClaim();
+    });
 
-      // Exactly one winner, one loser. The tiebreaker is deterministic
-      // (smallest claim id wins), so the outcome is stable regardless of
-      // scheduling.
-      const statuses = [resA.status, resB.status].sort();
-      expect(statuses).toEqual([200, 409]);
+    it('claim: concurrent same-model sibling-task race — B fired first (inverted order)', async () => {
+      await setupRaceGroup();
+      // Inverted firing order: B's request enters the Promise.all first.
+      // Correctness must not depend on which side Promise.all scheduled first.
+      const [resB, resA] = await Promise.all([
+        request('POST', '/api/tasks/task-B/claim', {
+          agent_id: 'agent-B',
+          role: 'review',
+          model: 'claude-opus-4-7',
+          tool: 'claude',
+        }),
+        request('POST', '/api/tasks/task-A/claim', {
+          agent_id: 'agent-A',
+          role: 'review',
+          model: 'claude-opus-4-7',
+          tool: 'claude',
+        }),
+      ]);
+      assertExactlyOneWinner([resA.status, resB.status]);
+      await assertGroupHasOneOpusClaim();
+    });
 
-      const loser = resA.status === 409 ? resA : resB;
-      const loserBody = await loser.json();
-      expect(loserBody.error.code).toBe('CLAIM_CONFLICT');
-      expect(loserBody.error.message).toMatch(/claude-opus-4-7/);
+    it('claim: sequential same-model claim across sibling tasks still rejected', async () => {
+      // This is the scenario a pure post-insert tiebreaker would miss: B
+      // completes its entire flow (insert + response) before A starts, so
+      // B's post-check saw an empty group. The atomic INSERT closes this
+      // case because A's subquery sees B's committed claim.
+      await setupRaceGroup();
+      const resB = await request('POST', '/api/tasks/task-B/claim', {
+        agent_id: 'agent-B',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(resB.status).toBe(200);
 
-      // Exactly one non-terminal worker claim for this model in the group.
-      const allClaims = [
-        ...(await store.getClaims('task-A')),
-        ...(await store.getClaims('task-B')),
-      ];
-      const nonTerminalOpusClaims = allClaims.filter(
-        (c) =>
-          c.model === 'claude-opus-4-7' &&
-          c.role === 'review' &&
-          c.status !== 'rejected' &&
-          c.status !== 'error',
-      );
-      expect(nonTerminalOpusClaims).toHaveLength(1);
+      const resA = await request('POST', '/api/tasks/task-A/claim', {
+        agent_id: 'agent-A',
+        role: 'review',
+        model: 'claude-opus-4-7',
+        tool: 'claude',
+      });
+      expect(resA.status).toBe(409);
+      const body = await resA.json();
+      expect(body.error.code).toBe('CLAIM_CONFLICT');
+      expect(body.error.message).toMatch(/claude-opus-4-7/);
 
-      // The winning claim is the one with the smaller id (deterministic).
-      const winningId = nonTerminalOpusClaims[0].id;
-      const expectedWinner = ['task-A:agent-A:review', 'task-B:agent-B:review'].sort()[0];
-      expect(winningId).toBe(expectedWinner);
-
-      // The losing claim exists as a terminal 'error' (rolled back), not
-      // deleted — so the operator can see why the request failed.
-      const loserClaims = allClaims.filter(
-        (c) => c.model === 'claude-opus-4-7' && c.status === 'error',
-      );
-      expect(loserClaims).toHaveLength(1);
-
-      // And the loser's task is back to pending so another (different-model)
-      // agent can still claim it.
-      const losingTaskId = loser === resA ? 'task-A' : 'task-B';
-      const losingTask = await store.getTask(losingTaskId);
+      // Losing task released back to pending so a different-model agent
+      // can still claim it.
+      const losingTask = await store.getTask('task-A');
       expect(losingTask?.status).toBe('pending');
+
+      await assertGroupHasOneOpusClaim();
     });
   });
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -7,6 +7,7 @@ import type {
   ResultResponse,
   ReviewVerdict,
   ReviewTask,
+  TaskClaim,
   TaskRole,
   DedupReport,
   TriageReport,
@@ -1053,63 +1054,6 @@ async function filterTasksForAgent(
 }
 
 /**
- * Collect models held by non-terminal worker claims in a group (#785).
- * Used at claim time as a fast-path pre-check to reject most duplicate-model
- * worker claims before touching task state. Terminal (rejected/error) claims
- * are excluded so failed attempts don't permanently lock out retries.
- *
- * Note: this is NOT the final authority on duplicate-model rejection — because
- * the pre-check is not atomic with the subsequent `claimTask` + `createClaim`
- * writes, concurrent same-model claimers on sibling tasks in the same group
- * can both pass. `hasConflictingWorkerModelClaim` runs AFTER the insert and
- * resolves the race with a deterministic tiebreaker.
- */
-async function getWorkerModelsInGroup(store: DataStore, groupId: string): Promise<Set<string>> {
-  const models = new Set<string>();
-  const groupTasks = await store.getTasksByGroup(groupId);
-  for (const gt of groupTasks) {
-    if (!isWorkerTask(gt)) continue;
-    const claims = await store.getClaims(gt.id);
-    for (const claim of claims) {
-      if (!claim.model) continue;
-      if (isClaimFailed(claim)) continue;
-      models.add(claim.model);
-    }
-  }
-  return models;
-}
-
-/**
- * Post-insert tiebreaker for the claim-time diversity race (#785).
- *
- * After `createClaim` succeeds, this scans the group for another non-terminal
- * worker claim with the same model. If one exists AND its claim id is
- * lexicographically smaller than `ownClaimId`, the caller lost the race and
- * must roll back. Claim ids are deterministic (`${taskId}:${agent_id}:${role}`),
- * so two racing sides evaluate the same comparator and exactly one loses —
- * giving atomic-equivalent correctness without a migration or new store method.
- */
-async function hasConflictingWorkerModelClaim(
-  store: DataStore,
-  groupId: string,
-  model: string,
-  ownClaimId: string,
-): Promise<boolean> {
-  const groupTasks = await store.getTasksByGroup(groupId);
-  for (const gt of groupTasks) {
-    if (!isWorkerTask(gt)) continue;
-    const claims = await store.getClaims(gt.id);
-    for (const claim of claims) {
-      if (claim.id === ownClaimId) continue;
-      if (claim.model !== model) continue;
-      if (isClaimFailed(claim)) continue;
-      if (claim.id < ownClaimId) return true; // the other claim wins the tiebreak
-    }
-  }
-  return false;
-}
-
-/**
  * Get completed worker reviews for a group (used for summary poll/claim responses).
  */
 async function getWorkerReviews(store: DataStore, groupId: string): Promise<ClaimReview[]> {
@@ -1467,13 +1411,40 @@ export function taskRoutes() {
       }
     }
 
-    // Strict model diversity (#785): for worker tasks, reject if the agent's
-    // model is already held by any non-terminal worker claim in the same group.
-    // Terminal (rejected/error) claims do not block retries. Summary claims are
-    // exempt — the synthesizer model is free to overlap with any worker model.
-    if (isWorkerTask(task) && model && task.group_id) {
-      const usedModels = await getWorkerModelsInGroup(store, task.group_id);
-      if (usedModels.has(model)) {
+    // Atomic CAS: pending → reviewing
+    const claimed = await store.claimTask(taskId);
+    if (!claimed) {
+      return apiError(c, 409, 'CLAIM_CONFLICT', 'Task already claimed');
+    }
+
+    // Role-aware claim ID
+    const claimId = `${taskId}:${agent_id}:${role}`;
+    const claimPayload: TaskClaim = {
+      id: claimId,
+      task_id: taskId,
+      agent_id,
+      role,
+      status: 'pending',
+      model,
+      tool,
+      thinking,
+      github_user_id: verifiedIdentity?.github_user_id,
+      github_username: verifiedIdentity?.github_username,
+      created_at: Date.now(),
+    };
+
+    // Strict model diversity (#785): for worker tasks with a declared model,
+    // use the atomic store method so the duplicate-model check and the
+    // claim insert happen in a single SQLite statement. This closes the
+    // TOCTOU race that a check-then-insert pattern would leave open —
+    // including the case where one claim fully finishes before the other
+    // starts. Summary and no-model claims take the plain createClaim path,
+    // since worker-level diversity doesn't apply to them.
+    const useAtomicDiversity = isWorkerTask(task) && !!model && !!task.group_id;
+    if (useAtomicDiversity) {
+      const outcome = await store.createWorkerClaimIfNoModelConflict(claimPayload, task.group_id);
+      if (outcome === 'model_conflict') {
+        await store.releaseTask(taskId);
         logger.warn('Claim rejected — duplicate model in group', {
           agentId: agent_id,
           taskId,
@@ -1487,60 +1458,15 @@ export function taskRoutes() {
           `Model '${model}' is already in use by another agent in this review group`,
         );
       }
-    }
-
-    // Atomic CAS: pending → reviewing
-    const claimed = await store.claimTask(taskId);
-    if (!claimed) {
-      return apiError(c, 409, 'CLAIM_CONFLICT', 'Task already claimed');
-    }
-
-    // Role-aware claim ID
-    const claimId = `${taskId}:${agent_id}:${role}`;
-    const claimCreated = await store.createClaim({
-      id: claimId,
-      task_id: taskId,
-      agent_id,
-      role,
-      status: 'pending',
-      model,
-      tool,
-      thinking,
-      github_user_id: verifiedIdentity?.github_user_id,
-      github_username: verifiedIdentity?.github_username,
-      created_at: Date.now(),
-    });
-    if (!claimCreated) {
-      // Release the task so another agent can claim it
-      await store.releaseTask(taskId);
-      return apiError(c, 409, 'CLAIM_CONFLICT', 'Agent already has a claim on this task');
-    }
-
-    // Post-insert tiebreaker for strict model diversity (#785).
-    // The pre-check above is not atomic with createClaim, so two same-model
-    // agents racing on different sibling tasks in the same group can both
-    // pass. Re-scan now and, if another non-terminal worker claim with the
-    // same model and a lexicographically smaller id exists, the race is lost.
-    // Roll back deterministically so exactly one same-model worker survives
-    // in the group.
-    if (isWorkerTask(task) && model && task.group_id) {
-      const lostRace = await hasConflictingWorkerModelClaim(store, task.group_id, model, claimId);
-      if (lostRace) {
-        await store.updateClaim(claimId, { status: 'error' });
+      if (outcome === 'agent_conflict') {
         await store.releaseTask(taskId);
-        logger.warn('Claim rolled back — lost model diversity race in group', {
-          agentId: agent_id,
-          taskId,
-          groupId: task.group_id,
-          model,
-          claimId,
-        });
-        return apiError(
-          c,
-          409,
-          'CLAIM_CONFLICT',
-          `Model '${model}' is already in use by another agent in this review group`,
-        );
+        return apiError(c, 409, 'CLAIM_CONFLICT', 'Agent already has a claim on this task');
+      }
+    } else {
+      const claimCreated = await store.createClaim(claimPayload);
+      if (!claimCreated) {
+        await store.releaseTask(taskId);
+        return apiError(c, 409, 'CLAIM_CONFLICT', 'Agent already has a claim on this task');
       }
     }
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -119,30 +119,32 @@ function isTargetModelVisible(
 }
 
 /**
- * Check if a task is visible to the given agent considering model diversity.
- * During the grace window, hides tasks from agents whose model is already
- * used by another claim in the same group. After the grace window, visible to all.
+ * Check if a worker task is visible to the given agent considering model
+ * diversity. Strict rule (#785): if the agent's model is already used by ANY
+ * non-terminal (pending or completed) worker claim in the same task group,
+ * hide the task. Terminal claims (rejected/error) do NOT lock out retries.
  *
- * Grace period starts from when the model was first claimed in the group,
- * not from task creation time. This ensures the diversity window covers
- * the actual review period.
+ * Diversity applies only to worker tasks — summary tasks are exempt (the
+ * synthesizer model is free to overlap with a worker's model). Callers must
+ * only invoke this for worker tasks.
+ *
+ * The legacy `modelDiversityGraceMs` config is no longer consulted; the check
+ * is always strict. The field is still parsed for back-compat with existing
+ * configs (silently ignored).
  */
 function isModelDiversityVisible(
   task: ReviewTask,
   model: string | undefined,
-  groupClaimedModels: Map<string, Map<string, number>>,
+  groupClaimedModels: Map<string, Set<string>>,
 ): boolean {
-  const graceMs = task.config.modelDiversityGraceMs;
-  if (graceMs <= 0) return true; // diversity disabled
   if (!model) return true; // agent didn't declare a model, can't check
   if (!task.group_id) return true; // no group, no diversity to enforce
 
   const claimedModels = groupClaimedModels.get(task.group_id);
   if (!claimedModels || !claimedModels.has(model)) return true; // model not yet used
 
-  // Model already used — check if grace period has elapsed since the model was claimed
-  const claimedAt = claimedModels.get(model)!;
-  return Date.now() - claimedAt >= graceMs;
+  // Model already used by a non-terminal worker claim — strictly hide.
+  return false;
 }
 
 /**
@@ -775,7 +777,12 @@ interface PollContext {
   tasksById: Map<string, ReviewTask>;
   dedupBlockedRepos: Set<string>;
   oldestDedupPerRepo: Map<string, ReviewTask>;
-  groupClaimedModels: Map<string, Map<string, number>>;
+  /**
+   * Per-group set of models held by non-terminal worker claims (pending or
+   * completed). Used for strict model diversity enforcement — an agent with
+   * a model present here cannot claim any worker slot in that group (#785).
+   */
+  groupClaimedModels: Map<string, Set<string>>;
 }
 
 /**
@@ -805,34 +812,29 @@ async function buildPollContext(store: DataStore): Promise<PollContext> {
     }
   }
 
-  // Model diversity: build claimed-models-per-group map (model → earliest claim timestamp)
+  // Model diversity (#785): build per-group set of models held by non-terminal
+  // worker claims (pending or completed). Strictly blocks same-model claims in
+  // the group. Summary claims are exempt — synthesizer model can overlap with
+  // any worker's model.
   const pendingGroupIds = new Set<string>();
   for (const t of tasks) {
-    if (t.group_id && t.config.modelDiversityGraceMs > 0) {
-      pendingGroupIds.add(t.group_id);
-    }
+    if (t.group_id) pendingGroupIds.add(t.group_id);
   }
-  const groupClaimedModels = new Map<string, Map<string, number>>();
-  if (pendingGroupIds.size > 0) {
-    for (const groupId of pendingGroupIds) {
-      const groupTasks = await store.getTasksByGroup(groupId);
-      for (const gt of groupTasks) {
-        if (gt.status !== 'reviewing' && gt.status !== 'completed') continue;
-        const claims = await store.getClaims(gt.id);
-        for (const claim of claims) {
-          if (claim.model) {
-            let models = groupClaimedModels.get(groupId);
-            if (!models) {
-              models = new Map();
-              groupClaimedModels.set(groupId, models);
-            }
-            const existing = models.get(claim.model);
-            const claimTime = claim.created_at;
-            if (existing === undefined || claimTime < existing) {
-              models.set(claim.model, claimTime);
-            }
-          }
+  const groupClaimedModels = new Map<string, Set<string>>();
+  for (const groupId of pendingGroupIds) {
+    const groupTasks = await store.getTasksByGroup(groupId);
+    for (const gt of groupTasks) {
+      if (!isWorkerTask(gt)) continue;
+      const claims = await store.getClaims(gt.id);
+      for (const claim of claims) {
+        if (!claim.model) continue;
+        if (isClaimFailed(claim)) continue; // terminal failures don't lock out retries
+        let models = groupClaimedModels.get(groupId);
+        if (!models) {
+          models = new Set();
+          groupClaimedModels.set(groupId, models);
         }
+        models.add(claim.model);
       }
     }
   }
@@ -940,13 +942,12 @@ async function filterTasksForAgent(
     } else {
       // Worker task — check model/tool preference grace period
       if (!isWorkerVisibleToAgent(task, agent.model, agent.tool, effectiveReviewGraceMs)) continue;
+      // Strict model diversity (#785): worker-level only — summary tasks exempt.
+      if (!isModelDiversityVisible(task, agent.model, groupClaimedModels)) continue;
     }
 
     // Target model preference: during grace period, only matching agents see the task
     if (!isTargetModelVisible(task, agent.model, effectiveTargetModelGraceMs)) continue;
-
-    // Model diversity: prefer agents with different models across the group
-    if (!isModelDiversityVisible(task, agent.model, groupClaimedModels)) continue;
 
     candidates.push({
       task,
@@ -1045,6 +1046,27 @@ async function filterTasksForAgent(
   });
 
   return available;
+}
+
+/**
+ * Collect models held by non-terminal worker claims in a group (#785).
+ * Used at claim time to strictly reject duplicate-model worker claims.
+ * Terminal (rejected/error) claims are excluded so failed attempts don't
+ * permanently lock out retries from the same model.
+ */
+async function getWorkerModelsInGroup(store: DataStore, groupId: string): Promise<Set<string>> {
+  const models = new Set<string>();
+  const groupTasks = await store.getTasksByGroup(groupId);
+  for (const gt of groupTasks) {
+    if (!isWorkerTask(gt)) continue;
+    const claims = await store.getClaims(gt.id);
+    for (const claim of claims) {
+      if (!claim.model) continue;
+      if (isClaimFailed(claim)) continue;
+      models.add(claim.model);
+    }
+  }
+  return models;
 }
 
 /**
@@ -1402,6 +1424,28 @@ export function taskRoutes() {
       const effTargetGrace = effectiveGracePeriod(TARGET_MODEL_GRACE_PERIOD_MS, lastCompleted);
       if (!isTargetModelVisible(task, model, effTargetGrace)) {
         return apiError(c, 409, 'CLAIM_CONFLICT', 'No slots available');
+      }
+    }
+
+    // Strict model diversity (#785): for worker tasks, reject if the agent's
+    // model is already held by any non-terminal worker claim in the same group.
+    // Terminal (rejected/error) claims do not block retries. Summary claims are
+    // exempt — the synthesizer model is free to overlap with any worker model.
+    if (isWorkerTask(task) && model && task.group_id) {
+      const usedModels = await getWorkerModelsInGroup(store, task.group_id);
+      if (usedModels.has(model)) {
+        logger.warn('Claim rejected — duplicate model in group', {
+          agentId: agent_id,
+          taskId,
+          groupId: task.group_id,
+          model,
+        });
+        return apiError(
+          c,
+          409,
+          'CLAIM_CONFLICT',
+          `Model '${model}' is already in use by another agent in this review group`,
+        );
       }
     }
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -825,6 +825,10 @@ async function buildPollContext(store: DataStore): Promise<PollContext> {
     const groupTasks = await store.getTasksByGroup(groupId);
     for (const gt of groupTasks) {
       if (!isWorkerTask(gt)) continue;
+      // Pending tasks can only carry terminal claims (released after a
+      // prior error/reject). Skip them to avoid an unnecessary getClaims
+      // round-trip — terminal claims would be filtered out below anyway.
+      if (gt.status !== 'reviewing' && gt.status !== 'completed') continue;
       const claims = await store.getClaims(gt.id);
       for (const claim of claims) {
         if (!claim.model) continue;
@@ -1050,9 +1054,15 @@ async function filterTasksForAgent(
 
 /**
  * Collect models held by non-terminal worker claims in a group (#785).
- * Used at claim time to strictly reject duplicate-model worker claims.
- * Terminal (rejected/error) claims are excluded so failed attempts don't
- * permanently lock out retries from the same model.
+ * Used at claim time as a fast-path pre-check to reject most duplicate-model
+ * worker claims before touching task state. Terminal (rejected/error) claims
+ * are excluded so failed attempts don't permanently lock out retries.
+ *
+ * Note: this is NOT the final authority on duplicate-model rejection — because
+ * the pre-check is not atomic with the subsequent `claimTask` + `createClaim`
+ * writes, concurrent same-model claimers on sibling tasks in the same group
+ * can both pass. `hasConflictingWorkerModelClaim` runs AFTER the insert and
+ * resolves the race with a deterministic tiebreaker.
  */
 async function getWorkerModelsInGroup(store: DataStore, groupId: string): Promise<Set<string>> {
   const models = new Set<string>();
@@ -1067,6 +1077,36 @@ async function getWorkerModelsInGroup(store: DataStore, groupId: string): Promis
     }
   }
   return models;
+}
+
+/**
+ * Post-insert tiebreaker for the claim-time diversity race (#785).
+ *
+ * After `createClaim` succeeds, this scans the group for another non-terminal
+ * worker claim with the same model. If one exists AND its claim id is
+ * lexicographically smaller than `ownClaimId`, the caller lost the race and
+ * must roll back. Claim ids are deterministic (`${taskId}:${agent_id}:${role}`),
+ * so two racing sides evaluate the same comparator and exactly one loses —
+ * giving atomic-equivalent correctness without a migration or new store method.
+ */
+async function hasConflictingWorkerModelClaim(
+  store: DataStore,
+  groupId: string,
+  model: string,
+  ownClaimId: string,
+): Promise<boolean> {
+  const groupTasks = await store.getTasksByGroup(groupId);
+  for (const gt of groupTasks) {
+    if (!isWorkerTask(gt)) continue;
+    const claims = await store.getClaims(gt.id);
+    for (const claim of claims) {
+      if (claim.id === ownClaimId) continue;
+      if (claim.model !== model) continue;
+      if (isClaimFailed(claim)) continue;
+      if (claim.id < ownClaimId) return true; // the other claim wins the tiebreak
+    }
+  }
+  return false;
 }
 
 /**
@@ -1474,6 +1514,34 @@ export function taskRoutes() {
       // Release the task so another agent can claim it
       await store.releaseTask(taskId);
       return apiError(c, 409, 'CLAIM_CONFLICT', 'Agent already has a claim on this task');
+    }
+
+    // Post-insert tiebreaker for strict model diversity (#785).
+    // The pre-check above is not atomic with createClaim, so two same-model
+    // agents racing on different sibling tasks in the same group can both
+    // pass. Re-scan now and, if another non-terminal worker claim with the
+    // same model and a lexicographically smaller id exists, the race is lost.
+    // Roll back deterministically so exactly one same-model worker survives
+    // in the group.
+    if (isWorkerTask(task) && model && task.group_id) {
+      const lostRace = await hasConflictingWorkerModelClaim(store, task.group_id, model, claimId);
+      if (lostRace) {
+        await store.updateClaim(claimId, { status: 'error' });
+        await store.releaseTask(taskId);
+        logger.warn('Claim rolled back — lost model diversity race in group', {
+          agentId: agent_id,
+          taskId,
+          groupId: task.group_id,
+          model,
+          claimId,
+        });
+        return apiError(
+          c,
+          409,
+          'CLAIM_CONFLICT',
+          `Model '${model}' is already in use by another agent in this review group`,
+        );
+      }
     }
 
     // Update heartbeat — keep agent alive after successful claim

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -502,6 +502,68 @@ export class D1DataStore implements DataStore {
     return (result.meta?.changes ?? 0) > 0;
   }
 
+  async createWorkerClaimIfNoModelConflict(
+    claim: TaskClaim,
+    groupId: string,
+  ): Promise<'ok' | 'model_conflict' | 'agent_conflict'> {
+    // Step 1: handle any prior claim by the same agent on this task+role. An
+    // active (pending/completed) claim means the agent can't re-claim; a
+    // terminal (rejected/error) claim is removed so the retry can proceed.
+    // This is scoped to the agent's own claim tuple, so it cannot race with
+    // another agent's insert.
+    const existing = await this.db
+      .prepare('SELECT id, status FROM claims WHERE task_id = ? AND agent_id = ? AND role = ?')
+      .bind(claim.task_id, claim.agent_id, claim.role)
+      .first<{ id: string; status: string }>();
+
+    if (existing) {
+      if (existing.status === 'pending' || existing.status === 'completed') {
+        return 'agent_conflict';
+      }
+      await this.db.prepare('DELETE FROM claims WHERE id = ?').bind(existing.id).run();
+    }
+
+    // Step 2: atomic INSERT guarded by a NOT EXISTS subquery for model
+    // conflict. SQLite evaluates the subquery and performs the INSERT as a
+    // single statement, so no two same-model worker claims in the same group
+    // can both pass this gate concurrently (#785).
+    const result = await this.db
+      .prepare(
+        `INSERT INTO claims (id, task_id, agent_id, role, status, model, tool, thinking,
+          review_text, verdict, tokens_used, github_user_id, github_username, created_at)
+         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+         WHERE NOT EXISTS (
+           SELECT 1 FROM claims c
+           JOIN tasks t ON c.task_id = t.id
+           WHERE t.group_id = ?
+             AND c.role IN ('review', 'issue_review')
+             AND c.status IN ('pending', 'completed')
+             AND c.model = ?
+         )`,
+      )
+      .bind(
+        claim.id,
+        claim.task_id,
+        claim.agent_id,
+        claim.role,
+        claim.status,
+        claim.model ?? null,
+        claim.tool ?? null,
+        claim.thinking ?? null,
+        claim.review_text ?? null,
+        claim.verdict ?? null,
+        claim.tokens_used ?? null,
+        claim.github_user_id ?? null,
+        claim.github_username ?? null,
+        claim.created_at,
+        groupId,
+        claim.model ?? null,
+      )
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0 ? 'ok' : 'model_conflict';
+  }
+
   async getClaim(claimId: string): Promise<TaskClaim | null> {
     const row = await this.db
       .prepare('SELECT * FROM claims WHERE id = ?')

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -58,6 +58,27 @@ export interface DataStore {
 
   // Claims — createClaim returns false if (task_id, agent_id) already exists
   createClaim(claim: TaskClaim): Promise<boolean>;
+  /**
+   * Atomically create a worker claim only if no other non-terminal worker
+   * claim (`review` or `issue_review`, `pending`/`completed`) in the given
+   * group already uses the claim's model. Strict model diversity (#785).
+   *
+   * Returns:
+   *   - `'ok'` — claim inserted.
+   *   - `'model_conflict'` — another agent already holds a non-terminal worker
+   *     claim with the same model in this group; nothing was inserted.
+   *   - `'agent_conflict'` — an active claim already exists for this
+   *     (task_id, agent_id, role); nothing was inserted.
+   *
+   * Must be implemented so that the model-conflict check and the insert are a
+   * single atomic operation (e.g. a SQLite `INSERT ... WHERE NOT EXISTS`
+   * statement). This is the sole authority on duplicate-model rejection — the
+   * poll-side visibility check is a fast-path hint, not a correctness gate.
+   */
+  createWorkerClaimIfNoModelConflict(
+    claim: TaskClaim,
+    groupId: string,
+  ): Promise<'ok' | 'model_conflict' | 'agent_conflict'>;
   getClaim(claimId: string): Promise<TaskClaim | null>;
   /** Batch fetch multiple claims by ID. Returns a Map of claimId → TaskClaim for found claims. */
   getClaimsBatch(claimIds: string[]): Promise<Map<string, TaskClaim>>;

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -222,6 +222,44 @@ export class MemoryDataStore implements DataStore {
     return true;
   }
 
+  async createWorkerClaimIfNoModelConflict(
+    claim: TaskClaim,
+    groupId: string,
+  ): Promise<'ok' | 'model_conflict' | 'agent_conflict'> {
+    // The body is fully synchronous once entered — no `await` between the
+    // checks and the set — so no other async invocation can interleave.
+    // That gives the same atomicity guarantee as the D1 `INSERT ... WHERE
+    // NOT EXISTS` statement.
+    for (const [id, existing] of this.claims) {
+      if (
+        existing.task_id === claim.task_id &&
+        existing.agent_id === claim.agent_id &&
+        existing.role === claim.role
+      ) {
+        if (existing.status === 'pending' || existing.status === 'completed') {
+          return 'agent_conflict';
+        }
+        this.claims.delete(id);
+      }
+    }
+
+    if (claim.model) {
+      const groupTaskIds = new Set<string>();
+      for (const t of this.tasks.values()) {
+        if (t.group_id === groupId) groupTaskIds.add(t.id);
+      }
+      for (const other of this.claims.values()) {
+        if (!groupTaskIds.has(other.task_id)) continue;
+        if (other.role !== 'review' && other.role !== 'issue_review') continue;
+        if (other.status !== 'pending' && other.status !== 'completed') continue;
+        if (other.model === claim.model) return 'model_conflict';
+      }
+    }
+
+    this.claims.set(claim.id, { ...claim });
+    return 'ok';
+  }
+
   async getClaim(claimId: string): Promise<TaskClaim | null> {
     const claim = this.claims.get(claimId);
     return claim ? { ...claim } : null;


### PR DESCRIPTION
Part of #785

## Summary

- **Root cause**: `isModelDiversityVisible` had a grace-period escape (`Date.now() - claimedAt >= graceMs`). With `instances = N` on the same `(model, tool)`, a second instance could trivially clear the grace window and claim a second review slot — the bot review then listed the same `model/tool` combo twice.
- **Fix**: worker-level model diversity is now strict. If any non-terminal (`pending` or `completed`) worker claim in the task group uses a given model, no further same-model worker claim in that group is visible or claimable. Terminal claims (`rejected`, `error`) do **not** block — a failed Opus claim no longer locks out other Opus agents from retrying. Summary claims are explicitly exempt so the synthesizer may reuse any worker's model.
- **Back-compat**: `modelDiversityGraceMs` remains parsed but is no longer consulted. The new rule is strictly stricter than any prior config, so existing configs continue to work without migration.
- **Server-side enforcement**: new `getWorkerModelsInGroup` helper scans the group for non-terminal worker claim models; the claim endpoint rejects duplicates with `409 CLAIM_CONFLICT` and a clear message identifying the conflicting model.

Live case: https://github.com/ParadiseEngine/ParadiseEngine/pull/55#issuecomment-4311407805

## Test plan

- [x] Updated 3 existing `#554` diversity tests to reflect the new strict behavior (grace no longer opens the gate; `graceMs=0` no longer disables; summary tasks are exempt).
- [x] New `#785` claim-time tests:
  - Same-model second claim → `409 CLAIM_CONFLICT` with message identifying the conflicting model.
  - Same-model third agent allowed after first claim errors.
  - Same-model allowed after prior claim is rejected.
  - Different-model claims in same group → both allowed.
  - Summary claim may reuse a worker model (worker-level rule only).
  - Same-model claim rejected even past the legacy `modelDiversityGraceMs` window.
- [x] Full server test suite: `pnpm test` — 3004 tests pass.
- [x] `pnpm build && pnpm lint && pnpm run format:check && pnpm run typecheck` — all clean.