### PR TITLE
[server-dev] Add per-claim heartbeat endpoint + reclaim integration

### DIFF
--- a/packages/server/migrations/0019_claims_heartbeat.sql
+++ b/packages/server/migrations/0019_claims_heartbeat.sql
@@ -1,0 +1,7 @@
+-- Per-claim liveness timestamp. Updated by POST /api/tasks/:taskId/heartbeat
+-- while a long-running tool is executing so reclaimAbandonedClaims does not
+-- mark the claim as 'error' mid-run when the agent-level heartbeat is only
+-- refreshed at claim-create / result-submit. Nullable: NULL on claims created
+-- before this migration, in which case reclaim falls back to the agent-level
+-- heartbeat (back-compat with old CLIs).
+ALTER TABLE claims ADD COLUMN last_heartbeat_at INTEGER;

--- a/packages/server/src/__tests__/routes-tasks.test.ts
+++ b/packages/server/src/__tests__/routes-tasks.test.ts
@@ -1624,6 +1624,155 @@ describe('Task Routes', () => {
     });
   });
 
+  // ── Heartbeat (#783) ────────────────────────────────────
+
+  describe('POST /api/tasks/:taskId/heartbeat', () => {
+    async function seedActiveClaim() {
+      await store.createTask(
+        makeTask({
+          review_count: 1,
+          queue: 'review',
+          task_type: 'review',
+          status: 'reviewing',
+        }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1:review',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+    }
+
+    it('updates the claim-level heartbeat and agent last-seen', async () => {
+      await seedActiveClaim();
+      const before = Date.now() - 1;
+
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+        role: 'review',
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ success: true });
+
+      const claim = await store.getClaim('task-1:agent-1:review');
+      expect(claim?.last_heartbeat_at).toBeDefined();
+      expect(claim!.last_heartbeat_at!).toBeGreaterThanOrEqual(before);
+
+      const lastSeen = await store.getAgentLastSeen('agent-1');
+      expect(lastSeen).toBeGreaterThanOrEqual(before);
+    });
+
+    it('returns 404 when no claim exists for task + agent + role', async () => {
+      await store.createTask(
+        makeTask({
+          review_count: 1,
+          queue: 'review',
+          task_type: 'review',
+          status: 'pending',
+        }),
+      );
+
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'ghost',
+        role: 'review',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a terminal claim (completed/error/rejected)', async () => {
+      await store.createTask(makeTask({ task_type: 'review', status: 'completed' }));
+      await store.createClaim({
+        id: 'task-1:agent-1:review',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'completed',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+        role: 'review',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 400 for invalid body (missing agent_id)', async () => {
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        role: 'review',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid body (missing role)', async () => {
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('is idempotent — repeated heartbeats keep refreshing the timestamp', async () => {
+      await seedActiveClaim();
+
+      const res1 = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+        role: 'review',
+      });
+      expect(res1.status).toBe(200);
+      const claim1 = await store.getClaim('task-1:agent-1:review');
+      const firstTs = claim1!.last_heartbeat_at!;
+
+      // Busy-wait a tiny moment so Date.now() advances past the first call.
+      await new Promise((r) => setTimeout(r, 2));
+
+      const res2 = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+        role: 'review',
+      });
+      expect(res2.status).toBe(200);
+      const claim2 = await store.getClaim('task-1:agent-1:review');
+      expect(claim2!.last_heartbeat_at!).toBeGreaterThan(firstTs);
+    });
+
+    it('only heartbeats the matching role (does not touch a different-role claim)', async () => {
+      // Two claims on the same task — one review, one summary. The endpoint
+      // must only refresh the claim matching the request role.
+      await store.createTask(
+        makeTask({ review_count: 1, task_type: 'review', status: 'reviewing' }),
+      );
+      await store.createClaim({
+        id: 'task-1:agent-1:review',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'review',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+      await store.createClaim({
+        id: 'task-1:agent-1:summary',
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        role: 'summary',
+        status: 'pending',
+        created_at: Date.now(),
+      });
+
+      const res = await request('POST', '/api/tasks/task-1/heartbeat', {
+        agent_id: 'agent-1',
+        role: 'review',
+      });
+      expect(res.status).toBe(200);
+
+      const review = await store.getClaim('task-1:agent-1:review');
+      const summary = await store.getClaim('task-1:agent-1:summary');
+      expect(review?.last_heartbeat_at).toBeDefined();
+      expect(summary?.last_heartbeat_at).toBeUndefined();
+    });
+  });
+
   // ── Timeout throttle ────────────────────────────────────
 
   describe('checkTimeouts throttle', () => {

--- a/packages/server/src/__tests__/store-d1.test.ts
+++ b/packages/server/src/__tests__/store-d1.test.ts
@@ -1185,6 +1185,38 @@ describe('D1DataStore', () => {
     });
   });
 
+  // ── updateClaimHeartbeat (#783) ─────────────────────────────
+
+  describe('updateClaimHeartbeat', () => {
+    it('updates last_heartbeat_at on a pending claim and returns true', async () => {
+      await store.createTask(makeTask());
+      await store.createClaim(makeClaim());
+
+      const ts = Date.now();
+      const ok = await store.updateClaimHeartbeat('task-1:agent-1:review', ts);
+      expect(ok).toBe(true);
+
+      const claim = await store.getClaim('task-1:agent-1:review');
+      expect(claim?.last_heartbeat_at).toBe(ts);
+    });
+
+    it('returns false for a missing claim', async () => {
+      const ok = await store.updateClaimHeartbeat('missing', Date.now());
+      expect(ok).toBe(false);
+    });
+
+    it('returns false for a terminal claim and does not touch last_heartbeat_at', async () => {
+      await store.createTask(makeTask());
+      await store.createClaim(makeClaim({ status: 'completed' }));
+
+      const ok = await store.updateClaimHeartbeat('task-1:agent-1:review', 123456);
+      expect(ok).toBe(false);
+
+      const claim = await store.getClaim('task-1:agent-1:review');
+      expect(claim?.last_heartbeat_at).toBeUndefined();
+    });
+  });
+
   // ── reclaimAbandonedSummarySlots ────────────────────────────
 
   describe('reclaimAbandonedSummarySlots', () => {

--- a/packages/server/src/__tests__/store-memory.test.ts
+++ b/packages/server/src/__tests__/store-memory.test.ts
@@ -843,6 +843,133 @@ describe('MemoryDataStore', () => {
       expect(task?.queue).toBe('finished');
       expect(task?.summary_agent_id).toBe('new-agent');
     });
+
+    // #783 — per-claim heartbeat precedence over agent-level.
+
+    it('does not reclaim when claim-level heartbeat is fresh (#783)', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ review_claims: 1, queue: 'review' }));
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:busy:review',
+          agent_id: 'busy',
+          role: 'review',
+          created_at: now - 600_000, // claim is old...
+          last_heartbeat_at: now - 60_000, // ...but tool is still beating
+        }),
+      );
+      // Agent-level heartbeat is stale — only claim-hb keeps it alive
+      await store.setAgentLastSeen('busy', now - 600_000);
+
+      const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+      expect(freed).toBe(0);
+
+      const claim = await store.getClaim('task-1:busy:review');
+      expect(claim?.status).toBe('pending');
+    });
+
+    it('reclaims when claim-level heartbeat is stale (#783)', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ review_claims: 1, queue: 'review' }));
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:dead:review',
+          agent_id: 'dead',
+          role: 'review',
+          last_heartbeat_at: now - 600_000, // stale claim hb
+        }),
+      );
+      // Agent-level heartbeat is FRESH — proves claim-hb is authoritative
+      await store.setAgentLastSeen('dead', now);
+
+      const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+      expect(freed).toBe(1);
+
+      const claim = await store.getClaim('task-1:dead:review');
+      expect(claim?.status).toBe('error');
+    });
+
+    it('falls back to agent-level heartbeat when claim-hb is absent (#783 back-compat)', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ review_claims: 1, queue: 'review' }));
+      // Old claim created before the heartbeat feature — no last_heartbeat_at
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:old:review',
+          agent_id: 'old',
+          role: 'review',
+          created_at: now - 600_000,
+        }),
+      );
+      // Fresh agent-level heartbeat keeps it alive
+      await store.setAgentLastSeen('old', now - 60_000);
+
+      const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+      expect(freed).toBe(0);
+
+      const claim = await store.getClaim('task-1:old:review');
+      expect(claim?.status).toBe('pending');
+    });
+
+    it('reclaims when claim-hb absent and agent-hb stale (#783 back-compat)', async () => {
+      const now = Date.now();
+      await store.createTask(makeTask({ review_claims: 1, queue: 'review' }));
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:old-stale:review',
+          agent_id: 'old-stale',
+          role: 'review',
+          created_at: now - 600_000,
+        }),
+      );
+      await store.setAgentLastSeen('old-stale', now - 600_000);
+
+      const freed = await store.reclaimAbandonedClaims(STALE_THRESHOLD);
+      expect(freed).toBe(1);
+
+      const claim = await store.getClaim('task-1:old-stale:review');
+      expect(claim?.status).toBe('error');
+    });
+  });
+
+  // ── updateClaimHeartbeat ────────────────────────────────────
+
+  describe('updateClaimHeartbeat', () => {
+    it('updates last_heartbeat_at on a pending claim', async () => {
+      await store.createTask(makeTask());
+      await store.createClaim(makeClaim({ id: 'task-1:a:review', agent_id: 'a', role: 'review' }));
+
+      const ts = Date.now();
+      const ok = await store.updateClaimHeartbeat('task-1:a:review', ts);
+      expect(ok).toBe(true);
+
+      const claim = await store.getClaim('task-1:a:review');
+      expect(claim?.last_heartbeat_at).toBe(ts);
+    });
+
+    it('returns false for a non-existent claim', async () => {
+      const ok = await store.updateClaimHeartbeat('missing', Date.now());
+      expect(ok).toBe(false);
+    });
+
+    it('returns false for a terminal claim (does not touch the timestamp)', async () => {
+      await store.createTask(makeTask());
+      await store.createClaim(
+        makeClaim({
+          id: 'task-1:a:review',
+          agent_id: 'a',
+          role: 'review',
+          status: 'completed',
+          last_heartbeat_at: 1,
+        }),
+      );
+
+      const ok = await store.updateClaimHeartbeat('task-1:a:review', 9999);
+      expect(ok).toBe(false);
+
+      const claim = await store.getClaim('task-1:a:review');
+      expect(claim?.last_heartbeat_at).toBe(1); // unchanged
+    });
   });
 
   // ── reclaimAbandonedSummarySlots ────────────────────────────

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -58,6 +58,7 @@ import {
   ResultRequestSchema,
   RejectRequestSchema,
   ErrorRequestSchema,
+  HeartbeatRequestSchema,
   REVIEW_TEXT_MIN_LENGTH,
   REVIEW_TEXT_MAX_LENGTH,
 } from '../schemas.js';
@@ -1834,6 +1835,41 @@ export function taskRoutes() {
       role: claim.role,
       error,
     });
+    return c.json({ success: true });
+  });
+
+  // ── Heartbeat ──────────────────────────────────────────────────
+  //
+  // Keeps both agent-level and per-claim liveness fresh while a long-running
+  // tool is executing. Without this, a claim that runs >CLAIM_STALE_THRESHOLD_MS
+  // gets reclaimed as 'error' by reclaimAbandonedClaims even though the agent
+  // is still working — see #783.
+
+  app.post('/api/tasks/:taskId/heartbeat', rateLimitByAgent(MUTATION_RATE_LIMIT), async (c) => {
+    const store = c.get('store');
+    const taskId = c.req.param('taskId');
+    const body = await parseBody(c, HeartbeatRequestSchema);
+    if (body instanceof Response) return body;
+    const { agent_id, role } = body;
+
+    // Use the role-aware claim ID directly so we only heartbeat the specific
+    // claim the caller identified (vs. findClaimForAgent, which searches all
+    // roles — overkill here and would mask callers pointing at the wrong
+    // claim).
+    const claimId = `${taskId}:${agent_id}:${role}`;
+    const now = Date.now();
+    const updated = await store.updateClaimHeartbeat(claimId, now);
+    if (!updated) {
+      // Either no claim, or claim already terminal (completed/rejected/error).
+      // Safe for stale/racing heartbeats from a CLI that hasn't yet noticed
+      // the server-side transition.
+      return apiError(c, 404, 'CLAIM_NOT_FOUND', 'No active claim for this task + agent + role');
+    }
+
+    // Also refresh the agent-level heartbeat so the existing fallback path
+    // (claims with NULL last_heartbeat_at) benefits from the same ping.
+    await store.setAgentLastSeen(agent_id, now);
+
     return c.json({ success: true });
   });
 

--- a/packages/server/src/schemas.ts
+++ b/packages/server/src/schemas.ts
@@ -160,6 +160,11 @@ export const ErrorRequestSchema = z.object({
   error: z.string().min(1, 'error must be a non-empty string'),
 });
 
+export const HeartbeatRequestSchema = z.object({
+  agent_id: agentIdSchema,
+  role: taskRoleSchema,
+});
+
 // ── Auth schemas ────────────────────────────────────────────────
 
 export const DeviceFlowTokenRequestSchema = z.object({

--- a/packages/server/src/store/d1.ts
+++ b/packages/server/src/store/d1.ts
@@ -92,6 +92,7 @@ interface ClaimRow {
   github_user_id: number | null;
   github_username: string | null;
   created_at: number;
+  last_heartbeat_at: number | null;
 }
 
 /** Convert a D1 row to a ReviewTask object. */
@@ -164,6 +165,9 @@ export function rowToClaim(row: ClaimRow): TaskClaim {
   if (row.tokens_used !== null) claim.tokens_used = row.tokens_used;
   if (row.github_user_id !== null) claim.github_user_id = row.github_user_id;
   if (row.github_username !== null) claim.github_username = row.github_username;
+  if (row.last_heartbeat_at !== null && row.last_heartbeat_at !== undefined) {
+    claim.last_heartbeat_at = row.last_heartbeat_at;
+  }
 
   return claim;
 }
@@ -572,6 +576,17 @@ export class D1DataStore implements DataStore {
       .run();
   }
 
+  async updateClaimHeartbeat(claimId: string, timestamp: number): Promise<boolean> {
+    // Guard on `status = ?` (not inlined 'pending') so the WHERE matches
+    // terminal claims atomically — a race could flip the claim to
+    // completed/rejected/error between the route's lookup and this UPDATE.
+    const result = await this.db
+      .prepare(`UPDATE claims SET last_heartbeat_at = ? WHERE id = ? AND status = ?`)
+      .bind(timestamp, claimId, 'pending')
+      .run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
   // ── Generic task claiming (new separate task model) ─────────
 
   async claimTask(taskId: string): Promise<boolean> {
@@ -849,8 +864,13 @@ export class D1DataStore implements DataStore {
   async reclaimAbandonedClaims(staleThresholdMs: number): Promise<number> {
     const cutoff = Date.now() - staleThresholdMs;
 
-    // Find pending claims where the agent's heartbeat is stale, OR where the agent
-    // has no heartbeat and the claim itself is older than the threshold.
+    // Reclaim order of precedence (per #783):
+    //  1. `c.last_heartbeat_at` — per-claim liveness beat while a tool runs.
+    //     If present and >= cutoff, the claim is active; never reclaim.
+    //     If present and < cutoff, reclaim.
+    //  2. `h.last_seen` (agent-level) — fallback when claim-hb is NULL (old
+    //     CLIs that don't call /heartbeat). Preserves prior behavior.
+    //  3. `c.created_at` — last-resort when agent has never been seen.
     const staleResult = await this.db
       .prepare(
         `SELECT c.id, c.task_id, c.role, c.agent_id
@@ -858,11 +878,17 @@ export class D1DataStore implements DataStore {
          LEFT JOIN agent_heartbeats h ON c.agent_id = h.agent_id
          WHERE c.status = 'pending'
            AND (
-             (h.last_seen IS NOT NULL AND h.last_seen < ?)
-             OR (h.last_seen IS NULL AND c.created_at < ?)
+             (c.last_heartbeat_at IS NOT NULL AND c.last_heartbeat_at < ?)
+             OR (
+               c.last_heartbeat_at IS NULL
+               AND (
+                 (h.last_seen IS NOT NULL AND h.last_seen < ?)
+                 OR (h.last_seen IS NULL AND c.created_at < ?)
+               )
+             )
            )`,
       )
-      .bind(cutoff, cutoff)
+      .bind(cutoff, cutoff, cutoff)
       .all<{ id: string; task_id: string; role: string; agent_id: string }>();
 
     const staleClaims = staleResult.results ?? [];

--- a/packages/server/src/store/interface.ts
+++ b/packages/server/src/store/interface.ts
@@ -63,6 +63,13 @@ export interface DataStore {
   getClaimsBatch(claimIds: string[]): Promise<Map<string, TaskClaim>>;
   getClaims(taskId: string): Promise<TaskClaim[]>;
   updateClaim(claimId: string, updates: Partial<TaskClaim>): Promise<void>;
+  /**
+   * Refresh per-claim liveness timestamp. Only succeeds on claims that are
+   * still `pending` — returns false if the claim doesn't exist or has
+   * already transitioned to a terminal state, so the route can map the
+   * result to a 404 for stale/racing callers.
+   */
+  updateClaimHeartbeat(claimId: string, timestamp: number): Promise<boolean>;
 
   // ── Generic task claiming (new separate task model) ────────
   /** Atomically transition a task from pending → reviewing. Returns true if claimed. */

--- a/packages/server/src/store/memory.ts
+++ b/packages/server/src/store/memory.ts
@@ -249,6 +249,13 @@ export class MemoryDataStore implements DataStore {
     }
   }
 
+  async updateClaimHeartbeat(claimId: string, timestamp: number): Promise<boolean> {
+    const claim = this.claims.get(claimId);
+    if (!claim || claim.status !== 'pending') return false;
+    claim.last_heartbeat_at = timestamp;
+    return true;
+  }
+
   // ── Generic task claiming (new separate task model) ─────────
 
   async claimTask(taskId: string): Promise<boolean> {
@@ -471,14 +478,21 @@ export class MemoryDataStore implements DataStore {
 
     for (const claim of this.claims.values()) {
       if (claim.status !== 'pending') continue;
-      const lastSeen = this.agentLastSeen.get(claim.agent_id);
-      // Reclaim if agent has a stale heartbeat, OR if no heartbeat exists
-      // and the claim itself is older than the threshold.
-      if (lastSeen !== undefined) {
-        if (lastSeen >= cutoff) continue; // Agent is active
+      // Reclaim precedence (per #783):
+      //  1. Per-claim last_heartbeat_at — authoritative when present.
+      //  2. Agent-level last_seen — fallback for old CLIs that don't send
+      //     /heartbeat (claim-hb is undefined).
+      //  3. claim.created_at — last resort when agent has never checked in.
+      if (claim.last_heartbeat_at !== undefined) {
+        if (claim.last_heartbeat_at >= cutoff) continue; // Active per-claim
       } else {
-        // No heartbeat — only reclaim if the claim itself is old
-        if (claim.created_at >= cutoff) continue;
+        const lastSeen = this.agentLastSeen.get(claim.agent_id);
+        if (lastSeen !== undefined) {
+          if (lastSeen >= cutoff) continue; // Agent is active
+        } else {
+          // No heartbeat — only reclaim if the claim itself is old
+          if (claim.created_at >= cutoff) continue;
+        }
       }
       claim.status = 'error';
       const task = this.tasks.get(claim.task_id);

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -164,6 +164,25 @@ export interface ErrorRequest {
   error: string;
 }
 
+// ── Heartbeat ──────────────────────────────────────────────────
+
+/**
+ * POST /api/tasks/{taskId}/heartbeat — request
+ *
+ * Keeps both the agent-level heartbeat and the active claim's per-claim
+ * `last_heartbeat_at` fresh while a long-running tool is executing, so
+ * `reclaimAbandonedClaims` does not mark the claim as `error` mid-run.
+ */
+export interface HeartbeatRequest {
+  agent_id: string;
+  role: TaskRole;
+}
+
+/** POST /api/tasks/{taskId}/heartbeat — success response */
+export interface HeartbeatResponse {
+  success: true;
+}
+
 // ── Registry ───────────────────────────────────────────────────
 
 /** Tool entry in the platform registry */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,6 +47,8 @@ export type {
   ResultResponse,
   RejectRequest,
   ErrorRequest,
+  HeartbeatRequest,
+  HeartbeatResponse,
   ToolRegistryEntry,
   ModelRegistryEntry,
   RegistryResponse,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -162,6 +162,13 @@ export interface TaskClaim {
   github_user_id?: number; // verified GitHub user ID from OAuth (optional for backward compat)
   github_username?: string; // verified GitHub username from OAuth (optional for backward compat)
   created_at: number;
+  /**
+   * Per-claim liveness signal updated by POST /api/tasks/:taskId/heartbeat
+   * while the agent is executing a tool. Absent (NULL in D1) for claims
+   * created before the heartbeat feature landed — reclaim falls back to
+   * the agent-level heartbeat in that case.
+   */
+  last_heartbeat_at?: number;
 }
 
 // ── Dedup Report Types ──────────────────────────────────────────


### PR DESCRIPTION
Part of #783

## Summary
- `POST /api/tasks/:taskId/heartbeat { agent_id, role }` refreshes both the agent-level `last_seen` and a new per-claim `last_heartbeat_at` on each call. Rate-limited like other mutation endpoints.
- Adds `claims.last_heartbeat_at` column (migration `0019_claims_heartbeat.sql`) + mirror field in `MemoryDataStore` and `TaskClaim`.
- `reclaimAbandonedClaims` now prefers per-claim heartbeat when present; falls back to agent-level heartbeat when the column is NULL (old claims, old CLIs). Behavior unchanged for pre-existing rows.
- `DataStore.updateClaimHeartbeat(claimId, timestamp)` only touches claims in `status = 'pending'` so a terminal transition cannot be overwritten by a racing heartbeat.
- Pairs with CLI-side #782 (the CLI will call this endpoint periodically during `executeTool`). Old CLIs that do not call the endpoint still work via the agent-level fallback — no regression.

### Root cause recap
`reclaimAbandonedClaims` only checked `agent_heartbeats.last_seen`, which the CLI only refreshed at claim-create and result-submit. A 13–30 min review would cross `CLAIM_STALE_THRESHOLD_MS` (10 min) and be reclaimed as `error` mid-run; the final submit then 409'd with "Claim already error".

## Test plan
- [x] `pnpm build` — passes (shared + server + cli + docs)
- [x] `pnpm test` — 3015/3015 passing
- [x] `pnpm lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run typecheck` — clean
- [x] Server coverage: `memory.ts 99.65%`, `tasks.ts 89.27%` (new route + logic fully covered)
- New tests:
  - `store-memory.test.ts` — 4 new scenarios covering fresh/stale per-claim heartbeat vs. fresh/stale agent heartbeat, plus updateClaimHeartbeat happy path / missing / terminal.
  - `store-d1.test.ts` — updateClaimHeartbeat happy path / missing / terminal (LEFT JOIN mock limitation noted in existing file; reclaim business logic covered by Memory tests).
  - `routes-tasks.test.ts` — 200 happy path, 404 missing claim, 404 terminal claim, 400 invalid body (×2), idempotent repeat, role scoping (review heartbeat must not touch summary claim).

## Deployment
Migration 0019 is additive; existing rows get NULL and fall through to the agent-level fallback path. Safe to deploy before cli-dev #782 ships.