### PR TITLE
[cli-dev] Periodic heartbeat during long-running tool execution

### DIFF
--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -16,7 +16,7 @@ import { startAgent, type ConsumptionDeps } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
 import { createSessionTracker } from '../consumption.js';
 import { FakeServer, FAKE_SERVER_URL } from './helpers/fake-server.js';
-import { executeTool } from '../tool-executor.js';
+import { executeTool, startHeartbeatTimer } from '../tool-executor.js';
 import { checkoutWorktree, diffFromWorktree } from '../repo-cache.js';
 
 // ── Mock child_process so fetchDiffViaGh falls back to HTTP ──
@@ -92,6 +92,7 @@ vi.mock('../tool-executor.js', () => ({
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
   DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
+  startHeartbeatTimer: vi.fn(() => () => {}),
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);
@@ -1119,6 +1120,61 @@ describe('Agent Coverage Tests', () => {
         expect(resultBody!.type).toBe('summary');
 
         await server.store.updateTask(summaryTaskId, { status: 'completed' });
+        await stopAgent(promise, server);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('arms a heartbeat around router-mode sendPrompt (regression for #782)', async () => {
+      // Router mode skips executeReview → executeTool, so the heartbeat must
+      // be armed explicitly around routerRelay.sendPrompt via runWithHeartbeat
+      // (which delegates to startHeartbeatTimer). The mocked startHeartbeatTimer
+      // spy records each call.
+      const taskId = await server.injectTask({ reviewCount: 2 });
+      const mockRelay = createMockRouterRelay();
+
+      const mockedStartHeartbeat = vi.mocked(startHeartbeatTimer);
+      mockedStartHeartbeat.mockClear();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes(`/api/tasks/${taskId}/result`)) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+
+      try {
+        const deps = makeDeps('router-heartbeat-agent');
+        const promise = startAgent(
+          'router-heartbeat-agent',
+          FAKE_SERVER_URL,
+          { model: 'test', tool: 'test' },
+          deps.reviewDeps,
+          deps.consumptionDeps,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { pollIntervalMs: 100, routerRelay: mockRelay as any },
+        );
+
+        await advanceTime(2000);
+
+        expect(mockRelay.sendPrompt).toHaveBeenCalled();
+        // `runWithHeartbeat` → `startHeartbeatTimer` must have been called
+        // with a defined HeartbeatControl (wiring confirmed).
+        const heartbeatCalls = mockedStartHeartbeat.mock.calls.filter((c) => c[0] !== undefined);
+        expect(heartbeatCalls.length).toBeGreaterThan(0);
+        // Each call's first arg should be a HeartbeatControl (callback + intervalMs).
+        for (const call of heartbeatCalls) {
+          expect(call[0]).toMatchObject({
+            callback: expect.any(Function),
+            intervalMs: expect.any(Number),
+          });
+        }
+
+        await server.store.updateTask(taskId, { status: 'completed' });
         await stopAgent(promise, server);
       } finally {
         globalThis.fetch = originalFetch;

--- a/packages/cli/src/__tests__/agent-coverage.test.ts
+++ b/packages/cli/src/__tests__/agent-coverage.test.ts
@@ -91,6 +91,7 @@ vi.mock('../tool-executor.js', () => ({
   validateCommandBinary: vi.fn(() => true),
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
+  DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1,9 +1,18 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { startAgent, computeRoles, type ConsumptionDeps } from '../commands/agent.js';
+import {
+  startAgent,
+  computeRoles,
+  createHeartbeatControl,
+  isLongRunningRole,
+  type ConsumptionDeps,
+} from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
 import type { RouterRelay } from '../router.js';
 import { createSessionTracker } from '../consumption.js';
 import type { LocalAgentConfig } from '../config.js';
+import { HttpError, type ApiClient } from '../http.js';
+import { DEFAULT_HEARTBEAT_INTERVAL_MS } from '../tool-executor.js';
+import type { Logger } from '../logger.js';
 
 // Mock child_process so fetchDiffViaGh falls back to HTTP
 vi.mock('node:child_process', async (importOriginal) => {
@@ -1091,5 +1100,118 @@ describe('computeRoles', () => {
       roles: undefined,
     };
     expect(computeRoles(agent)).toEqual(['review', 'summary', 'implement', 'fix']);
+  });
+});
+
+describe('isLongRunningRole', () => {
+  it('returns true for review, summary, implement, fix', () => {
+    expect(isLongRunningRole('review')).toBe(true);
+    expect(isLongRunningRole('summary')).toBe(true);
+    expect(isLongRunningRole('implement')).toBe(true);
+    expect(isLongRunningRole('fix')).toBe(true);
+  });
+
+  it('returns false for short-running roles', () => {
+    expect(isLongRunningRole('pr_triage')).toBe(false);
+    expect(isLongRunningRole('issue_triage')).toBe(false);
+    expect(isLongRunningRole('pr_dedup')).toBe(false);
+    expect(isLongRunningRole('issue_dedup')).toBe(false);
+    expect(isLongRunningRole('issue_review')).toBe(false);
+  });
+});
+
+describe('createHeartbeatControl', () => {
+  function makeLogger(): Logger {
+    return {
+      log: vi.fn(),
+      logWarn: vi.fn(),
+      logError: vi.fn(),
+    } as unknown as Logger;
+  }
+
+  function makeClient(post: ReturnType<typeof vi.fn>): ApiClient {
+    return { post } as unknown as ApiClient;
+  }
+
+  it('posts to /api/tasks/:id/heartbeat with agent_id and role', async () => {
+    const post = vi.fn().mockResolvedValue({});
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(
+      makeClient(post),
+      'task-abc',
+      'agent-42',
+      'review',
+      logger,
+      1000,
+    );
+
+    expect(hb.intervalMs).toBe(1000);
+    await hb.callback();
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/api/tasks/task-abc/heartbeat', {
+      agent_id: 'agent-42',
+      role: 'review',
+    });
+    expect(logger.logWarn).not.toHaveBeenCalled();
+  });
+
+  it('silently swallows 404 (old server) and logs the no-op once', async () => {
+    const post = vi.fn().mockRejectedValue(new HttpError(404, 'not found'));
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'summary', logger);
+
+    await expect(hb.callback()).resolves.toBeUndefined();
+    await expect(hb.callback()).resolves.toBeUndefined();
+    await expect(hb.callback()).resolves.toBeUndefined();
+
+    // Post is still attempted each tick (server may be upgraded mid-run)
+    expect(post).toHaveBeenCalledTimes(3);
+    // ...but the operator-visible log only fires once
+    expect(logger.log).toHaveBeenCalledTimes(1);
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('heartbeat endpoint not available'),
+    );
+    expect(logger.logWarn).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning but does not throw on transient 5xx errors', async () => {
+    const post = vi.fn().mockRejectedValue(new HttpError(503, 'service unavailable'));
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(
+      makeClient(post),
+      'task-abc',
+      'agent-42',
+      'implement',
+      logger,
+    );
+
+    await expect(hb.callback()).resolves.toBeUndefined();
+    expect(logger.logWarn).toHaveBeenCalledTimes(1);
+    expect(logger.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Heartbeat failed for task task-abc'),
+    );
+  });
+
+  it('logs a warning but does not throw on network errors', async () => {
+    const post = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'fix', logger);
+
+    await expect(hb.callback()).resolves.toBeUndefined();
+    expect(logger.logWarn).toHaveBeenCalledTimes(1);
+    expect(logger.logWarn).toHaveBeenCalledWith(expect.stringContaining('ECONNREFUSED'));
+  });
+
+  it('uses DEFAULT_HEARTBEAT_INTERVAL_MS when intervalMs is omitted', () => {
+    const post = vi.fn();
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'review', logger);
+    expect(hb.intervalMs).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
   });
 });

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -1207,6 +1207,49 @@ describe('createHeartbeatControl', () => {
     expect(logger.logWarn).toHaveBeenCalledWith(expect.stringContaining('ECONNREFUSED'));
   });
 
+  it('suppresses repeated warnings during a failure streak (keeps POSTing)', async () => {
+    const post = vi.fn().mockRejectedValue(new HttpError(503, 'service unavailable'));
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'review', logger);
+
+    await hb.callback();
+    await hb.callback();
+    await hb.callback();
+    await hb.callback();
+
+    // POST still attempted every tick — the server may recover mid-run.
+    expect(post).toHaveBeenCalledTimes(4);
+    // But the warn fires only once per streak.
+    expect(logger.logWarn).toHaveBeenCalledTimes(1);
+    expect(logger.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('further failures suppressed'),
+    );
+  });
+
+  it('re-enables the warning after a successful heartbeat resets the streak', async () => {
+    // Fail → fail → succeed → fail → fail → succeed → fail
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(new HttpError(503, 'boom')) // warn #1
+      .mockRejectedValueOnce(new HttpError(503, 'boom')) // suppressed
+      .mockResolvedValueOnce({}) // resets gate
+      .mockRejectedValueOnce(new Error('ECONNRESET')) // warn #2
+      .mockRejectedValueOnce(new Error('ECONNRESET')) // suppressed
+      .mockResolvedValueOnce({}) // resets gate
+      .mockRejectedValueOnce(new HttpError(502, 'bad gateway')); // warn #3
+    const logger = makeLogger();
+
+    const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'summary', logger);
+
+    for (let i = 0; i < 7; i++) {
+      await hb.callback();
+    }
+
+    expect(post).toHaveBeenCalledTimes(7);
+    expect(logger.logWarn).toHaveBeenCalledTimes(3);
+  });
+
   it('uses DEFAULT_HEARTBEAT_INTERVAL_MS when intervalMs is omitted', () => {
     const post = vi.fn();
     const logger = makeLogger();

--- a/packages/cli/src/__tests__/agent.test.ts
+++ b/packages/cli/src/__tests__/agent.test.ts
@@ -4,6 +4,7 @@ import {
   computeRoles,
   createHeartbeatControl,
   isLongRunningRole,
+  runWithHeartbeat,
   type ConsumptionDeps,
 } from '../commands/agent.js';
 import type { ReviewExecutorDeps } from '../review.js';
@@ -1256,5 +1257,69 @@ describe('createHeartbeatControl', () => {
 
     const hb = createHeartbeatControl(makeClient(post), 'task-abc', 'agent-42', 'review', logger);
     expect(hb.intervalMs).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+  });
+});
+
+describe('runWithHeartbeat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires heartbeat ticks for the duration of the wrapped work', async () => {
+    const cb = vi.fn();
+    let resolveWork: (v: string) => void = () => {};
+    const work = new Promise<string>((resolve) => {
+      resolveWork = resolve;
+    });
+
+    const promise = runWithHeartbeat({ callback: cb, intervalMs: 50 }, () => work);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(3);
+
+    resolveWork('done');
+    const result = await promise;
+    expect(result).toBe('done');
+
+    // After work resolves, the interval is cleared — no more ticks
+    vi.advanceTimersByTime(500);
+    expect(cb).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears the interval when work rejects', async () => {
+    const cb = vi.fn();
+    let rejectWork: (e: Error) => void = () => {};
+    const work = new Promise<string>((_, reject) => {
+      rejectWork = reject;
+    });
+
+    const promise = runWithHeartbeat({ callback: cb, intervalMs: 50 }, () => work);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    rejectWork(new Error('work failed'));
+    await expect(promise).rejects.toThrow('work failed');
+
+    vi.advanceTimersByTime(500);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a no-op when heartbeat is undefined', async () => {
+    const result = await runWithHeartbeat(undefined, async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('passes through the return value of work', async () => {
+    const cb = vi.fn();
+    const result = await runWithHeartbeat({ callback: cb, intervalMs: 50 }, async () => ({
+      x: 1,
+    }));
+    expect(result).toEqual({ x: 1 });
   });
 });

--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -79,6 +79,7 @@ vi.mock('../tool-executor.js', () => ({
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
   DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
+  startHeartbeatTimer: vi.fn(() => () => {}),
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);

--- a/packages/cli/src/__tests__/cli-server-integration.test.ts
+++ b/packages/cli/src/__tests__/cli-server-integration.test.ts
@@ -78,6 +78,7 @@ vi.mock('../tool-executor.js', () => ({
   validateCommandBinary: () => true,
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
+  DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -64,6 +64,7 @@ vi.mock('../tool-executor.js', () => ({
   validateCommandBinary: () => true,
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
+  DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);

--- a/packages/cli/src/__tests__/e2e-agent.test.ts
+++ b/packages/cli/src/__tests__/e2e-agent.test.ts
@@ -65,6 +65,7 @@ vi.mock('../tool-executor.js', () => ({
   parseCommandTemplate: (cmd: string) => cmd.split(' '),
   testCommand: vi.fn(async () => ({ ok: true, elapsedMs: 100 })),
   DEFAULT_HEARTBEAT_INTERVAL_MS: 60_000,
+  startHeartbeatTimer: vi.fn(() => () => {}),
 }));
 
 const mockedExecuteTool = vi.mocked(executeTool);

--- a/packages/cli/src/__tests__/implement.test.ts
+++ b/packages/cli/src/__tests__/implement.test.ts
@@ -271,6 +271,8 @@ describe('executeImplement', () => {
       undefined,
       undefined,
       '/tmp/worktree',
+      undefined,
+      undefined,
     );
     expect(result.output.summary).toBe('Added feature');
     expect(result.output.filesChanged).toEqual(['src/app.ts']);
@@ -397,6 +399,8 @@ describe('executeImplementTask', () => {
       undefined,
       undefined,
       '/tmp/repos/acme/widgets-worktrees/implement-42',
+      undefined,
+      undefined,
     );
 
     // Verify commit and push

--- a/packages/cli/src/__tests__/review.test.ts
+++ b/packages/cli/src/__tests__/review.test.ts
@@ -376,6 +376,7 @@ describe('executeReview', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     // Prompt should contain both system and user content
     const prompt = mockRunTool.mock.calls[0][1];

--- a/packages/cli/src/__tests__/summary.test.ts
+++ b/packages/cli/src/__tests__/summary.test.ts
@@ -388,6 +388,7 @@ describe('executeSummary', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
   });
 

--- a/packages/cli/src/__tests__/tool-executor.test.ts
+++ b/packages/cli/src/__tests__/tool-executor.test.ts
@@ -9,6 +9,7 @@ import {
   SIGKILL_GRACE_MS,
   STDOUT_LIVENESS_TIMEOUT_MS,
   DEFAULT_HEARTBEAT_INTERVAL_MS,
+  startHeartbeatTimer,
 } from '../tool-executor.js';
 
 import EventEmitter from 'node:events';
@@ -1161,5 +1162,96 @@ describe('parseTokenUsage', () => {
       input: 0,
       output: 0,
     });
+  });
+});
+
+describe('startHeartbeatTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires callback on the configured interval', () => {
+    const cb = vi.fn();
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 50 });
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it('uses DEFAULT_HEARTBEAT_INTERVAL_MS when intervalMs is omitted', () => {
+    const cb = vi.fn();
+    const stop = startHeartbeatTimer({ callback: cb });
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS - 1);
+    expect(cb).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('returns a no-op stopper when heartbeat is undefined', () => {
+    const stop = startHeartbeatTimer(undefined);
+    expect(() => stop()).not.toThrow();
+    // No timers were scheduled, so nothing to assert beyond "did not crash"
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 5);
+  });
+
+  it('returns a no-op stopper when intervalMs is 0', () => {
+    const cb = vi.fn();
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 0 });
+    vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 5);
+    expect(cb).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('stop() clears the interval and halts further firings', () => {
+    const cb = vi.fn();
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 50 });
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(1);
+    stop();
+    vi.advanceTimersByTime(500);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips ticks when isSettled() returns true', () => {
+    const cb = vi.fn();
+    let settled = false;
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 50 }, () => settled);
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(1);
+    settled = true;
+    vi.advanceTimersByTime(150); // 3 ticks, but all suppressed
+    expect(cb).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('swallows synchronous throws from the callback', () => {
+    const cb = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 50 });
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    expect(cb).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it('swallows rejected promises from the callback', async () => {
+    const cb = vi.fn(async () => {
+      throw new Error('async boom');
+    });
+    const stop = startHeartbeatTimer({ callback: cb, intervalMs: 50 });
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(cb).toHaveBeenCalledTimes(2);
+    stop();
   });
 });

--- a/packages/cli/src/__tests__/tool-executor.test.ts
+++ b/packages/cli/src/__tests__/tool-executor.test.ts
@@ -8,6 +8,7 @@ import {
   ToolTimeoutError,
   SIGKILL_GRACE_MS,
   STDOUT_LIVENESS_TIMEOUT_MS,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
 } from '../tool-executor.js';
 
 import EventEmitter from 'node:events';
@@ -751,6 +752,320 @@ describe('executeTool', () => {
 
       // Should report main timeout, not liveness
       await expect(promise).rejects.toThrow(/timed out after 60s/);
+    });
+  });
+
+  describe('heartbeat', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('fires callback on the configured interval while the tool is running', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const intervalMs = 60_000;
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0, // disable liveness to isolate heartbeat behavior
+        { callback: heartbeat, intervalMs },
+      );
+
+      // No ticks have fired yet
+      expect(heartbeat).not.toHaveBeenCalled();
+
+      // Tick 1
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+
+      // Tick 2
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(2);
+
+      // Tick 3
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(3);
+
+      // Finish the tool — interval must stop firing
+      emitOutput(child, { stdout: 'done', code: 0 });
+      await promise;
+
+      // Advance further — NO more heartbeats after tool exit
+      vi.advanceTimersByTime(intervalMs * 5);
+      expect(heartbeat).toHaveBeenCalledTimes(3);
+    });
+
+    it('uses DEFAULT_HEARTBEAT_INTERVAL_MS when intervalMs is omitted', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat },
+      );
+
+      vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS - 1);
+      expect(heartbeat).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+
+      emitOutput(child, { stdout: 'done', code: 0 });
+      await promise;
+    });
+
+    it('is a no-op when no heartbeat is supplied', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const promise = executeTool(
+        'quiet-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+      );
+
+      // No heartbeat config — just advance time and confirm nothing throws
+      vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 3);
+
+      emitOutput(child, { stdout: 'done', code: 0 });
+      const result = await promise;
+      expect(result.stdout).toBe('done');
+    });
+
+    it('is disabled when intervalMs is 0', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs: 0 },
+      );
+
+      vi.advanceTimersByTime(DEFAULT_HEARTBEAT_INTERVAL_MS * 5);
+      expect(heartbeat).not.toHaveBeenCalled();
+
+      emitOutput(child, { stdout: 'done', code: 0 });
+      await promise;
+    });
+
+    it('stops firing after the tool exits with an error', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const intervalMs = 60_000;
+      const promise = executeTool(
+        'broken-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs },
+      );
+
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+
+      // Simulate tool crash
+      child.emit('error', new Error('ENOENT: tool missing'));
+      await expect(promise).rejects.toThrow('ENOENT');
+
+      // Advance further — interval must be cleared
+      vi.advanceTimersByTime(intervalMs * 3);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops firing after the tool is killed by timeout', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const intervalMs = 60_000;
+      const timeoutMs = 30_000;
+      const promise = executeTool(
+        'stuck-tool',
+        'test',
+        timeoutMs,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs },
+      );
+
+      // Timeout fires before first heartbeat (interval > timeout)
+      vi.advanceTimersByTime(timeoutMs);
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(heartbeat).not.toHaveBeenCalled();
+
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+      await expect(promise).rejects.toThrow(ToolTimeoutError);
+
+      // Advance past interval — interval must be cleared
+      vi.advanceTimersByTime(intervalMs * 3);
+      expect(heartbeat).not.toHaveBeenCalled();
+    });
+
+    it('stops firing after the abort signal is triggered', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const intervalMs = 60_000;
+      const controller = new AbortController();
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        controller.signal,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs },
+      );
+
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+
+      controller.abort();
+      emitOutput(child, { code: null, signal: 'SIGTERM' });
+      await expect(promise).rejects.toThrow(ToolTimeoutError);
+
+      // Advance further — interval must be cleared
+      vi.advanceTimersByTime(intervalMs * 3);
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows synchronous errors thrown from the callback without killing the tool', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn(() => {
+        throw new Error('boom');
+      });
+      const intervalMs = 60_000;
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs },
+      );
+
+      // Multiple ticks — each throws, but the tool keeps running and the
+      // interval keeps firing.
+      vi.advanceTimersByTime(intervalMs);
+      vi.advanceTimersByTime(intervalMs);
+      vi.advanceTimersByTime(intervalMs);
+      expect(heartbeat).toHaveBeenCalledTimes(3);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      emitOutput(child, { stdout: 'still works', code: 0 });
+      const result = await promise;
+      expect(result.stdout).toBe('still works');
+    });
+
+    it('swallows rejected promises from the callback without killing the tool', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn(async () => {
+        throw new Error('network blip');
+      });
+      const intervalMs = 60_000;
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        { callback: heartbeat, intervalMs },
+      );
+
+      // Fire two ticks — each returns a rejected promise. The executor must
+      // attach a .catch so the unhandled rejection does not propagate.
+      vi.advanceTimersByTime(intervalMs);
+      vi.advanceTimersByTime(intervalMs);
+      // Let the pending microtasks (the .catch handlers) settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(heartbeat).toHaveBeenCalledTimes(2);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      emitOutput(child, { stdout: 'ok', code: 0 });
+      const result = await promise;
+      expect(result.stdout).toBe('ok');
+    });
+
+    it('coexists with the liveness timer', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const heartbeat = vi.fn();
+      const intervalMs = 30_000;
+      const livenessMs = 60_000;
+      const promise = executeTool(
+        'long-tool',
+        'test',
+        600_000,
+        undefined,
+        undefined,
+        undefined,
+        livenessMs,
+        { callback: heartbeat, intervalMs },
+      );
+
+      vi.advanceTimersByTime(intervalMs);
+      child.stdout.emit('data', Buffer.from('progress'));
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(intervalMs);
+      child.stdout.emit('data', Buffer.from('more progress'));
+      expect(heartbeat).toHaveBeenCalledTimes(2);
+
+      // Tool exits cleanly — both timers must be cleared
+      emitOutput(child, { stdout: 'done', code: 0 });
+      await promise;
+
+      vi.advanceTimersByTime(intervalMs * 5 + livenessMs);
+      expect(heartbeat).toHaveBeenCalledTimes(2);
+      expect(child.kill).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -711,20 +711,26 @@ export function createHeartbeatControl(
   intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
 ): HeartbeatControl {
   let sawNotFound = false;
+  // Rate-limit the transient-failure warn: log on the first failure of a
+  // failing run, then stay silent until a success resets the counter. This
+  // avoids spamming operator logs every 60s when the endpoint is persistently
+  // misbehaving, while still surfacing the problem.
+  let failureStreakLogged = false;
   return {
     intervalMs,
     callback: async () => {
-      // Old server returned 404 last time — stop logging to avoid spam; the
-      // interval still fires cheaply but the POST is still attempted each tick
-      // in case the server is upgraded mid-run.
       try {
         await client.post(`/api/tasks/${taskId}/heartbeat`, {
           agent_id: agentId,
           role,
         });
+        // Success — reset the failure-streak gate so the next bad run logs again.
+        failureStreakLogged = false;
       } catch (err) {
         if (err instanceof HttpError && err.status === 404) {
-          // Old server: silent no-op. Log once for operator visibility.
+          // Old server: silent no-op. Log once for operator visibility;
+          // subsequent ticks still attempt the POST in case the server
+          // is upgraded mid-run, but stay quiet.
           if (!sawNotFound) {
             sawNotFound = true;
             logger.log(`  (heartbeat endpoint not available — old server, continuing)`);
@@ -732,9 +738,13 @@ export function createHeartbeatControl(
           return;
         }
         // Transient 4xx/5xx/network — log-and-continue. Never throw.
-        logger.logWarn(
-          `  ${icons.warn} Heartbeat failed for task ${taskId}: ${(err as Error).message}`,
-        );
+        // Only warn once per failure streak to avoid log spam.
+        if (!failureStreakLogged) {
+          failureStreakLogged = true;
+          logger.logWarn(
+            `  ${icons.warn} Heartbeat failed for task ${taskId}: ${(err as Error).message} (further failures suppressed until next success)`,
+          );
+        }
       }
     },
   };

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -65,6 +65,7 @@ import {
   validateCommandBinary,
   estimateTokens,
   testCommand,
+  startHeartbeatTimer,
   DEFAULT_HEARTBEAT_INTERVAL_MS,
   type HeartbeatControl,
 } from '../tool-executor.js';
@@ -702,6 +703,28 @@ export function isLongRunningRole(role: TaskRole): boolean {
  * tool. Old servers that don't implement this endpoint return 404, which is
  * treated as a silent no-op for the transition period.
  */
+/**
+ * Run `work()` with a heartbeat interval armed for its entire duration.
+ *
+ * Used to wrap async awaits that `executeTool` / `executeAgentic` can't cover
+ * — e.g. `routerRelay.sendPrompt(...)` in router mode, which bypasses the
+ * deps-wired heartbeat path. The interval is cleared whether `work` resolves
+ * or throws. A no-op when `heartbeat` is undefined.
+ */
+export async function runWithHeartbeat<T>(
+  heartbeat: HeartbeatControl | undefined,
+  work: () => Promise<T>,
+): Promise<T> {
+  let done = false;
+  const stop = startHeartbeatTimer(heartbeat, () => done);
+  try {
+    return await work();
+  } finally {
+    done = true;
+    stop();
+  }
+}
+
 export function createHeartbeatControl(
   client: ApiClient,
   taskId: string,
@@ -1281,7 +1304,10 @@ async function executeReviewTask(
   let usageOpts: RecordUsageOptions | undefined;
 
   if (routerRelay) {
-    // Router mode: relay to external agent
+    // Router mode: relay to external agent. `executeReview` → `executeTool`
+    // is skipped here, so the deps-wired heartbeat must be armed explicitly
+    // around the sendPrompt await (see issue #782 — router reviews on large
+    // PRs also exceed the 10-min CLAIM_STALE_THRESHOLD_MS).
     logger.log(`  ${icons.running} Executing review: [router mode]`);
     const fullPrompt = routerRelay.buildReviewPrompt({
       owner,
@@ -1291,11 +1317,8 @@ async function executeReviewTask(
       diffContent,
       contextBlock,
     });
-    const response = await routerRelay.sendPrompt(
-      'review_request',
-      taskId,
-      fullPrompt,
-      timeoutSeconds,
+    const response = await runWithHeartbeat(reviewDeps.heartbeat, () =>
+      routerRelay.sendPrompt('review_request', taskId, fullPrompt, timeoutSeconds),
     );
     const parsed = routerRelay.parseReviewResponse(response);
     reviewText = parsed.review;
@@ -1415,6 +1438,8 @@ async function executeSummaryTask(
     let usageOpts: RecordUsageOptions;
 
     if (routerRelay) {
+      // Router mode (single-agent summary): see executeReviewTask for the
+      // rationale — heartbeat must be armed around sendPrompt.
       logger.log(`  ${icons.running} Executing summary: [router mode]`);
       const fullPrompt = routerRelay.buildReviewPrompt({
         owner,
@@ -1424,11 +1449,8 @@ async function executeSummaryTask(
         diffContent,
         contextBlock,
       });
-      const response = await routerRelay.sendPrompt(
-        'review_request',
-        taskId,
-        fullPrompt,
-        timeoutSeconds,
+      const response = await runWithHeartbeat(reviewDeps.heartbeat, () =>
+        routerRelay.sendPrompt('review_request', taskId, fullPrompt, timeoutSeconds),
       );
       const parsed = routerRelay.parseReviewResponse(response);
       reviewText = parsed.review;
@@ -1526,6 +1548,8 @@ async function executeSummaryTask(
   let flaggedReviews: FlaggedReview[] = [];
 
   if (routerRelay) {
+    // Router mode (multi-agent summary): see executeReviewTask for the
+    // rationale — heartbeat must be armed around sendPrompt.
     logger.log(`  ${icons.running} Executing summary: [router mode]`);
     const fullPrompt = routerRelay.buildSummaryPrompt({
       owner,
@@ -1535,11 +1559,8 @@ async function executeSummaryTask(
       diffContent,
       contextBlock,
     });
-    const response = await routerRelay.sendPrompt(
-      'summary_request',
-      taskId,
-      fullPrompt,
-      timeoutSeconds,
+    const response = await runWithHeartbeat(reviewDeps.heartbeat, () =>
+      routerRelay.sendPrompt('summary_request', taskId, fullPrompt, timeoutSeconds),
     );
     const parsed = extractVerdict(response);
     summaryText = parsed.review;

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -61,7 +61,13 @@ import {
   InputTooLargeError,
   type FlaggedReview,
 } from '../summary.js';
-import { validateCommandBinary, estimateTokens, testCommand } from '../tool-executor.js';
+import {
+  validateCommandBinary,
+  estimateTokens,
+  testCommand,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  type HeartbeatControl,
+} from '../tool-executor.js';
 import { RouterRelay } from '../router.js';
 import {
   createSessionTracker,
@@ -679,6 +685,62 @@ interface HandleTaskResult {
 }
 
 /**
+ * Roles whose tool execution can exceed `CLAIM_STALE_THRESHOLD_MS` (10 min)
+ * and therefore require periodic heartbeats to stop the server from
+ * reclaiming their claim as `'error'`. Short-running roles (triage, dedup,
+ * issue_review) complete well under the threshold and do not need this.
+ */
+export function isLongRunningRole(role: TaskRole): boolean {
+  return isFixRole(role) || isImplementRole(role) || role === 'review' || role === 'summary';
+}
+
+/**
+ * Build a HeartbeatControl for a given task+agent.
+ *
+ * The callback POSTs `{ agent_id, role }` to `/api/tasks/:id/heartbeat`.
+ * Failures are swallowed — a broken heartbeat must never kill the in-flight
+ * tool. Old servers that don't implement this endpoint return 404, which is
+ * treated as a silent no-op for the transition period.
+ */
+export function createHeartbeatControl(
+  client: ApiClient,
+  taskId: string,
+  agentId: string,
+  role: TaskRole,
+  logger: Logger,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): HeartbeatControl {
+  let sawNotFound = false;
+  return {
+    intervalMs,
+    callback: async () => {
+      // Old server returned 404 last time — stop logging to avoid spam; the
+      // interval still fires cheaply but the POST is still attempted each tick
+      // in case the server is upgraded mid-run.
+      try {
+        await client.post(`/api/tasks/${taskId}/heartbeat`, {
+          agent_id: agentId,
+          role,
+        });
+      } catch (err) {
+        if (err instanceof HttpError && err.status === 404) {
+          // Old server: silent no-op. Log once for operator visibility.
+          if (!sawNotFound) {
+            sawNotFound = true;
+            logger.log(`  (heartbeat endpoint not available — old server, continuing)`);
+          }
+          return;
+        }
+        // Transient 4xx/5xx/network — log-and-continue. Never throw.
+        logger.logWarn(
+          `  ${icons.warn} Heartbeat failed for task ${taskId}: ${(err as Error).message}`,
+        );
+      }
+    },
+  };
+}
+
+/**
  * Handle a single task: claim → fetch diff → review → submit
  */
 async function handleTask(
@@ -876,6 +938,16 @@ async function handleTask(
     }
   }
 
+  // Build a heartbeat control for long-running roles only. The heartbeat
+  // POSTs to `/api/tasks/:id/heartbeat` every DEFAULT_HEARTBEAT_INTERVAL_MS
+  // while the tool is running, preventing the server from reclaiming an
+  // active claim as `'error'` (see issue #782). Short-running roles (triage,
+  // dedup, issue_review) complete well under CLAIM_STALE_THRESHOLD_MS and
+  // don't get one.
+  const heartbeat: HeartbeatControl | undefined = isLongRunningRole(role)
+    ? createHeartbeatControl(client, task_id, agentId, role, logger)
+    : undefined;
+
   // Execute review, summary, dedup, triage, fix, or implement
   try {
     if (isImplementRole(role)) {
@@ -883,6 +955,7 @@ async function handleTask(
       const implementDeps: ImplementExecutorDeps = {
         commandTemplate: reviewDeps.commandTemplate,
         codebaseDir,
+        heartbeat,
       };
       const implementResult = await executeImplementTask(
         client,
@@ -917,6 +990,7 @@ async function handleTask(
       }
       const fixDeps: FixExecutorDeps = {
         commandTemplate: reviewDeps.commandTemplate,
+        heartbeat,
       };
       const fixResult = await executeFixTask(
         client,
@@ -1030,6 +1104,7 @@ async function handleTask(
         { execGh: defaultExecGh },
       );
     } else if (role === 'summary' && 'reviews' in claimResponse && claimResponse.reviews) {
+      const summaryDeps: ReviewExecutorDeps = { ...taskReviewDeps, heartbeat };
       await executeSummaryTask(
         client,
         agentId,
@@ -1041,7 +1116,7 @@ async function handleTask(
         prompt,
         timeout_seconds,
         claimResponse.reviews,
-        taskReviewDeps,
+        summaryDeps,
         consumptionDeps,
         logger,
         agentInfo,
@@ -1051,6 +1126,7 @@ async function handleTask(
         verbose,
       );
     } else {
+      const reviewDepsWithHeartbeat: ReviewExecutorDeps = { ...taskReviewDeps, heartbeat };
       await executeReviewTask(
         client,
         agentId,
@@ -1061,7 +1137,7 @@ async function handleTask(
         diffContent,
         prompt,
         timeout_seconds,
-        taskReviewDeps,
+        reviewDepsWithHeartbeat,
         consumptionDeps,
         logger,
         agentInfo,

--- a/packages/cli/src/fix.ts
+++ b/packages/cli/src/fix.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import type { PollTask, FixReport } from '@opencara/shared';
 import type { ToolExecutorResult, TokenUsageDetail } from './tool-executor.js';
-import { executeTool, estimateTokens } from './tool-executor.js';
+import { executeTool, estimateTokens, type HeartbeatControl } from './tool-executor.js';
 import { sanitizeTokens } from './sanitize.js';
 import type { Logger } from './logger.js';
 import { buildFixPrompt } from './prompts.js';
@@ -106,6 +106,8 @@ export interface FixResponse {
 
 export interface FixExecutorDeps {
   commandTemplate: string;
+  /** Optional heartbeat — fires periodically during tool execution to keep the server-side claim fresh. */
+  heartbeat?: HeartbeatControl;
 }
 
 /**
@@ -125,6 +127,8 @@ export async function executeFix(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<{ tokensUsed: number; tokensEstimated: boolean; tokenDetail: TokenUsageDetail }> {
   const timeoutMs = timeoutSeconds * 1000;
@@ -149,6 +153,8 @@ export async function executeFix(
     signal,
     undefined,
     worktreePath,
+    undefined,
+    deps.heartbeat,
   );
 
   // Compute token usage
@@ -194,6 +200,8 @@ export async function executeFixTask(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult>,
 ): Promise<{ tokensUsed: number; tokensEstimated: boolean; tokenDetail: TokenUsageDetail }> {
   const { log } = logger;

--- a/packages/cli/src/implement.ts
+++ b/packages/cli/src/implement.ts
@@ -8,7 +8,7 @@ import {
   estimateTokens,
   parseCommandTemplate,
   ToolTimeoutError,
-  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  startHeartbeatTimer,
 } from './tool-executor.js';
 import { sanitizeTokens } from './sanitize.js';
 import { validatePathSegment, isGhAvailable, buildCloneUrl } from './codebase.js';
@@ -452,27 +452,8 @@ function executeAgentic(
       }
     }, timeoutMs);
 
-    // Heartbeat timer: fires callback every intervalMs while the tool is running.
-    // Transient failures are swallowed — a broken heartbeat must NEVER kill the tool.
-    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-    if (heartbeat) {
-      const intervalMs = heartbeat.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
-      if (intervalMs > 0) {
-        heartbeatTimer = setInterval(() => {
-          if (settled) return;
-          try {
-            const r = heartbeat.callback();
-            if (r && typeof (r as Promise<void>).catch === 'function') {
-              (r as Promise<void>).catch(() => {
-                /* swallowed — heartbeat must not kill the tool */
-              });
-            }
-          } catch {
-            /* swallowed */
-          }
-        }, intervalMs);
-      }
-    }
+    // Heartbeat: shared with executeTool via startHeartbeatTimer.
+    const stopHeartbeat = startHeartbeatTimer(heartbeat, () => settled);
 
     let onAbort: (() => void) | undefined;
     if (signal) {
@@ -484,7 +465,7 @@ function executeAgentic(
 
     function agenticCleanup(): void {
       clearTimeout(timer);
-      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      stopHeartbeat();
       if (onAbort && signal) signal.removeEventListener('abort', onAbort);
     }
 

--- a/packages/cli/src/implement.ts
+++ b/packages/cli/src/implement.ts
@@ -2,12 +2,13 @@ import { execFileSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PollTask, ImplementReport, TaskRole } from '@opencara/shared';
-import type { ToolExecutorResult, TokenUsageDetail } from './tool-executor.js';
+import type { ToolExecutorResult, TokenUsageDetail, HeartbeatControl } from './tool-executor.js';
 import {
   executeTool,
   estimateTokens,
   parseCommandTemplate,
   ToolTimeoutError,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
 } from './tool-executor.js';
 import { sanitizeTokens } from './sanitize.js';
 import { validatePathSegment, isGhAvailable, buildCloneUrl } from './codebase.js';
@@ -401,6 +402,8 @@ export interface ImplementResponse {
 export interface ImplementExecutorDeps {
   commandTemplate: string;
   codebaseDir: string;
+  /** Optional heartbeat — fires periodically during tool execution to keep the server-side claim fresh. */
+  heartbeat?: HeartbeatControl;
 }
 
 /**
@@ -422,6 +425,7 @@ function executeAgentic(
   timeoutMs: number,
   cwd: string,
   signal?: AbortSignal,
+  heartbeat?: HeartbeatControl,
 ): Promise<{ exitCode: number }> {
   const allVars: Record<string, string> = { PROMPT: prompt, CODEBASE_DIR: cwd };
   const { command, args } = parseCommandTemplate(commandTemplate, allVars);
@@ -448,6 +452,28 @@ function executeAgentic(
       }
     }, timeoutMs);
 
+    // Heartbeat timer: fires callback every intervalMs while the tool is running.
+    // Transient failures are swallowed — a broken heartbeat must NEVER kill the tool.
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+    if (heartbeat) {
+      const intervalMs = heartbeat.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+      if (intervalMs > 0) {
+        heartbeatTimer = setInterval(() => {
+          if (settled) return;
+          try {
+            const r = heartbeat.callback();
+            if (r && typeof (r as Promise<void>).catch === 'function') {
+              (r as Promise<void>).catch(() => {
+                /* swallowed — heartbeat must not kill the tool */
+              });
+            }
+          } catch {
+            /* swallowed */
+          }
+        }, intervalMs);
+      }
+    }
+
     let onAbort: (() => void) | undefined;
     if (signal) {
       onAbort = () => {
@@ -456,17 +482,21 @@ function executeAgentic(
       signal.addEventListener('abort', onAbort, { once: true });
     }
 
-    child.on('error', (err) => {
+    function agenticCleanup(): void {
       clearTimeout(timer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
       if (onAbort && signal) signal.removeEventListener('abort', onAbort);
+    }
+
+    child.on('error', (err) => {
+      agenticCleanup();
       if (settled) return;
       settled = true;
       reject(err);
     });
 
     child.on('close', (code, sig) => {
-      clearTimeout(timer);
-      if (onAbort && signal) signal.removeEventListener('abort', onAbort);
+      agenticCleanup();
       if (settled) return;
       settled = true;
       if (sig === 'SIGTERM' || sig === 'SIGKILL') {
@@ -495,6 +525,8 @@ export async function executeImplement(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<{
   output: ImplementOutput;
@@ -519,6 +551,7 @@ export async function executeImplement(
       effectiveTimeout,
       worktreePath,
       signal,
+      deps.heartbeat,
     );
     return {
       output: {
@@ -540,6 +573,8 @@ export async function executeImplement(
     signal,
     undefined,
     worktreePath,
+    undefined,
+    deps.heartbeat,
   );
 
   const output = parseImplementOutput(result.stdout);
@@ -583,6 +618,8 @@ export async function executeImplementTask(
     signal?: AbortSignal,
     vars?: Record<string, string>,
     cwd?: string,
+    livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult>,
   role: TaskRole = 'implement',
   // Dependency injection for git/gh operations (testing)

--- a/packages/cli/src/review.ts
+++ b/packages/cli/src/review.ts
@@ -4,6 +4,7 @@ import {
   estimateTokens,
   type ToolExecutorResult,
   type TokenUsageDetail,
+  type HeartbeatControl,
 } from './tool-executor.js';
 import {
   type ReviewMode,
@@ -128,6 +129,8 @@ export interface ReviewExecutorDeps {
   maxRepoSizeMb?: number;
   codebaseDir?: string | null;
   livenessTimeoutMs?: number;
+  /** Optional heartbeat — fires periodically during tool execution to keep the server-side claim fresh. */
+  heartbeat?: HeartbeatControl;
 }
 
 export async function executeReview(
@@ -141,6 +144,7 @@ export async function executeReview(
     vars?: Record<string, string>,
     cwd?: string,
     livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<ReviewResponse> {
   const diffSizeKb = Buffer.byteLength(req.diffContent, 'utf-8') / 1024;
@@ -174,6 +178,7 @@ export async function executeReview(
       undefined,
       deps.codebaseDir ?? undefined,
       deps.livenessTimeoutMs,
+      deps.heartbeat,
     );
 
     const { verdict, review } = extractVerdict(result.stdout);

--- a/packages/cli/src/summary.ts
+++ b/packages/cli/src/summary.ts
@@ -8,6 +8,7 @@ import {
   estimateTokens,
   type ToolExecutorResult,
   type TokenUsageDetail,
+  type HeartbeatControl,
 } from './tool-executor.js';
 
 export interface SummaryReviewInput {
@@ -135,6 +136,7 @@ export async function executeSummary(
     vars?: Record<string, string>,
     cwd?: string,
     livenessTimeoutMs?: number,
+    heartbeat?: HeartbeatControl,
   ) => Promise<ToolExecutorResult> = executeTool,
 ): Promise<SummaryResponse> {
   const inputSize = calculateInputSize(req.prompt, req.reviews, req.diffContent, req.contextBlock);
@@ -175,6 +177,7 @@ export async function executeSummary(
       undefined,
       deps.codebaseDir ?? undefined,
       deps.livenessTimeoutMs,
+      deps.heartbeat,
     );
 
     const { verdict, review } = extractVerdict(result.stdout);

--- a/packages/cli/src/tool-executor.ts
+++ b/packages/cli/src/tool-executor.ts
@@ -36,8 +36,23 @@ const MIN_PARTIAL_RESULT_LENGTH = 50;
 /** Default stdout liveness timeout (ms). Kill process if no stdout for this long. */
 export const STDOUT_LIVENESS_TIMEOUT_MS = 300_000;
 
+/** Default heartbeat interval (ms) when a heartbeat callback is supplied. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+
 /** Maximum stderr length included in error/warning messages */
 const MAX_STDERR_LENGTH = 1000;
+
+/**
+ * Heartbeat control — fires `callback` every `intervalMs` while the tool is
+ * running. The callback MUST not throw; any error it produces is caught by
+ * the caller and swallowed. The interval is cleared when the tool exits
+ * (success, error, timeout, kill, abort).
+ */
+export interface HeartbeatControl {
+  callback: () => void | Promise<void>;
+  /** Defaults to {@link DEFAULT_HEARTBEAT_INTERVAL_MS} when omitted. */
+  intervalMs?: number;
+}
 
 /**
  * Validate that the binary referenced by a command template exists and is executable.
@@ -210,6 +225,7 @@ export function executeTool(
   vars?: Record<string, string>,
   cwd?: string,
   livenessTimeoutMs?: number,
+  heartbeat?: HeartbeatControl,
 ): Promise<ToolExecutorResult> {
   const promptViaArg = commandTemplate.includes('${PROMPT}');
   const allVars: Record<string, string> = { ...vars, PROMPT: prompt };
@@ -271,6 +287,29 @@ export function executeTool(
       }, effectiveLivenessMs);
     }
 
+    // Heartbeat timer: fire callback every heartbeatIntervalMs while tool is running.
+    // Transient failures (network, 4xx/5xx, 404 old-server) are swallowed — a
+    // broken heartbeat must NEVER kill the in-flight tool.
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+    if (heartbeat) {
+      const intervalMs = heartbeat.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+      if (intervalMs > 0) {
+        heartbeatTimer = setInterval(() => {
+          if (settled) return;
+          try {
+            const r = heartbeat.callback();
+            if (r && typeof (r as Promise<void>).catch === 'function') {
+              (r as Promise<void>).catch(() => {
+                /* swallowed — heartbeat must not kill the tool */
+              });
+            }
+          } catch {
+            /* swallowed — heartbeat must not kill the tool */
+          }
+        }, intervalMs);
+      }
+    }
+
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
       // Reset liveness timer on stdout activity
@@ -306,6 +345,7 @@ export function executeTool(
       clearTimeout(timer);
       if (livenessTimer) clearTimeout(livenessTimer);
       if (sigkillTimer) clearTimeout(sigkillTimer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
       if (onAbort && signal) {
         signal.removeEventListener('abort', onAbort);
       }

--- a/packages/cli/src/tool-executor.ts
+++ b/packages/cli/src/tool-executor.ts
@@ -55,6 +55,46 @@ export interface HeartbeatControl {
 }
 
 /**
+ * Start a heartbeat `setInterval` that fires `heartbeat.callback` every
+ * `intervalMs` (default {@link DEFAULT_HEARTBEAT_INTERVAL_MS}). Returns a
+ * stop function that clears the interval — callers MUST invoke it on every
+ * exit path (close, error, timeout, kill, abort) to prevent leaks.
+ *
+ * `isSettled` is an optional predicate consulted on each tick: when it
+ * returns true, the callback is skipped. This lets the caller guard against
+ * one last tick firing between SIGTERM and the close event.
+ *
+ * Callback errors (sync throws and async rejections) are swallowed — a
+ * broken heartbeat must NEVER kill the in-flight tool.
+ *
+ * Returns a no-op stopper when `heartbeat` is undefined or `intervalMs` is 0.
+ */
+export function startHeartbeatTimer(
+  heartbeat: HeartbeatControl | undefined,
+  isSettled: () => boolean = () => false,
+): () => void {
+  if (!heartbeat) return () => {};
+  const intervalMs = heartbeat.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  if (intervalMs <= 0) return () => {};
+
+  const timer = setInterval(() => {
+    if (isSettled()) return;
+    try {
+      const r = heartbeat.callback();
+      if (r && typeof (r as Promise<void>).catch === 'function') {
+        (r as Promise<void>).catch(() => {
+          /* swallowed — heartbeat must not kill the tool */
+        });
+      }
+    } catch {
+      /* swallowed — heartbeat must not kill the tool */
+    }
+  }, intervalMs);
+
+  return () => clearInterval(timer);
+}
+
+/**
  * Validate that the binary referenced by a command template exists and is executable.
  * Cross-platform: uses `where` on Windows, `command -v` via shell on Unix.
  */
@@ -287,28 +327,10 @@ export function executeTool(
       }, effectiveLivenessMs);
     }
 
-    // Heartbeat timer: fire callback every heartbeatIntervalMs while tool is running.
-    // Transient failures (network, 4xx/5xx, 404 old-server) are swallowed — a
-    // broken heartbeat must NEVER kill the in-flight tool.
-    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-    if (heartbeat) {
-      const intervalMs = heartbeat.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
-      if (intervalMs > 0) {
-        heartbeatTimer = setInterval(() => {
-          if (settled) return;
-          try {
-            const r = heartbeat.callback();
-            if (r && typeof (r as Promise<void>).catch === 'function') {
-              (r as Promise<void>).catch(() => {
-                /* swallowed — heartbeat must not kill the tool */
-              });
-            }
-          } catch {
-            /* swallowed — heartbeat must not kill the tool */
-          }
-        }, intervalMs);
-      }
-    }
+    // Heartbeat: fires callback every intervalMs while the tool is running.
+    // The `isSettled` predicate suppresses the one last tick that may fire
+    // between SIGTERM and the close event. See startHeartbeatTimer.
+    const stopHeartbeat = startHeartbeatTimer(heartbeat, () => settled);
 
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -345,7 +367,7 @@ export function executeTool(
       clearTimeout(timer);
       if (livenessTimer) clearTimeout(livenessTimer);
       if (sigkillTimer) clearTimeout(sigkillTimer);
-      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      stopHeartbeat();
       if (onAbort && signal) {
         signal.removeEventListener('abort', onAbort);
       }


### PR DESCRIPTION
Part of #782

## Summary

- Add an optional `HeartbeatControl` to `executeTool` (and the agentic-mode spawn in `implement.ts`) — fires a callback every ~60s while the tool is running, alongside the existing liveness timer. The interval is cleared on every exit path (close, error, timeout, abort).
- Wire the callback from `handleTask` in `agent.ts`: for `review` / `summary` / `implement` / `fix` roles, it POSTs `{agent_id, role}` to `/api/tasks/:id/heartbeat` via the existing `ApiClient`. Short-running roles (triage, dedup, issue_review) don't opt in.
- Back-compat: a 404 response (old server without the paired #783 endpoint) is a silent no-op, logged once per task for operator visibility; other 4xx/5xx or network errors are logged-and-continued. A broken heartbeat never kills the in-flight tool.

## Fix for the observed bug

> `[01:07:58] ✗ Error on task 4c05ea84: Tool "npx" killed: no stdout for 300s`
> `[01:08:09] ✓ Claimed task 4c05ea84 (review)`
> `[01:21:02] ✗ Error on task 4c05ea84: Claim already error`

Any tool run >10 min had its claim reclaimed server-side as `'error'` before submission, and the final `/result` POST 409'd. The new heartbeat refreshes the claim every 60s, well under `CLAIM_STALE_THRESHOLD_MS = 10 * 60 * 1000`.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm test` — 3015/3015 green (10 new heartbeat cases in `tool-executor.test.ts`, 5 new cases in `agent.test.ts`)
- [x] `pnpm lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run typecheck` — clean
- [x] Manual: interval fires every 60s, cleared on every exit path, transient failures swallowed silently, 404 treated as silent no-op (one-shot log)

## Files

- `packages/cli/src/tool-executor.ts` — `HeartbeatControl` type, `DEFAULT_HEARTBEAT_INTERVAL_MS`, interval setup/teardown alongside liveness timer
- `packages/cli/src/review.ts` / `summary.ts` / `implement.ts` / `fix.ts` — add `heartbeat` to deps, forward via `runTool`
- `packages/cli/src/commands/agent.ts` — `createHeartbeatControl` helper, `isLongRunningRole` gate, wired into `handleTask`

## Back-compat with #783

If the paired server-side endpoint isn't deployed yet, the heartbeat POST returns 404 and is silently swallowed (one-shot operator log). CLI continues working exactly as before on old servers.